### PR TITLE
Fixes 90: commands to download and load external repos

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,8 +11,7 @@ FROM registry.redhat.io/ubi8/ubi-minimal:8.5
 
 WORKDIR /
 
-COPY --from=builder /go/src/app/release/dbmigrate ./dbmigrate
-COPY --from=builder /go/src/app/release/content-sources ./content-sources
+COPY --from=builder /go/src/app/release/* ./
 RUN mkdir ./db/
 COPY --from=builder /go/src/app/db ./db/
 

--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -70,6 +70,7 @@ func main() {
 		if err := upMigrationCmd.Parse(args[2:]); err != nil {
 			log.Fatal().Err(err).Msg("Failed to migrate")
 		}
+		fmt.Println(upMigrationSteps)
 		if err := db.MigrateDB(dbURL, "up", *upMigrationSteps); err != nil {
 			log.Fatal().Err(err).Msg("Failed to migrate")
 		}

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"sort"
+
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/external_repos"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/lib/pq"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+)
+
+func main() {
+	args := os.Args
+	if len(args) < 2 {
+		log.Fatal().Msg("Requires arguments: import.")
+	}
+	if args[1] == "download" {
+		if len(args) < 3 {
+			log.Fatal().Msg("Usage:  ./external-repos import /path/to/jsons/")
+		}
+		scanForExternalRepos(args[2])
+	} else if args[1] == "import" {
+		config.Load()
+		err := db.Connect()
+		if err != nil {
+			log.Panic().Err(err).Msg("Failed to save repositories")
+		}
+		err = saveToDB(db.DB)
+		if err != nil {
+			log.Panic().Err(err).Msg("Failed to save repositories")
+		}
+		log.Debug().Msg("Successfully loaded external repositories.")
+	}
+}
+
+func saveToDB(db *gorm.DB) error {
+	var (
+		err      error
+		extRepos []external_repos.ExternalRepository
+		urls     []string
+	)
+	extRepos, err = external_repos.LoadFromFile()
+
+	if err == nil {
+		urls = external_repos.GetBaseURLs(extRepos)
+		err = dao.GetRepositoryDao(db).SavePublicRepos(urls)
+	}
+	return err
+}
+
+func scanForExternalRepos(path string) {
+	urls, err := external_repos.IBUrlsFromDir(path)
+	if err != nil {
+		log.Panic().Err(err).Msg("Failed to import repositories")
+	}
+	sort.Strings(urls)
+	err = external_repos.SaveToFile(urls)
+	if err != nil {
+		log.Panic().Err(err).Msg("Failed to import repositories")
+	}
+	log.Info().Msg("Saved External Repositories")
+}

--- a/db/migrations/20220512132042_create_repository_configurations_table.up.sql
+++ b/db/migrations/20220512132042_create_repository_configurations_table.up.sql
@@ -9,7 +9,8 @@ CREATE TABLE IF NOT EXISTS repositories (
     updated_at TIMESTAMP WITH TIME ZONE,
     url VARCHAR(255) NOT NULL,
     last_read_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
-    last_read_error VARCHAR(255) DEFAULT NULL
+    last_read_error VARCHAR(255) DEFAULT NULL,
+    public boolean NOT NULL DEFAULT FALSE
 );
 
 ALTER TABLE repositories

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -27,6 +27,10 @@ objects:
             args:
               - /dbmigrate
               - up
+          - env:
+            inheritEnv: true
+            args:
+              - /external-repos import
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3

--- a/mk/includes.mk
+++ b/mk/includes.mk
@@ -31,3 +31,5 @@ include mk/meta-db.mk
 include mk/db.mk
 include mk/meta-docker.mk
 include mk/docker.mk
+include mk/meta-repos.mk
+include mk/repos.mk

--- a/mk/meta-repos.mk
+++ b/mk/meta-repos.mk
@@ -1,0 +1,1 @@
+##@ Manage external repo information

--- a/mk/repos.mk
+++ b/mk/repos.mk
@@ -1,0 +1,12 @@
+.PHONY: repos-download
+repos-download: $(GO_OUTPUT)/external-repos  ## Download external repo urls from Image Builder
+	{\
+		export TMPDIR="$(shell mktemp -d)" ; \
+		git clone https://github.com/osbuild/image-builder.git --sparse --depth=1 "$${TMPDIR}" \
+		&& ( cd "$${TMPDIR}"; git sparse-checkout set distributions/ ) \
+		&& $(GO_OUTPUT)/external-repos download "$${TMPDIR}/distributions/" \
+	; }
+
+.PHONY: repos-import
+repos-import: ## Import External repo urls from Image Builders into the DB.  Generates pkg/external_repos/external_repos.json
+	go run ./cmd/external-repos/main.go import

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -10,6 +10,7 @@ type RepositoryDao interface {
 	Fetch(orgID string, uuid string) (api.RepositoryResponse, error)
 	List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)
 	Delete(orgID string, uuid string) error
+	SavePublicRepos(urls []string) error
 }
 
 type RpmDao interface {

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *RepositorySuite) TestCreate() {
@@ -513,6 +514,25 @@ func (suite *RepositorySuite) TestListFilterMultipleVersions() {
 	assert.Nil(t, err)
 	assert.Equal(t, quantity, len(response.Data))
 	assert.Equal(t, int64(quantity), count)
+}
+
+func (suite *RepositorySuite) TestSavePublicUrls() {
+	t := suite.T()
+	repoUrls := []string{"https://somepublicRepo.com/", "https://anotherpublicRepo.com/"}
+	err := GetRepositoryDao(suite.tx).SavePublicRepos(repoUrls)
+
+	require.NoError(t, err)
+	repo := models.Repository{}
+	result := suite.tx.Where("url = ?", repoUrls[0]).Find(&repo)
+
+	assert.NoError(t, result.Error)
+	var count int64
+	suite.tx.Model(&repo).Count(&count)
+	assert.Equal(t, int64(2), count)
+
+	err = GetRepositoryDao(suite.tx).SavePublicRepos(repoUrls)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), count)
 }
 
 func (suite *RepositorySuite) TestDelete() {

--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -1,0 +1,83 @@
+[
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
+    },
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+    },
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/extras/x86_64/os/"
+    },
+    {
+        "base_url": "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
+    },
+    {
+        "base_url": "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.5/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.5/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.6/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.6/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+    },
+    {
+        "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+    }
+]

--- a/pkg/external_repos/image_builder.go
+++ b/pkg/external_repos/image_builder.go
@@ -1,0 +1,83 @@
+package external_repos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// IBUrlsFromDir Import Repo Urls from image builder's git repo
+// The dirPath should point to GITDIR/distributions/ which contains
+// 		the repo directories.  Each directory contains a json file
+//		with the same name as the directory itself:
+//		./distributions/rhel-90/rhel-90.json
+func IBUrlsFromDir(dirPath string) ([]string, error) {
+	var urls []string
+	files, err := scanDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(files); i++ {
+		subUrls, err := extractUrls(files[i])
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, subUrls...)
+	}
+	return urls, nil
+}
+
+type ImageBuilderRepoJson struct {
+	MainArch   ImageBuilderArch `json:"x86_64"`
+	PlatformId string           `json:"module_platform_id"`
+}
+
+type ImageBuilderArch struct {
+	Repositories []ImageBuilderRepo `json:"repositories"`
+	ImageTypes   []string           `json:"image_types"`
+}
+
+type ImageBuilderRepo struct {
+	BaseUrl string `json:"baseurl"`
+}
+
+func extractUrls(filePath string) ([]string, error) {
+	var repoUrls []string
+	jsonStr, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	parsed := ImageBuilderRepoJson{}
+	err = json.Unmarshal(jsonStr, &parsed)
+	if err != nil {
+		return nil, err
+	}
+	repos := parsed.MainArch.Repositories
+	for i := 0; i < len(repos); i++ {
+		repoUrls = append(repoUrls, repos[i].BaseUrl)
+	}
+	return repoUrls, nil
+}
+
+// Scans the IB Distributions directory for repo json files
+//   This assumes that some directory "distributions/foo/" contains
+// 	 a json file  distributions/foo/foo.json
+func scanDir(dirPath string) ([]string, error) {
+	var foundFiles []string
+
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(files); i++ {
+		if files[i].IsDir() && files[i].Name()[0:1] != "." {
+			filename := fmt.Sprintf("%s.json", files[i].Name())
+			foundFiles = append(foundFiles, filepath.Join(dirPath, files[i].Name(), filename))
+		}
+	}
+
+	return foundFiles, nil
+}

--- a/pkg/external_repos/store.go
+++ b/pkg/external_repos/store.go
@@ -1,0 +1,65 @@
+package external_repos
+
+import (
+	"embed"
+	"encoding/json"
+	"os"
+)
+
+const Filename = "./pkg/external_repos/external_repos.json"
+
+//go:embed "external_repos.json"
+
+var fs embed.FS
+
+type ExternalRepository struct {
+	BaseUrl string `json:"base_url"`
+}
+
+// SaveToFile Saves a list of repo urls to the external file
+func SaveToFile(repoUrls []string) error {
+	var (
+		repos    []ExternalRepository
+		err      error
+		repoJson []byte
+	)
+	for i := 0; i < len(repoUrls); i++ {
+		repos = append(repos, ExternalRepository{BaseUrl: repoUrls[i]})
+	}
+	repoJson, err = json.MarshalIndent(&repos, "", "    ")
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(Filename, repoJson, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// LoadFromFile Loads repo urls from the external file
+func LoadFromFile() ([]ExternalRepository, error) {
+	var (
+		repos    []ExternalRepository
+		contents []byte
+		err      error
+	)
+
+	contents, err = fs.ReadFile("external_repos.json")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(contents, &repos)
+	if err != nil {
+		return nil, err
+	}
+	return repos, nil
+}
+
+func GetBaseURLs(repos []ExternalRepository) []string {
+	var urls []string
+	for i := 0; i < len(repos); i++ {
+		urls = append(urls, repos[i].BaseUrl)
+	}
+	return urls
+}

--- a/pkg/external_repos/store_test.go
+++ b/pkg/external_repos/store_test.go
@@ -1,0 +1,18 @@
+package external_repos
+
+import "github.com/stretchr/testify/assert"
+
+func (s *ExternalRepoSuite) TestLoadFromFile() {
+	extRepos, error := LoadFromFile()
+	assert.NoError(s.T(), error)
+	assert.NotEmpty(s.T(), extRepos)
+}
+
+func (s *ExternalRepoSuite) TestGetBaseURLs() {
+	extRepos := []ExternalRepository{{
+		BaseUrl: "http://somerepourl/",
+	}}
+	urls := GetBaseURLs(extRepos)
+
+	assert.Equal(s.T(), []string{"http://somerepourl/"}, urls)
+}

--- a/pkg/external_repos/suite_test.go
+++ b/pkg/external_repos/suite_test.go
@@ -1,0 +1,43 @@
+package external_repos
+
+import (
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+type ExternalRepoSuite struct {
+	suite.Suite
+	db                        *gorm.DB
+	tx                        *gorm.DB
+	skipDefaultTransactionOld bool
+}
+
+func (s *ExternalRepoSuite) SetupTest() {
+	if db.DB == nil {
+		if err := db.Connect(); err != nil {
+			s.FailNow(err.Error())
+		}
+	}
+	s.db = db.DB
+	s.skipDefaultTransactionOld = s.db.SkipDefaultTransaction
+	s.db.SkipDefaultTransaction = false
+	s.tx = s.db.Begin()
+
+	// Remove the content for the 3 involved tables
+	s.tx.Where("1=1").Delete(models.Rpm{})
+	s.tx.Where("1=1").Delete(models.Repository{})
+	s.tx.Where("1=1").Delete(models.RepositoryConfiguration{})
+}
+
+func (s *ExternalRepoSuite) TearDownTest() {
+	s.tx.Rollback()
+	s.db.SkipDefaultTransaction = s.skipDefaultTransactionOld
+}
+
+func TestExternalRepoSuite(t *testing.T) {
+	suite.Run(t, new(ExternalRepoSuite))
+}

--- a/pkg/handler/repository_test.go
+++ b/pkg/handler/repository_test.go
@@ -72,6 +72,10 @@ func (r *MockRepositoryDao) List(
 	}
 }
 
+func (r *MockRepositoryDao) SavePublicRepos(urls []string) error {
+	return nil
+}
+
 func (r *MockRepositoryDao) Delete(orgID string, uuid string) error {
 	args := r.Called(orgID, uuid)
 	return args.Error(0)

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -16,6 +16,7 @@ type Repository struct {
 	LastReadError            *string                   `gorm:"default:null"`
 	RepositoryConfigurations []RepositoryConfiguration `gorm:"foreignKey:RepositoryUUID"`
 	Rpms                     []Rpm                     `gorm:"many2many:repositories_rpms"`
+	Public                   bool                      `gorm:"default:false"`
 }
 
 func (r *Repository) BeforeCreate(tx *gorm.DB) (err error) {


### PR DESCRIPTION
This adds a couple commands:

```
Manage external repo information
  repos-download   Download external repo urls from Image Builder
  repos-import     Import External repo urls from Image Builders into the DB
```

so you can run:

```
rm ./pkg/external_repos/external_repos.json    #clear out the existing cache
make repos-download  
```
the file should be recreated exactly

```
make repos-import
```

check your db and see the repos import:
```
make db-cli-connect


 select * from repositories ;
```

This also adds a "public" field to repositories, to mark repos that are available to all accounts, regardless of presence of repository_configuration