### PR TITLE
proposal:configuration which allow to run and debug unit tests from VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ release/
 .idea
 .env
 configs/config.yaml
+
+# Visual Studio Code settings
+.vscode/**
+!.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "go.testEnvVars": {
+        "CONFIG_PATH": "${workspaceFolder}/configs"
+    }
+}


### PR DESCRIPTION
- Set configuration for .gitignore
- For tests, set CONFIG_PATH to point out the current 'configs` direcotory
  using the absolute workspace path.