### PR TITLE
Update iqe plugin name in deployment.yaml

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     testing:
-      iqePlugin: ingress
+      iqePlugin: hms-content
     dependencies: []
     deployments:
     - name: service


### PR DESCRIPTION
Definitely more to come in this area, but hms-content is the plugin name
that should hold tests for this service