### PR TITLE
Refs 101: update commit format

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -1,0 +1,19 @@
+name: PR Validation 
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  title-validate:
+    name: Title
+    runs-on: ubuntu-latest
+    steps:
+    - uses: deepakputhraya/action-pr-title@master
+      with:
+        regex: '(Fixes |Refs )\d+: .+' # Regex the title should match.
+        allowed_prefixes: 'Refs ,Fixes ' # title should start with the given prefix
+        disallowed_prefixes: '' # title should not start with the given prefix
+        prefix_case_sensitive: false # title prefix are case insensitive
+        min_length: 5 # Min length of the title
+        max_length: 60 # Max length of the title
+        github_token: ${{ github.token }} # Default: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ The default configuration file in ./configs/config.yaml.example shows all availa
 ### Contributing
  * Pull requests welcome!
  * Pull requests should come with good tests
- * Generally, feature PRs should be backed by a JIRA ticket and included in the subject using the format:
-   * `CONTENT-23: Some great feature`
+ * All PRs should be backed by a JIRA ticket and included in the subject using the format:
+   * `Fixes 23: Some great feature` - if a PR fully resolves an issue or feature, or is the last PR in a series of PRs.
+   * `Refs 23: Partial work for issue` - if a PR partially resolves an issue or feature or is not the last PR in a series of PRs.
+   * If you do not have access to the Jira (we are working on opening it up), open a PR without this
+     and we will add it for you.
 
 ## More info
  * [Architecture](docs/architecture.md)


### PR DESCRIPTION
Changes the commit format such that:
* A jira card is now required
* You can use Refs or Fixes to indicate if a PR
  is related to or fully fixes a card
* Adds a github action to validate PR Title