### PR TITLE
makefile:proposals for Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+release/**
+vendor/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 release/**
-vendor/**
+vendor

--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -80,10 +80,7 @@ jobs:
         with:
           go-version: "1.16"
       - run: |
-          make vendor
-          make dbmigrate
-          ./release/dbmigrate up
-          go test ./...
+          make get-deps dbmigrate db-migrate-up test
         env:
           DATABASE_HOST: localhost
           DATABASE_PORT: 5432

--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           go-version: "1.16"
       - run: |
+          make vendor
           make dbmigrate
           ./release/dbmigrate up
           go test ./...
@@ -89,4 +90,3 @@ jobs:
           DATABASE_USER: postgres
           DATABASE_NAME: postgres
           DATABASE_PASSWORD: postgres
-

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,24 @@
-.PHONY: test
--include .env
+##
+# Entrypoint for the Makefile
+#
+# It is composed at mk/includes.mk by including
+# small make files which provides all the necessary
+# rules.
+#
+# Some considerations:
+#
+# - Variables customization can be
+#   stored at '.env', 'mk/private.mk' files.
+# - By default the 'help' rule is executed.
+# - No parallel jobs are executed from the main Makefile,
+#   so that multiple rules from the command line will be
+#   executed in serial.
+##
 
-clean:
-	go clean
-	rm release/*
+include mk/includes.mk
 
-content-sources:
-	go build -o release/content-sources cmd/content-sources/main.go
+.NOT_PARALLEL:
 
-dbmigrate:
-	go build -o release/dbmigrate cmd/dbmigrate/main.go
+# Set the default rule
+.DEFAULT_GOAL := help
 
-seed:
-	go run cmd/dbmigrate/main.go seed
-
-test:
-	CONFIG_PATH="$(shell pwd)/configs/" go test ./...
-
-test-ci:
-	go test ./...
-
-openapi:
-	swag init --generalInfo api.go --o ./api --dir pkg/handler/ --pd pkg/api
-	#convert from swagger to openapi
-	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json
-	rm ./api/swagger.json ./api/swagger.yaml
-
-arch:   #yum install plantuml if not installed
-	java -jar /usr/share/java/plantuml.jar docs/architecture.puml
-
-build: content-sources dbmigrate
-	
-
-image:
-	podman build -f ./build/Dockerfile --tag content-sources:$(shell git rev-parse --short HEAD) ./

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,3 @@ include mk/includes.mk
 
 # Set the default rule
 .DEFAULT_GOAL := help
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ Content Sources is an application for storing information about external content
 
 ## Developing
 
-### Configuring Postgresql
+### Create your configuration
+
+Create a config file from the example:
+
+```sh
+$ cp ./configs/config.yaml.example ./configs/config.yaml
+```
+
+### Start / Stop postgres
 
 - Start the database container by:
 
@@ -36,12 +44,6 @@ Content Sources is an application for storing information about external content
   ```sh
   $ podman exec -it postgresql bash
   ```
-
-### Create your configuration
-Create a config file from the example:
-```
-cp ./configs/config.yaml.example ./configs/config.yaml
-```
 
 ### Migrate your database (and seed it if desired)
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,41 @@
 # Content Sources
 
-##What is it?
+## What is it?
+
 Content Sources is an application for storing information about external content (currently YUM repositories) in a central location.
 
 
-##Developing
+## Developing
 
 ### Configuring Postgresql
 
-As root run: 
-```shell
-yum install -y postgresql
+- Start the database container by:
 
-echo "host    all             all             127.0.0.1/32            trust" >> /var/lib/pgsql/data/pg_hba.conf
-echo "host    all             all             ::1/128                 trust" >> /var/lib/pgsql/data/pg_hba.conf
-systemctl start postgresql
-systemctl enable postgresql
-sudo -u postgres createdb content
-sudo -u postgres psql -c "CREATE USER content WITH PASSWORD 'content'"
-sudo -u postgres psql -c "grant all privileges on database content TO content"
-```
+  ```sh
+  $ make db-up
+  ```
+
+---
+
+- You can stop it by:
+
+  ```sh
+  $ make db-down
+  ```
+
+- And clean the volume that it uses by (this stop
+  the container before doing it if it were running):
+
+  ```sh
+  $ make db-clean
+  ```
+
+- Or inspect inside the container if necessary meanwhile it is
+  running by:
+
+  ```sh
+  $ podman exec -it postgresql bash
+  ```
 
 ### Create your configuration
 Create a config file from the example:
@@ -28,17 +44,19 @@ cp ./configs/config.yaml.example ./configs/config.yaml
 ```
 
 ### Migrate your database (and seed it if desired)
+
+```sh
+$ make db-migrate-up
 ```
-go run ./cmd/dbmigrate/main.go up
-```
-```
-go run ./cmd/dbmigrate/main.go seed
+
+```sh
+$ make db-migrate-seed
 ```
 
 ### Run the server!
 
-```
-go run ./cmd/content-sources/main.go
+```sh
+$ make run
 ```
 
 ###
@@ -47,12 +65,12 @@ Hit the api:
 ```
 curl http://localhost:8000/api/content_sources/v1.0/repositories/ ```
 ```
+
 ### Generating new openapi docs:
 
-~~~
-go install github.com/swaggo/swag/cmd/swag@latest
-make openapi
-~~~
+```sh
+$ make openapi
+```
 
 ### Configuration
 
@@ -63,6 +81,6 @@ The default configuration file in ./configs/config.yaml.example shows all availa
  * Pull requests should come with good tests
  * Generally, feature PRs should be backed by a JIRA ticket and included in the subject using the format:
    * `CONTENT-23: Some great feature`
- 
+
 ## More info
  * [Architecture](docs/architecture.md)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 USER 0
 
-RUN go get -d ./... && make build
+RUN make get-deps build
 
 FROM registry.redhat.io/ubi8/ubi-minimal:8.5
 

--- a/mk/alias.mk
+++ b/mk/alias.mk
@@ -4,6 +4,8 @@
 ##
 
 .PHONY: arch
+arch: PLANTUML ?= $(shell command -v plantuml 2>/dev/null)
+arch: PLANTUML ?= false
 arch: docs/architecture.svg  ## Alias for 'make plantuml-generate'
 
 .PHONY: image

--- a/mk/alias.mk
+++ b/mk/alias.mk
@@ -1,0 +1,28 @@
+##
+# This file contains different alias rules to keep
+# compatibility with the previous rules.
+##
+
+.PHONY: arch
+arch: docs/architecture.svg  ## Alias for 'make plantuml-generate'
+
+.PHONY: image
+image: DOCKER_DOCKERFILE := ./build/Dockerfile
+image: DOCKER_IMAGE := content-sources:$(DOCKER_IMAGE_TAG)
+image: ## Alias for 'make docker-build DOCKER_DOCKERFILE=build/Dockerfile DOCKER_IMAGE=content-sources:$(git rev-parse --short HEAD)
+	$(MAKE) docker-build \
+	  DOCKER_DOCKERFILE=$(DOCKER_DOCKERFILE) \
+	  DOCKER_IMAGE=$(DOCKER_IMAGE)
+
+.PHONY: seed
+seed: db-migrate-seed ## Alias for 'make db-migrate-seed'
+
+.PHONY: dbmigrate
+dbmigrate: $(GO_OUTPUT)/dbmigrate  ## Alias for 'make build' for dbmigrate
+
+.PHONY: content-sources
+content-sources: $(GO_OUTPUT)/content-sources ## Alias for 'make build' for content-sources
+
+.PHONY: swagger2openapi
+swagger2openapi: $(GO_OUTPUT)/swagger2openapi ## Alias for 'make build' for swagger2openapi
+

--- a/mk/alias.mk
+++ b/mk/alias.mk
@@ -25,4 +25,3 @@ content-sources: $(GO_OUTPUT)/content-sources ## Alias for 'make build' for cont
 
 .PHONY: swagger2openapi
 swagger2openapi: $(GO_OUTPUT)/swagger2openapi ## Alias for 'make build' for swagger2openapi
-

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -25,7 +25,6 @@ db-up: $(GO_OUTPUT)/dbmigrate  ## Start postgres database
 	  $(DOCKER_IMAGE)
 	$(MAKE) .db-health-wait
 	$(MAKE) db-migrate-up
-	@echo "Run 'make db-migrate-up' to upgrade the database model"
 	@echo "Run 'make db-migrate-seed' to seed the database"
 
 .PHONY: .db-health

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -1,13 +1,15 @@
 ##
-# Set of rules to interact with a local database 
+# Set of rules to interact with a local database
 # from a container and database initialization.
+#
+# Requires 'mk/docker.mk'
 ##
 
 .PHONY: db-up
 db-up: DOCKER_IMAGE=docker.io/postgres:14
 db-up: $(GO_OUTPUT)/dbmigrate ## Start postgres database
-	docker volume exists postgres || docker volume create postgres
-	docker container exists postgres || docker run \
+	$(DOCKER) volume exists postgres || $(DOCKER) volume create postgres
+	$(DOCKER) container exists postgres || $(DOCKER) run \
 	  -d \
 	  --rm \
 	  --name postgres \
@@ -30,9 +32,8 @@ db-migrate-seed: ## Run dbmigrate seed
 
 .PHONY: db-down
 db-down: ## Stop postgres database
-	! docker container exists postgres || docker container stop postgres
+	! $(DOCKER) container exists postgres || $(DOCKER) container stop postgres
 
 .PHONY: db-clean
 db-clean: db-down ## Clean database volume
-	! docker volume exists postgres || docker volume rm postgres
-
+	! $(DOCKER) volume exists postgres || $(DOCKER) volume rm postgres

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -1,0 +1,38 @@
+##
+# Set of rules to interact with a local database 
+# from a container and database initialization.
+##
+
+.PHONY: db-up
+db-up: DOCKER_IMAGE=docker.io/postgres:14
+db-up: $(GO_OUTPUT)/dbmigrate ## Start postgres database
+	docker volume exists postgres || docker volume create postgres
+	docker container exists postgres || docker run \
+	  -d \
+	  --rm \
+	  --name postgres \
+	  -p 5432:5432 \
+	  -e POSTGRES_PASSWORD=$(DATABASE_PASSWORD) \
+	  -e POSTGRES_USER=$(DATABASE_USER) \
+	  -e POSTGRES_DB=$(DATABASE_NAME) \
+	  -v postgres:/var/lib/postgresql/data \
+	  $(DOCKER_IMAGE)
+	$(MAKE) db-migrate-up
+	@echo "Now run db-migrate-seed to populate the database"
+
+.PHONY: db-migrate-up
+db-migrate-up: $(GO_OUTPUT)/dbmigrate ## Run dbmigrate up
+	$(GO_OUTPUT)/dbmigrate up
+
+.PHONY: db-migrate-seed
+db-migrate-seed: ## Run dbmigrate seed
+	$(GO_OUTPUT)/dbmigrate seed
+
+.PHONY: db-down
+db-down: ## Stop postgres database
+	! docker container exists postgres || docker container stop postgres
+
+.PHONY: db-clean
+db-clean: db-down ## Clean database volume
+	! docker volume exists postgres || docker volume rm postgres
+

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -53,3 +53,7 @@ db-down: ## Stop postgres database
 .PHONY: db-clean
 db-clean: db-down ## Clean database volume
 	! $(DOCKER) volume exists postgres || $(DOCKER) volume rm postgres
+
+.PHONY: db-cli-connect
+db-cli-connect: ## Open a postgres cli in the container (it requires db-up)
+	! $(DOCKER) container exists postgres || $(DOCKER) container exec -it postgres psql "sslmode=disable dbname=$(DATABASE_NAME) user=$(DATABASE_USER) host=$(DATABASE_HOST) port=$(DATABASE_PORT) password=$(DATABASE_PASSWORD)"

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -39,11 +39,11 @@ db-up: $(GO_OUTPUT)/dbmigrate  ## Start postgres database
 	@while [ "$$($(DOCKER) inspect -f '{{.State.Healthcheck.Status}}' postgres)" != "healthy" ]; do echo -n "."; sleep 1; done
 
 .PHONY: db-migrate-up
-db-migrate-up: $(GO_OUTPUT)/dbmigrate .db-health-wait ## Run dbmigrate up
+db-migrate-up: $(GO_OUTPUT)/dbmigrate ## Run dbmigrate up
 	$(GO_OUTPUT)/dbmigrate up
 
 .PHONY: db-migrate-seed
-db-migrate-seed: .db-health-wait ## Run dbmigrate seed
+db-migrate-seed: $(GO_OUTPUT)/dbmigrate ## Run dbmigrate seed
 	$(GO_OUTPUT)/dbmigrate seed
 
 .PHONY: db-down

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -1,0 +1,36 @@
+##
+# General rules for interacting with container
+# manager (podman or docker).
+##
+
+ifneq (,$(shell command podman -v 2>/dev/null))
+DOCKER ?= podman
+else
+ifneq (,$(shell command docker -v 2>/dev/null))
+DOCKER ?= docker
+else
+DOCKER ?= false
+endif
+endif
+
+DOCKER_CONTEXT_DIR ?= .
+DOCKER_DOCKERFILE ?= Dockerfile
+DOCKER_IMAGE_BASE ?= quay.io/$(USER)/myapp
+DOCKER_IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
+DOCKER_IMAGE ?= $(DOCKER_IMAGE_BASE):$(DOCKER_IMAGE_TAG)
+# DOCKER_OPTS
+# DOCKER_RUN_ARGS
+
+.PHONY: docker-build
+docker-build:  ## Build image DOCKER_IMAGE from DOCKER_DOCKERFILE using the DOCKER_CONTEXT_DIR
+	$(DOCKER) build -t "$(DOCKER_IMAGE)" -f $(DOCKER_DOCKERFILE) $(DOCKER_CONTEXT_DIR)
+
+.PHONY: docker-push
+docker-push:  ## Push image to remote registry
+	$(DOCKER) push "$(DOCKER_IMAGE)"
+
+# TODO Indicate in the options the IP assigned to the postgres container
+# .PHONY: docker-run
+# docker-run: DOCKER_OPTS += --env-file .env
+# docker-run:  ## Run with DOCKER_OPTS the DOCKER_IMAGE using DOCKER_RUN_ARGS as arguments (eg. make docker-run DOCKER_OPTS="-p 9000:9000")
+# 	$(DOCKER) run $(DOCKER_OPTS) $(DOCKER_IMAGE) $(DOCKER_RUN_ARGS)

--- a/mk/go-rules.mk
+++ b/mk/go-rules.mk
@@ -1,0 +1,41 @@
+##
+# Golang rules to build the binaries, tidy dependencies,
+# generate vendor directory and clean the generated binaries.
+##
+
+# Directory where the built binaries will be generated
+GO_OUTPUT ?= $(PROJECT_DIR)/bin
+
+.PHONY: build
+build: vendor $(patsubst cmd/%,$(GO_OUTPUT)/%,$(wildcard cmd/*)) ## Build binaries
+
+# export CGO_ENABLED
+# $(GO_OUTPUT)/%: CGO_ENABLED=0
+$(GO_OUTPUT)/%: cmd/%/main.go
+	@[ -e "$(GO_OUTPUT)" ] || mkdir -p "$(GO_OUTPUT)"
+	go build -mod vendor -o "$@" "$<"
+
+.PHONY: clean
+clean: ## Clean binaries and testbin generated
+	@[ ! -e "$(GO_OUTPUT)" ] || for item in cmd/*; do rm -vf "$(GO_OUTPUT)/$${item##cmd/}"; done
+#	@[ ! -e testbin ] || rm -rf testbin
+
+.PHONY: run
+run: build ## Run the service locally
+	"$(GO_OUTPUT)/content-sources"
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: vendor
+vendor:
+	go mod vendor
+
+.PHONY: test
+test: ## Run tests
+	CONFIG_PATH="$(PROJECT_DIR)/configs/" go test -mod vendor ./...
+
+.PHONY: test-ci
+test-ci: ## Run tests for ci
+	go test -mod vendor ./...

--- a/mk/help.mk
+++ b/mk/help.mk
@@ -11,4 +11,3 @@
 .PHONY: help
 help: ## Print out the help content
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-

--- a/mk/help.mk
+++ b/mk/help.mk
@@ -1,0 +1,14 @@
+##
+# This file only contains the rule that generate the
+# help content from the comments in the different files.
+#
+# Use '##@ My group text' at the beginning of a line to
+# print out a group text.
+#
+# Use '## My help text' at the end of a rule to print out
+# content related with a rule. Try to short the description.
+##
+.PHONY: help
+help: ## Print out the help content
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+

--- a/mk/includes.mk
+++ b/mk/includes.mk
@@ -4,7 +4,7 @@
 #
 # Unless you are not using conditional assignment within
 # the different variable files, this would be the priority:
-# - The values indicated at '.env' file.
+# - The values indicated at 'configs/config.yaml' file.
 # - The values indicated at 'mk/variables.mk' file. This
 #   file is included into the repository and define the
 #   default values for the variables, if not assigned yet.
@@ -18,13 +18,13 @@
 # This file set the 'help' rule as the default one when
 # no arguments are indicated.
 ##
--include .env
 include mk/projectdir.mk
 include mk/variables.mk
 
 include mk/help.mk
 include mk/meta-general.mk
 include mk/go-rules.mk
+include mk/printvars.mk
 include mk/plantuml.mk
 include mk/swag.mk
 include mk/meta-db.mk
@@ -33,6 +33,3 @@ include mk/meta-docker.mk
 include mk/docker.mk
 include mk/meta-alias.mk
 include mk/alias.mk
-
-
-

--- a/mk/includes.mk
+++ b/mk/includes.mk
@@ -1,0 +1,38 @@
+##
+# The target for this file is just to enumerate which partial
+# makefile we want to use to compose our final Makefile.
+#
+# Unless you are not using conditional assignment within
+# the different variable files, this would be the priority:
+# - The values indicated at '.env' file.
+# - The values indicated at 'mk/variables.mk' file. This
+#   file is included into the repository and define the
+#   default values for the variables, if not assigned yet.
+# - The 'mk/meta-*.mk' files just contain the comment to
+#   print out the group text for the help content. They
+#   are into independent files, because the order they
+#   appear into this include file matters, and provide
+#   the flexibility to print out the group text exactly
+#   where we want kust changing the order into this file.
+#
+# This file set the 'help' rule as the default one when
+# no arguments are indicated.
+##
+-include .env
+include mk/projectdir.mk
+include mk/variables.mk
+
+include mk/help.mk
+include mk/meta-general.mk
+include mk/go-rules.mk
+include mk/plantuml.mk
+include mk/swag.mk
+include mk/meta-db.mk
+include mk/db.mk
+include mk/meta-docker.mk
+include mk/docker.mk
+include mk/meta-alias.mk
+include mk/alias.mk
+
+
+

--- a/mk/meta-alias.mk
+++ b/mk/meta-alias.mk
@@ -1,0 +1,1 @@
+##@ Alias for previous rules

--- a/mk/meta-db.mk
+++ b/mk/meta-db.mk
@@ -1,0 +1,1 @@
+##@ Local database rules

--- a/mk/meta-docker.mk
+++ b/mk/meta-docker.mk
@@ -1,0 +1,1 @@
+##@ Container rules

--- a/mk/meta-general.mk
+++ b/mk/meta-general.mk
@@ -1,0 +1,1 @@
+##@ General rules

--- a/mk/meta-legacy.mk
+++ b/mk/meta-legacy.mk
@@ -1,0 +1,1 @@
+##@ Alias rules

--- a/mk/meta-legacy.mk
+++ b/mk/meta-legacy.mk
@@ -1,1 +1,0 @@
-##@ Alias rules

--- a/mk/plantuml.mk
+++ b/mk/plantuml.mk
@@ -1,0 +1,17 @@
+##
+# Rules related with the generation of plantuml diagrams.
+#
+# NOTE: Keep in mind that they don't need to be added to the
+#       repository as it can be seen at the link below:
+#       https://blog.anoff.io/2018-07-31-diagrams-with-plantuml/
+##
+
+.PHONY: diagrams
+plantuml-generate: PLANTUML ?= $(shell command -v plantuml 2>/dev/null)
+plantuml-generate: PLANTUML ?= false
+plantuml-generate: $(patsubst docs/%.puml,docs/%.svg,$(wildcard docs/*.puml)) ## Generate diagrams
+
+# General rule to generate a diagram in SVG format for 
+# each .puml file found at docs/ directory
+docs/%.svg: docs/%.puml
+	plantuml -tsvg $<

--- a/mk/plantuml.mk
+++ b/mk/plantuml.mk
@@ -11,7 +11,7 @@ plantuml-generate: PLANTUML ?= $(shell command -v plantuml 2>/dev/null)
 plantuml-generate: PLANTUML ?= false
 plantuml-generate: $(patsubst docs/%.puml,docs/%.svg,$(wildcard docs/*.puml)) ## Generate diagrams
 
-# General rule to generate a diagram in SVG format for 
+# General rule to generate a diagram in SVG format for
 # each .puml file found at docs/ directory
 docs/%.svg: docs/%.puml
 	$(PLANTUML) -tsvg $<

--- a/mk/plantuml.mk
+++ b/mk/plantuml.mk
@@ -6,7 +6,7 @@
 #       https://blog.anoff.io/2018-07-31-diagrams-with-plantuml/
 ##
 
-.PHONY: diagrams
+.PHONY: plantuml-generate
 plantuml-generate: PLANTUML ?= $(shell command -v plantuml 2>/dev/null)
 plantuml-generate: PLANTUML ?= false
 plantuml-generate: $(patsubst docs/%.puml,docs/%.svg,$(wildcard docs/*.puml)) ## Generate diagrams
@@ -14,4 +14,4 @@ plantuml-generate: $(patsubst docs/%.puml,docs/%.svg,$(wildcard docs/*.puml)) ##
 # General rule to generate a diagram in SVG format for 
 # each .puml file found at docs/ directory
 docs/%.svg: docs/%.puml
-	plantuml -tsvg $<
+	$(PLANTUML) -tsvg $<

--- a/mk/printvars.mk
+++ b/mk/printvars.mk
@@ -3,8 +3,6 @@
 # variable values (without expansion), so that we can see
 # what is the definition before expansion.
 ##
-
 .PHONY: printvars
 printvars: ## Print variable name and values
 	@$(foreach V, $(sort $(.VARIABLES)),$(if $(filter-out environment% default automatic,$(origin $V)),$(info $V=$(value $V))))
-

--- a/mk/printvars.mk
+++ b/mk/printvars.mk
@@ -1,0 +1,10 @@
+##
+# This file only contain the helper rule which print the
+# variable values (without expansion), so that we can see
+# what is the definition before expansion.
+##
+
+.PHONY: printvars
+printvars: ## Print variable name and values
+	@$(foreach V, $(sort $(.VARIABLES)),$(if $(filter-out environment% default automatic,$(origin $V)),$(info $V=$(value $V))))
+

--- a/mk/projectdir.mk
+++ b/mk/projectdir.mk
@@ -1,0 +1,5 @@
+##
+# Small file which only assign the path of the project by
+# reading the absolute path for the main Makefile.
+##
+PROJECT_DIR := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -5,8 +5,8 @@
 
 SWAG=$(GO_OUTPUT)/swag
 
-.PHONY: install-swag  ## Install swag locally on your GO_OUTPUT (./release) directory
-install-swag: $(SWAG)
+.PHONY: install-swag
+install-swag: $(SWAG) ## Install swag locally on your GO_OUTPUT (./release) directory
 
 $(SWAG): GOPATH:=$(shell mktemp -d "$(PROJECT_DIR)/tmp.XXXXXXXX" 2>/dev/null)
 $(SWAG):

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -22,7 +22,7 @@ $(SWAG):
 	}
 
 .PHONY: openapi
-openapi: swag ## Generate the openapi from the source code
+openapi: install-swag ## Generate the openapi from the source code
 	$(SWAG) init --generalInfo api.go --o ./api --dir pkg/handler/ --pd pkg/api
 	# Convert from swagger to openapi
 	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -5,7 +5,13 @@
 SWAG=$(GO_OUTPUT)/swag
 
 $(SWAG):
-	GOBIN=$(dir $(SWAG)) go install github.com/swaggo/swag/cmd/swag@latest
+	{\
+		export GOPATH=$(shell mktemp -d "$$PWD/tmp.XXXXXXXX") ; \
+		export GOBIN=$(dir $(SWAG)) ; \
+		go install github.com/swaggo/swag/cmd/swag@latest ; \
+		find "$${GOPATH}" -type d -exec chmod u+w {} \; ; \
+		rm -rf "$${GOPATH}" ; \
+	}
 
 .PHONY: openapi
 openapi: $(SWAG) ## Generate the openapi from the source code

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -1,0 +1,15 @@
+##
+# Rules to build openapi specification from the source code
+##
+
+SWAG=$(GO_OUTPUT)/swag
+
+$(SWAG):
+	GOBIN=$(dir $(SWAG)) go install github.com/swaggo/swag/cmd/swag@latest
+
+.PHONY: openapi
+openapi: $(SWAG) ## Generate the openapi from the source code
+	$(SWAG) init --generalInfo api.go --o ./api --dir pkg/handler/ --pd pkg/api
+	# Convert from swagger to openapi
+	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json
+	rm ./api/swagger.json ./api/swagger.yaml

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -8,17 +8,16 @@ SWAG=$(GO_OUTPUT)/swag
 .PHONY: install-swag
 install-swag: $(SWAG) ## Install swag locally on your GO_OUTPUT (./release) directory
 
-$(SWAG): GOPATH:=$(shell mktemp -d "$(PROJECT_DIR)/tmp.XXXXXXXX" 2>/dev/null)
 $(SWAG):
 	@{\
-		echo "Using GOPATH='$(GOPATH)'" ; \
-		export GOPATH="$(GOPATH)" ; \
-		[ "$(GOPATH)" != "" ] || { echo "error:GOPATH is empty"; exit 1; } ; \
+		export GOPATH="$(shell mktemp -d "$(PROJECT_DIR)/tmp.XXXXXXXX" 2>/dev/null)" ; \
+		echo "Using GOPATH='$${GOPATH}'" ; \
+		[ "$${GOPATH}" != "" ] || { echo "error:GOPATH is empty"; exit 1; } ; \
 		export GOBIN="$(dir $(SWAG))" ; \
 		echo "Installing 'swag' at '$(SWAG)'" ; \
 		go install github.com/swaggo/swag/cmd/swag@latest ; \
-		find "$(GOPATH)" -type d -exec chmod u+w {} \; ; \
-		rm -rf "$(GOPATH)" ; \
+		find "$${GOPATH}" -type d -exec chmod u+w {} \; ; \
+		rm -rf "$${GOPATH}" ; \
 	}
 
 .PHONY: openapi

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -1,20 +1,28 @@
 ##
 # Rules to build openapi specification from the source code
+# and to install swag locally.
 ##
 
 SWAG=$(GO_OUTPUT)/swag
 
+.PHONY: install-swag  ## Install swag locally on your GO_OUTPUT (./release) directory
+install-swag: $(SWAG)
+
+$(SWAG): GOPATH:=$(shell mktemp -d "$(PROJECT_DIR)/tmp.XXXXXXXX" 2>/dev/null)
 $(SWAG):
-	{\
-		export GOPATH=$(shell mktemp -d "$$PWD/tmp.XXXXXXXX") ; \
-		export GOBIN=$(dir $(SWAG)) ; \
+	@{\
+		echo "Using GOPATH='$(GOPATH)'" ; \
+		export GOPATH="$(GOPATH)" ; \
+		[ "$(GOPATH)" != "" ] || { echo "error:GOPATH is empty"; exit 1; } ; \
+		export GOBIN="$(dir $(SWAG))" ; \
+		echo "Installing 'swag' at '$(SWAG)'" ; \
 		go install github.com/swaggo/swag/cmd/swag@latest ; \
-		find "$${GOPATH}" -type d -exec chmod u+w {} \; ; \
-		rm -rf "$${GOPATH}" ; \
+		find "$(GOPATH)" -type d -exec chmod u+w {} \; ; \
+		rm -rf "$(GOPATH)" ; \
 	}
 
 .PHONY: openapi
-openapi: $(SWAG) ## Generate the openapi from the source code
+openapi: swag ## Generate the openapi from the source code
 	$(SWAG) init --generalInfo api.go --o ./api --dir pkg/handler/ --pd pkg/api
 	# Convert from swagger to openapi
 	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -12,14 +12,40 @@
 # variable value when invoking 'make' command.
 ##
 
-## Database variables (expected from mk/private.mk or .env)
+
+## Database variables (expected from configs/config.yaml)
 # Here just indicate that variables should be exported
+ifeq (,$(shell yq --version 2>/dev/null))
+$(info 'yq' can not be found in your environment)
+$(info to keep synced the config/config.yaml file with)
+$(info DATABASE_* variables)
+$(info You can install it by 'pip install yq')
+$(error Missed 'yq' tool)
+endif
+
+# Retrieve values from 'configs/config.yaml' file
+DATABASE_HOST:=$(shell yq -r -M '.database.host' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_PORT:=$(shell yq -M '.database.port' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_NAME:=$(shell yq -r -M '.database.name' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_USER:=$(shell yq -r -M '.database.user' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_PASSWORD:=$(shell yq -r -M '.database.password' "$(PROJECT_DIR)/configs/config.yaml")
+
+# Set some default values
+DATABASE_HOST ?= localhost
+DATABASE_PORT ?= 5432
+DATABASE_NAME ?= content
+DATABASE_USER ?= content
+DATABASE_PASSWORD ?= content
+
+# Make the values availables for the forked processes as env vars
 export DATABASE_HOST
 export DATABASE_PORT
 export DATABASE_NAME
 export DATABASE_USER
 export DATABASE_PASSWORD
 
+
+## Binary output
 # The directory where golang will output the
 # built binaries
 GO_OUTPUT ?= $(PROJECT_DIR)/release
@@ -39,4 +65,3 @@ DOCKER_IMAGE_BASE ?= quay.io/$(QUAY_USER)/content-sources
 DOCKER_IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 # Compose the container image with all the above
 DOCKER_IMAGE ?= $(DOCKER_IMAGE_BASE):$(DOCKER_IMAGE_TAG)
-

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -1,0 +1,42 @@
+##
+# This file contains the default variable values
+# that will be used along the Makefile execution.
+#
+# The values on this file can be overrided from
+# the 'mk/private.mk' file (which is ignored by
+# .gitignore file), that can be created from the
+# 'mk/private.mk.example' file. It is recommended
+# to use conditional assignment in your private.mk
+# file, so that you can override values from
+# the environment variable or just assigning the
+# variable value when invoking 'make' command.
+##
+
+## Database variables (expected from mk/private.mk or .env)
+# Here just indicate that variables should be exported
+export DATABASE_HOST
+export DATABASE_PORT
+export DATABASE_NAME
+export DATABASE_USER
+export DATABASE_PASSWORD
+
+# The directory where golang will output the
+# built binaries
+GO_OUTPUT ?= $(PROJECT_DIR)/release
+
+
+## Container variables
+# Default QUAY_USER set to the current user
+# Customize it at 'mk/private.mk' file
+QUAY_USER ?= $(USER)
+# Context directory to be used as base for building the container
+DOCKER_CONTEXT_DIR ?= .
+# Path to the main project Dockerfile file
+DOCKER_DOCKERFILE ?= build/Dockerfile
+# Base image name
+DOCKER_IMAGE_BASE ?= quay.io/$(QUAY_USER)/content-sources
+# Default image tag is set to the short git hash of the repo
+DOCKER_IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
+# Compose the container image with all the above
+DOCKER_IMAGE ?= $(DOCKER_IMAGE_BASE):$(DOCKER_IMAGE_TAG)
+

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -20,22 +20,20 @@ $(info 'yq' can not be found in your environment)
 $(info to keep synced the config/config.yaml file with)
 $(info DATABASE_* variables)
 $(info You can install it by 'pip install yq')
-$(error Missed 'yq' tool)
-endif
-
-# Retrieve values from 'configs/config.yaml' file
-DATABASE_HOST:=$(shell yq -r -M '.database.host' "$(PROJECT_DIR)/configs/config.yaml")
-DATABASE_PORT:=$(shell yq -M '.database.port' "$(PROJECT_DIR)/configs/config.yaml")
-DATABASE_NAME:=$(shell yq -r -M '.database.name' "$(PROJECT_DIR)/configs/config.yaml")
-DATABASE_USER:=$(shell yq -r -M '.database.user' "$(PROJECT_DIR)/configs/config.yaml")
-DATABASE_PASSWORD:=$(shell yq -r -M '.database.password' "$(PROJECT_DIR)/configs/config.yaml")
-
 # Set some default values
 DATABASE_HOST ?= localhost
 DATABASE_PORT ?= 5432
 DATABASE_NAME ?= content
 DATABASE_USER ?= content
 DATABASE_PASSWORD ?= content
+else
+# Retrieve values from 'configs/config.yaml' file
+DATABASE_HOST ?= $(shell yq -r -M '.database.host' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_PORT ?= $(shell yq -M '.database.port' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_NAME ?= $(shell yq -r -M '.database.name' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_USER ?= $(shell yq -r -M '.database.user' "$(PROJECT_DIR)/configs/config.yaml")
+DATABASE_PASSWORD ?= $(shell yq -r -M '.database.password' "$(PROJECT_DIR)/configs/config.yaml")
+endif
 
 # Make the values availables for the forked processes as env vars
 export DATABASE_HOST


### PR DESCRIPTION
A set of changes based on small snippets I had from other repos:

- Set default values for necessary variables in `mk/variables.mk`.
- Add generic rules to build golang binaries at `cmd/dir/**`, and other helper rules `tidy` and `vendor`.
- Add generic rule to generate diagrams from plantuml files at `docs/` directory.
- Install swag locally to the repository and add dependency in `openapi` rule.
- Add rules to start/stop postgres from a container (useful for developing from the workstation).
- Add generic rules to build and push container images.
- Set `help` as default rule, and generate help for the rules from the comments.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>