### PR TITLE
CONTENT-40: Create content source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-ci:
 	go test ./...
 
 openapi:
-	swag init --generalInfo api.go  --dir pkg/handler/
+	swag init --generalInfo api.go --dir pkg/handler/ --pd pkg/api
 	#convert from swagger to openapi
 	go run ./cmd/swagger2openapi/main.go docs/swagger.json docs/openapi.json
 	rm docs/swagger.json docs/swagger.yaml

--- a/db/migrations/20220512132042_create_repository_configurations_table.up.sql
+++ b/db/migrations/20220512132042_create_repository_configurations_table.up.sql
@@ -12,4 +12,7 @@ CREATE TABLE IF NOT EXISTS repository_configurations(
     updated_at timestamp NOT NULL
     );
 
+ALTER TABLE repository_configurations
+ADD CONSTRAINT url_and_org_id_unique UNIQUE (url, org_id);
+
 COMMIT;

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -38,8 +38,52 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.RepositoryCollectionResponse"
+                            "$ref": "#/definitions/api.RepositoryCollectionResponse"
                         }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a repository",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Create Repository",
+                "operationId": "createRepository",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateRepository"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "organization id",
+                        "name": "org_id",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "account number",
+                        "name": "account_id",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": ""
                     }
                 }
             }
@@ -60,7 +104,29 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handler.Links": {
+        "api.CreateRepository": {
+            "type": "object",
+            "properties": {
+                "distribution_arch": {
+                    "description": "Architecture to restrict client usage to",
+                    "type": "string",
+                    "example": "x86_64"
+                },
+                "distribution_version": {
+                    "description": "Version to restrict client usage to",
+                    "type": "string",
+                    "example": "7"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "description": "URL of the remote yum repository",
+                    "type": "string"
+                }
+            }
+        },
+        "api.Links": {
             "type": "object",
             "properties": {
                 "first": {
@@ -81,32 +147,13 @@ const docTemplate = `{
                 }
             }
         },
-        "handler.RepositoryCollectionResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "description": "Requested Data",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handler.RepositoryItem"
-                    }
-                },
-                "links": {
-                    "description": "Links to other pages of results",
-                    "$ref": "#/definitions/handler.Links"
-                },
-                "meta": {
-                    "description": "Metadata about the request",
-                    "$ref": "#/definitions/handler.ResponseMetadata"
-                }
-            }
-        },
-        "handler.RepositoryItem": {
+        "api.Repository": {
             "type": "object",
             "properties": {
                 "account_id": {
-                    "description": "Account Id of the owner",
-                    "type": "string"
+                    "description": "Account ID of the owner",
+                    "type": "string",
+                    "readOnly": true
                 },
                 "distribution_arch": {
                     "description": "Architecture to restrict client usage to",
@@ -122,19 +169,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "org_id": {
-                    "description": "Organization Id of the owner",
-                    "type": "string"
+                    "description": "Organization ID of the owner",
+                    "type": "string",
+                    "readOnly": true
                 },
                 "url": {
                     "description": "URL of the remote yum repository",
                     "type": "string"
                 },
                 "uuid": {
-                    "type": "string"
+                    "type": "string",
+                    "readOnly": true
                 }
             }
         },
-        "handler.ResponseMetadata": {
+        "api.RepositoryCollectionResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Requested Data",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Repository"
+                    }
+                },
+                "links": {
+                    "description": "Links to other pages of results",
+                    "$ref": "#/definitions/api.Links"
+                },
+                "meta": {
+                    "description": "Metadata about the request",
+                    "$ref": "#/definitions/api.ResponseMetadata"
+                }
+            }
+        },
+        "api.ResponseMetadata": {
             "type": "object",
             "properties": {
                 "count": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,29 @@
 {
     "components": {
         "schemas": {
-            "handler.Links": {
+            "api.CreateRepository": {
+                "properties": {
+                    "distribution_arch": {
+                        "description": "Architecture to restrict client usage to",
+                        "example": "x86_64",
+                        "type": "string"
+                    },
+                    "distribution_version": {
+                        "description": "Version to restrict client usage to",
+                        "example": "7",
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL of the remote yum repository",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.Links": {
                 "properties": {
                     "first": {
                         "description": "Path to first page of results",
@@ -22,28 +44,11 @@
                 },
                 "type": "object"
             },
-            "handler.RepositoryCollectionResponse": {
-                "properties": {
-                    "data": {
-                        "description": "Requested Data",
-                        "items": {
-                            "$ref": "#/components/schemas/handler.RepositoryItem"
-                        },
-                        "type": "array"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/handler.Links"
-                    },
-                    "meta": {
-                        "$ref": "#/components/schemas/handler.ResponseMetadata"
-                    }
-                },
-                "type": "object"
-            },
-            "handler.RepositoryItem": {
+            "api.Repository": {
                 "properties": {
                     "account_id": {
-                        "description": "Account Id of the owner",
+                        "description": "Account ID of the owner",
+                        "readOnly": true,
                         "type": "string"
                     },
                     "distribution_arch": {
@@ -60,7 +65,8 @@
                         "type": "string"
                     },
                     "org_id": {
-                        "description": "Organization Id of the owner",
+                        "description": "Organization ID of the owner",
+                        "readOnly": true,
                         "type": "string"
                     },
                     "url": {
@@ -68,12 +74,31 @@
                         "type": "string"
                     },
                     "uuid": {
+                        "readOnly": true,
                         "type": "string"
                     }
                 },
                 "type": "object"
             },
-            "handler.ResponseMetadata": {
+            "api.RepositoryCollectionResponse": {
+                "properties": {
+                    "data": {
+                        "description": "Requested Data",
+                        "items": {
+                            "$ref": "#/components/schemas/api.Repository"
+                        },
+                        "type": "array"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/api.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/api.ResponseMetadata"
+                    }
+                },
+                "type": "object"
+            },
+            "api.ResponseMetadata": {
                 "properties": {
                     "count": {
                         "description": "Total count of results",
@@ -120,7 +145,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/handler.RepositoryCollectionResponse"
+                                    "$ref": "#/components/schemas/api.RepositoryCollectionResponse"
                                 }
                             }
                         },
@@ -128,6 +153,51 @@
                     }
                 },
                 "summary": "List Repositories",
+                "tags": [
+                    "repositories"
+                ]
+            },
+            "post": {
+                "description": "create a repository",
+                "operationId": "createRepository",
+                "parameters": [
+                    {
+                        "description": "organization id",
+                        "in": "header",
+                        "name": "org_id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "account number",
+                        "in": "header",
+                        "name": "account_id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.CreateRepository"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "201": {
+                        "description": ""
+                    }
+                },
+                "summary": "Create Repository",
                 "tags": [
                     "repositories"
                 ]

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/lib/pq v1.10.5
 	github.com/redhatinsights/app-common-go v1.6.2
+	github.com/redhatinsights/platform-go-middlewares v0.17.0
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2/config v1.6.0/go.mod h1:TNtBVmka80lRPk5+S9ZqVfFszOQAGJJ9KbT3EM3CHNU=
@@ -441,6 +442,7 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
@@ -962,6 +964,7 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -976,6 +979,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -985,6 +989,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1090,6 +1095,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhatinsights/app-common-go v1.6.2 h1:SYOYC7eelAAMiOK8hp4GxmQLAJ4HtuJ50kNzEZa7S/4=
 github.com/redhatinsights/app-common-go v1.6.2/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
+github.com/redhatinsights/platform-go-middlewares v0.17.0 h1:upjyS2Fq+yGio0N8TrZWha6ZzhidIkRROM0QnDqpiMk=
+github.com/redhatinsights/platform-go-middlewares v0.17.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1980,6 +1987,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,23 @@
+package api
+
+type CollectionMetadataSettable interface {
+	SetMetadata(meta ResponseMetadata, links Links)
+}
+
+type PaginationData struct {
+	Limit  int `query:"limit" json:"limit" `  //Number of results to return
+	Offset int `query:"offset" json:"offset"` //Offset into the total results
+}
+
+type ResponseMetadata struct {
+	Limit  int   `query:"limit" json:"limit"`   //Limit of results used for the request
+	Offset int   `query:"offset" json:"offset"` //Offset into results used for the request
+	Count  int64 `json:"count"`                 //Total count of results
+}
+
+type Links struct {
+	First string `json:"first"`          //Path to first page of results
+	Next  string `json:"next,omitempty"` //Path to next page of results
+	Prev  string `json:"prev,omitempty"` //Path to previous page of results
+	Last  string `json:"last"`           //Path to last page of results
+}

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -1,0 +1,46 @@
+package api
+
+import "github.com/content-services/content-sources-backend/pkg/models"
+
+// Repository holds data received from, or returned by, a repositories API request or response
+type Repository struct {
+	UUID                string `json:"uuid" readonly:"true"`
+	Name                string `json:"name"`
+	URL                 string `json:"url"`                                //URL of the remote yum repository
+	DistributionVersion string `json:"distribution_version" example:"7"`   //Version to restrict client usage to
+	DistributionArch    string `json:"distribution_arch" example:"x86_64"` //Architecture to restrict client usage to
+	AccountID           string `json:"account_id" readonly:"true"`         //Account ID of the owner
+	OrgID               string `json:"org_id" readonly:"true"`             //Organization ID of the owner
+}
+
+// CreateRepository holds data received from request to create repository
+type CreateRepository struct {
+	UUID                string `json:"uuid" readonly:"true" swaggerignore:"true"`
+	Name                string `json:"name"`
+	URL                 string `json:"url"`                                             //URL of the remote yum repository
+	DistributionVersion string `json:"distribution_version" example:"7"`                //Version to restrict client usage to
+	DistributionArch    string `json:"distribution_arch" example:"x86_64"`              //Architecture to restrict client usage to
+	AccountID           string `json:"account_id" readonly:"true" swaggerignore:"true"` //Account ID of the owner
+	OrgID               string `json:"org_id" readonly:"true" swaggerignore:"true"`     //Organization ID of the owner
+}
+
+func (r *Repository) FromRepositoryConfiguration(repoConfig models.RepositoryConfiguration) {
+	r.UUID = repoConfig.UUID
+	r.Name = repoConfig.Name
+	r.URL = repoConfig.URL
+	r.DistributionVersion = repoConfig.Version
+	r.DistributionArch = repoConfig.Arch
+	r.AccountID = repoConfig.AccountID
+	r.OrgID = repoConfig.OrgID
+}
+
+type RepositoryCollectionResponse struct {
+	Data  []Repository     `json:"data"`  //Requested Data
+	Meta  ResponseMetadata `json:"meta"`  //Metadata about the request
+	Links Links            `json:"links"` //Links to other pages of results
+}
+
+func (r *RepositoryCollectionResponse) SetMetadata(meta ResponseMetadata, links Links) {
+	r.Meta = meta
+	r.Links = links
+}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -1,0 +1,9 @@
+package dao
+
+import (
+	"github.com/content-services/content-sources-backend/pkg/api"
+)
+
+type RepositoryDao interface {
+	Create(r api.Repository) error
+}

--- a/pkg/dao/repository.go
+++ b/pkg/dao/repository.go
@@ -1,0 +1,43 @@
+package dao
+
+import (
+	"fmt"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/models"
+)
+
+type repositoryDaoImpl struct {
+}
+
+func GetRepositoryDao() repositoryDaoImpl {
+	return repositoryDaoImpl{}
+}
+
+const uniqueConstraintErrMsg = "ERROR: duplicate key value violates unique constraint \"url_and_org_id_unique\" (SQLSTATE 23505)"
+
+func (r repositoryDaoImpl) Create(newRepo api.CreateRepository) error {
+
+	newRepoConfig := models.RepositoryConfiguration{
+		Name:      newRepo.Name,
+		URL:       newRepo.URL,
+		Version:   newRepo.DistributionVersion,
+		Arch:      newRepo.DistributionArch,
+		AccountID: newRepo.AccountID,
+		OrgID:     newRepo.OrgID,
+	}
+
+	dest := models.RepositoryConfiguration{}
+	result := db.DB.Where("org_id = ? AND url = ?", newRepo.OrgID, newRepo.URL).Find(&dest)
+	if result.Error != nil {
+		return result.Error
+	}
+	if err := db.DB.Create(&newRepoConfig).Error; err != nil {
+		if err.Error() == uniqueConstraintErrMsg {
+			return fmt.Errorf("repository with this URL already belongs to organization")
+		}
+		return err
+	}
+	return nil
+}

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -79,7 +80,7 @@ func TestParsePagination(t *testing.T) {
 }
 
 func TestCollectionResponse(t *testing.T) {
-	coll := RepositoryCollectionResponse{}
+	coll := api.RepositoryCollectionResponse{}
 
 	collectionResponse(&coll, getTestContext("?offset=0&limit=1"), 10)
 	assert.Equal(t, 0, coll.Meta.Offset)


### PR DESCRIPTION
Adds create endpoint for content source. Adds a 'dao' layer and 'api' package.

The 'api' package defines all the API request/response structs. For example, with create, when the handler gets a request, it binds it to the 'CreateRepository' struct in the 'api' package. Then, that struct is passed to the 'dao' package which interacts with the models and the database to the necessary items to the database.

To test you need to use the "x-hr-identity" header. You want a base64 encoded JSON that looks like: 

> "identity": {
        "account_number": "12345",
        "org_id": "54321"
}

Handling the account_number and org_id relies on this common package: https://github.com/RedHatInsights/platform-go-middlewares/tree/master/identity

TODO:

- [x]  Create endpoint with OpenAPI comments
- [x]  Unique constraint between org ID and URL
- [x]  dao layer
- [x]  tests
- [x]  address swag param type.
