### PR TITLE
CONTENT-56: Add list/delete dao layer and honor org id

### DIFF
--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -84,7 +84,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		err = seeds.SeedRepositoryConfigurations(db.DB, 1000)
+		err = seeds.SeedRepositoryConfigurations(db.DB, 1000, seeds.SeedOptions{})
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,5 +1,8 @@
 package api
 
+const IdentityHeader = "x-rh-identity"
+
+// CollectionMetadataSettable a collection response with settable metadata
 type CollectionMetadataSettable interface {
 	SetMetadata(meta ResponseMetadata, links Links)
 }

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -1,8 +1,6 @@
 package api
 
-import "github.com/content-services/content-sources-backend/pkg/models"
-
-// RepositoryResponse holds data received from, or returned by, a repositories API request or response
+// RepositoryResponse holds data returned by a repositories API response
 type RepositoryResponse struct {
 	UUID                 string   `json:"uuid" readonly:"true"`
 	Name                 string   `json:"name"`
@@ -13,7 +11,7 @@ type RepositoryResponse struct {
 	OrgID                string   `json:"org_id" readonly:"true"`                    //Organization ID of the owner
 }
 
-// RepositoryRequest holds data received from request to create repository
+// RepositoryRequest holds data received from request to create/update repository
 type RepositoryRequest struct {
 	UUID                 *string   `json:"uuid" readonly:"true" swaggerignore:"true"`
 	Name                 *string   `json:"name"`
@@ -42,16 +40,6 @@ func (r *RepositoryRequest) FillDefaults() {
 	if r.DistributionArch == nil {
 		r.DistributionArch = &defaultArch
 	}
-}
-
-func (r *RepositoryResponse) FromRepositoryConfiguration(repoConfig models.RepositoryConfiguration) {
-	r.UUID = repoConfig.UUID
-	r.Name = repoConfig.Name
-	r.URL = repoConfig.URL
-	r.DistributionVersions = repoConfig.Versions
-	r.DistributionArch = repoConfig.Arch
-	r.AccountID = repoConfig.AccountID
-	r.OrgID = repoConfig.OrgID
 }
 
 type RepositoryCollectionResponse struct {

--- a/pkg/dao/error.go
+++ b/pkg/dao/error.go
@@ -1,5 +1,9 @@
 package dao
 
+import (
+	"github.com/jackc/pgconn"
+)
+
 type Error struct {
 	Message       string
 	NotFound      bool
@@ -8,4 +12,14 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.Message
+}
+
+func isUniqueViolation(err error) bool {
+	pgError, ok := err.(*pgconn.PgError)
+	if ok {
+		if pgError.Code == "23505" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -6,6 +6,8 @@ import (
 
 type RepositoryDao interface {
 	Create(newRepo api.RepositoryRequest) error
-	Fetch(orgId string, uuid string) api.RepositoryResponse
-	Update(orgId string, uuid string, repoParams api.RepositoryRequest) error
+	Update(orgID string, uuid string, repoParams api.RepositoryRequest) error
+	Fetch(orgID string, uuid string) (api.RepositoryResponse, error)
+	List(orgID string, limit int, offset int) (api.RepositoryCollectionResponse, int64, error)
+	Delete(orgID string, uuid string) error
 }

--- a/pkg/dao/repository.go
+++ b/pkg/dao/repository.go
@@ -4,7 +4,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/models"
-	"github.com/jackc/pgconn"
+	"gorm.io/gorm"
 )
 
 type repositoryDaoImpl struct {
@@ -23,44 +23,79 @@ func (r repositoryDaoImpl) Create(newRepo api.RepositoryRequest) error {
 
 	if err := db.DB.Create(&newRepoConfig).Error; err != nil {
 		if isUniqueViolation(err) {
-			return &Error{BadValidation: true, Message: "RepositoryResponse with this URL already belongs to organization "}
+			return &Error{BadValidation: true, Message: "Repository with this URL already belongs to organization "}
 		}
 		return err
 	}
 	return nil
 }
 
-func (r repositoryDaoImpl) Fetch(orgId string, uuid string) api.RepositoryResponse {
+func (r repositoryDaoImpl) List(OrgID string, limit int, offset int) (api.RepositoryCollectionResponse, int64, error) {
+	var totalRepos int64
+	repoConfigs := make([]models.RepositoryConfiguration, 0)
+
+	result := db.DB.Where("org_id = ?", OrgID).Find(&repoConfigs).Count(&totalRepos)
+	if result.Error != nil {
+		return api.RepositoryCollectionResponse{}, totalRepos, result.Error
+	}
+
+	result = db.DB.Where("org_id = ?", OrgID).Limit(limit).Offset(offset).Find(&repoConfigs)
+	if result.Error != nil {
+		return api.RepositoryCollectionResponse{}, totalRepos, result.Error
+	}
+
+	repos := convertToResponses(repoConfigs)
+	return api.RepositoryCollectionResponse{Data: repos}, totalRepos, nil
+}
+
+func (r repositoryDaoImpl) Fetch(orgID string, uuid string) (api.RepositoryResponse, error) {
 	repo := api.RepositoryResponse{}
-	repo.FromRepositoryConfiguration(r.fetchRepoConfig(orgId, uuid))
-	return repo
+	repoConfig, err := r.fetchRepoConfig(orgID, uuid)
+	if err != nil {
+		return repo, err
+	}
+	ModelToApiFields(repoConfig, &repo)
+	return repo, err
 }
 
-func (r repositoryDaoImpl) fetchRepoConfig(orgId string, uuid string) models.RepositoryConfiguration {
+func (r repositoryDaoImpl) fetchRepoConfig(orgID string, uuid string) (models.RepositoryConfiguration, error) {
 	found := models.RepositoryConfiguration{}
-	db.DB.Where("UUID = ? AND ORG_ID = ?", uuid, orgId).First(&found)
-	return found
-}
+	result := db.DB.Where("UUID = ? AND ORG_ID = ?", uuid, orgID).First(&found)
 
-func isUniqueViolation(err error) bool {
-	pgError, ok := err.(*pgconn.PgError)
-	if ok {
-		if pgError.Code == "23505" {
-			return true
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return found, &Error{NotFound: true, Message: "Could not find repository with UUID " + uuid}
+		} else {
+			return found, result.Error
 		}
 	}
-	return false
+	return found, nil
 }
 
-func (r repositoryDaoImpl) Update(orgId string, uuid string, repoParams api.RepositoryRequest) error {
-	repoConfig := r.fetchRepoConfig(orgId, uuid)
-	if repoConfig.UUID == "" {
-		return &Error{NotFound: true, Message: "Could not find RepositoryResponse with uuid " + uuid}
+func (r repositoryDaoImpl) Update(orgID string, uuid string, repoParams api.RepositoryRequest) error {
+	repoConfig, err := r.fetchRepoConfig(orgID, uuid)
+	if err != nil {
+		return err
 	}
 	ApiFieldsToModel(&repoParams, &repoConfig)
 	result := db.DB.Model(&repoConfig).Updates(repoConfig.MapForUpdate())
 	if result.Error != nil {
 		return &Error{Message: result.Error.Error(), BadValidation: isUniqueViolation(result.Error)}
+	}
+	return nil
+}
+
+func (r repositoryDaoImpl) Delete(orgID string, uuid string) error {
+	repoConfig := models.RepositoryConfiguration{}
+	if err := db.DB.Debug().Where("UUID = ? AND ORG_ID = ?", uuid, orgID).First(&repoConfig).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return &Error{NotFound: true, Message: "Could not find repository with UUID " + uuid}
+		} else {
+			return err
+		}
+	}
+	if err := db.DB.Delete(&repoConfig).Error; err != nil {
+		return err
 	}
 	return nil
 }
@@ -78,4 +113,23 @@ func ApiFieldsToModel(apiRepo *api.RepositoryRequest, repoConfig *models.Reposit
 	if apiRepo.DistributionVersions != nil {
 		repoConfig.Versions = *apiRepo.DistributionVersions
 	}
+}
+
+func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.RepositoryResponse) {
+	apiRepo.UUID = repoConfig.UUID
+	apiRepo.Name = repoConfig.Name
+	apiRepo.URL = repoConfig.URL
+	apiRepo.DistributionVersions = repoConfig.Versions
+	apiRepo.DistributionArch = repoConfig.Arch
+	apiRepo.AccountID = repoConfig.AccountID
+	apiRepo.OrgID = repoConfig.OrgID
+}
+
+// Converts the database models to our response objects
+func convertToResponses(repoConfigs []models.RepositoryConfiguration) []api.RepositoryResponse {
+	repos := make([]api.RepositoryResponse, len(repoConfigs))
+	for i := 0; i < len(repoConfigs); i++ {
+		ModelToApiFields(repoConfigs[i], &repos[i])
+	}
+	return repos
 }

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -29,27 +29,6 @@ func (suite *ReposSuite) TearDownTest() {
 	db.DB = suite.savedDB
 }
 
-func (suite *ReposSuite) TestUpdate() {
-	name := "Updated"
-	url := "http://someUrl.com"
-	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
-	assert.Nil(t, err)
-	found := models.RepositoryConfiguration{}
-	db.DB.First(&found)
-
-	err = GetRepositoryDao().Update(found.OrgID, found.UUID,
-		api.RepositoryRequest{
-			Name: &name,
-			URL:  &url,
-		})
-	assert.Nil(t, err)
-
-	db.DB.First(&found)
-	assert.Equal(t, "Updated", found.Name)
-	assert.Equal(t, "http://someUrl.com", found.URL)
-}
-
 func (suite *ReposSuite) TestCreate() {
 	name := "Updated"
 	url := "http://someUrl.com"
@@ -77,7 +56,7 @@ func (suite *ReposSuite) TestCreate() {
 
 func (suite *ReposSuite) TestCreateAlreadyExists() {
 	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
 	assert.Nil(t, err)
 
 	found := models.RepositoryConfiguration{}
@@ -96,11 +75,32 @@ func (suite *ReposSuite) TestCreateAlreadyExists() {
 	assert.True(t, daoError.BadValidation)
 }
 
+func (suite *ReposSuite) TestUpdate() {
+	name := "Updated"
+	url := "http://someUrl.com"
+	t := suite.T()
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
+	assert.Nil(t, err)
+	found := models.RepositoryConfiguration{}
+	db.DB.First(&found)
+
+	err = GetRepositoryDao().Update(found.OrgID, found.UUID,
+		api.RepositoryRequest{
+			Name: &name,
+			URL:  &url,
+		})
+	assert.Nil(t, err)
+
+	db.DB.First(&found)
+	assert.Equal(t, "Updated", found.Name)
+	assert.Equal(t, "http://someUrl.com", found.URL)
+}
+
 func (suite *ReposSuite) TestUpdateEmpty() {
 	name := "Updated"
 	arch := ""
 	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
@@ -121,7 +121,7 @@ func (suite *ReposSuite) TestUpdateEmpty() {
 func (suite *ReposSuite) TestDuplicateUpdate() {
 	name := "unique"
 	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
@@ -144,7 +144,7 @@ func (suite *ReposSuite) TestDuplicateUpdate() {
 func (suite *ReposSuite) TestUpdateNotFound() {
 	name := "unique"
 	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
@@ -163,14 +163,127 @@ func (suite *ReposSuite) TestUpdateNotFound() {
 
 func (suite *ReposSuite) TestFetch() {
 	t := suite.T()
-	err := seeds.SeedRepositoryConfigurations(db.DB, 1)
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
 
-	fetched := GetRepositoryDao().Fetch(found.OrgID, found.UUID)
+	fetched, err := GetRepositoryDao().Fetch(found.OrgID, found.UUID)
+	assert.Nil(t, err)
 	assert.Equal(t, found.UUID, fetched.UUID)
 	assert.Equal(t, found.Name, fetched.Name)
+}
+
+func (suite *ReposSuite) TestFetchNotFound() {
+	t := suite.T()
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
+	assert.Nil(t, err)
+	found := models.RepositoryConfiguration{}
+	db.DB.First(&found)
+
+	_, err = GetRepositoryDao().Fetch("bad org id", found.UUID)
+	assert.NotNil(t, err)
+	daoError, ok := err.(*Error)
+	assert.True(t, ok)
+	assert.True(t, daoError.NotFound)
+}
+
+func (suite *ReposSuite) TestList() {
+	t := suite.T()
+	repoConfig := models.RepositoryConfiguration{}
+	orgID := "1028"
+	var total int64
+
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{OrgID: orgID})
+	assert.Nil(t, err)
+
+	result := db.DB.Where("org_id = ?", orgID).Find(&repoConfig).Count(&total)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, int64(1), total)
+
+	response, total, err := GetRepositoryDao().List(orgID, 100, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, repoConfig.Name, response.Data[0].Name)
+	assert.Equal(t, repoConfig.URL, response.Data[0].URL)
+	assert.Equal(t, int64(1), total)
+}
+
+func (suite *ReposSuite) TestListNoRepositories() {
+	t := suite.T()
+	repoConfigs := make([]models.RepositoryConfiguration, 0)
+	orgID := "1028"
+	limit := 100
+	offset := 0
+	var total int64
+
+	result := db.DB.Where("org_id = ?", orgID).Find(&repoConfigs).Count(&total)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, int64(0), total)
+
+	response, total, err := GetRepositoryDao().List(orgID, limit, offset)
+	assert.Nil(t, err)
+	assert.Empty(t, response.Data)
+	assert.Equal(t, int64(0), total)
+}
+
+func (suite *ReposSuite) TestListPageLimit() {
+	t := suite.T()
+	repoConfigs := make([]models.RepositoryConfiguration, 0)
+	orgID := "1028"
+	limit := 10
+	offset := 0
+	var total int64
+
+	err := seeds.SeedRepositoryConfigurations(db.DB, 20, seeds.SeedOptions{OrgID: orgID})
+	assert.Nil(t, err)
+
+	result := db.DB.Where("org_id = ?", orgID).Find(&repoConfigs).Count(&total)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, int64(20), total)
+
+	response, total, err := GetRepositoryDao().List(orgID, limit, offset)
+	assert.Nil(t, err)
+	assert.Equal(t, len(response.Data), limit)
+	assert.Equal(t, int64(20), total)
+}
+
+func (suite *ReposSuite) TestDelete() {
+	t := suite.T()
+
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
+	assert.Nil(t, err)
+
+	repoConfig := models.RepositoryConfiguration{}
+	result := db.DB.First(&repoConfig)
+	assert.Nil(t, result.Error)
+
+	err = GetRepositoryDao().Delete(repoConfig.OrgID, repoConfig.UUID)
+	assert.Nil(t, err)
+
+	result = db.DB.First(&repoConfig)
+	assert.Error(t, result.Error)
+
+}
+
+func (suite *ReposSuite) TestDeleteNotFound() {
+	t := suite.T()
+
+	err := seeds.SeedRepositoryConfigurations(db.DB, 1, seeds.SeedOptions{})
+	assert.Nil(t, err)
+
+	found := models.RepositoryConfiguration{}
+	result := db.DB.First(&found)
+	assert.Nil(t, result.Error)
+
+	err = GetRepositoryDao().Delete("bad org id", found.UUID)
+	assert.NotNil(t, err)
+	daoError, ok := err.(*Error)
+	assert.True(t, ok)
+	assert.True(t, daoError.NotFound)
+
+	result = db.DB.First(&found)
+	assert.Nil(t, result.Error)
+
 }
 
 func TestReposSuite(t *testing.T) {

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -123,7 +123,9 @@ func badIdentity(err error) error {
 	return echo.NewHTTPError(http.StatusBadRequest, "Error parsing identity: "+err.Error())
 }
 
-func collectionResponse(collection api.CollectionMetadataSettable, c echo.Context, totalCount int64) api.CollectionMetadataSettable {
+// setCollectionResponseMetadata determines metadata of collection response based on context and collection size.
+// Returns collection response with updated metadata.
+func setCollectionResponseMetadata(collection api.CollectionMetadataSettable, c echo.Context, totalCount int64) api.CollectionMetadataSettable {
 	page := ParsePagination(c)
 	var lastPage int
 	if int(totalCount) > 0 && (int(totalCount)%page.Limit) == 0 {

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -82,20 +82,20 @@ func TestParsePagination(t *testing.T) {
 func TestCollectionResponse(t *testing.T) {
 	coll := api.RepositoryCollectionResponse{}
 
-	collectionResponse(&coll, getTestContext("?offset=0&limit=1"), 10)
+	setCollectionResponseMetadata(&coll, getTestContext("?offset=0&limit=1"), 10)
 	assert.Equal(t, 0, coll.Meta.Offset)
 	assert.NotEmpty(t, coll.Links.First)
 	assert.NotEmpty(t, coll.Links.Last)
 	assert.Empty(t, coll.Links.Prev)
 	assert.NotEmpty(t, coll.Links.Next)
 
-	collectionResponse(&coll, getTestContext("?offset=10&limit=1"), 10)
+	setCollectionResponseMetadata(&coll, getTestContext("?offset=10&limit=1"), 10)
 	assert.NotEmpty(t, coll.Links.First)
 	assert.NotEmpty(t, coll.Links.Last)
 	assert.NotEmpty(t, coll.Links.Prev)
 	assert.Empty(t, coll.Links.Next)
 
-	collectionResponse(&coll, getTestContext("?offset=5&limit=1"), 10)
+	setCollectionResponseMetadata(&coll, getTestContext("?offset=5&limit=1"), 10)
 	assert.NotEmpty(t, coll.Links.First)
 	assert.NotEmpty(t, coll.Links.Last)
 	assert.NotEmpty(t, coll.Links.Prev)

--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -12,7 +12,7 @@ type RepositoryConfiguration struct {
 	OrgID     string         `json:"org_id" gorm:"default:null"`
 }
 
-//When updating a model with gorm, we want to explicitly update any field that is set to
+// When updating a model with gorm, we want to explicitly update any field that is set to
 // empty string.  We always fetch the object and then update it before saving
 // so every update is the full model of user changeable fields.
 // So OrgId and account Id are excluded

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -9,8 +9,16 @@ import (
 	"gorm.io/gorm"
 )
 
-func SeedRepositoryConfigurations(db *gorm.DB, size int) error {
+type SeedOptions struct {
+	OrgID string
+}
+
+func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) error {
 	var repos []models.RepositoryConfiguration
+
+	if options.OrgID == "" {
+		options.OrgID = fmt.Sprintf("%d", rand.Intn(9999))
+	}
 
 	for i := 0; i < size; i++ {
 		repoConfig := models.RepositoryConfiguration{
@@ -19,7 +27,7 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int) error {
 			Versions:  []string{"9"},
 			Arch:      "x86_64",
 			AccountID: fmt.Sprintf("%d", rand.Intn(9999)),
-			OrgID:     fmt.Sprintf("%d", rand.Intn(9999)),
+			OrgID:     options.OrgID,
 		}
 		repos = append(repos, repoConfig)
 	}


### PR DESCRIPTION
#### Adds
- Delete and List actions to the DAO layer.
- Additional error checking to Fetch/Update in the DAO layer.
- Rewrites the repository handler tests to use serveHTTP instead of context (because it feels less cumbersome)
- Org ID filters to all the queries that were missing them.
- Tests for verifying Org ID is correct when returning results from database and API
- IdentityHeader constant to api/api.go
- Rename collectionResponse -> setCollectionResponseMetadata

The TestList pagination tests in the handler tests are a bit tricky now because of the mocking. I'm not 100% sure they're still testing what they need to test.