### PR TITLE
Refs 105: Add pr_checks and build_deploy

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+IMAGE="${IMAGE:-quay.io/cloudservices/content-sources-backend}"
+IMAGE_TAG="$(git rev-parse --short=7 HEAD)"
+SMOKE_TEST_TAG="latest"
+
+if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
+    echo "QUAY_USER and QUAY_TOKEN must be set"
+    exit 1
+fi
+
+if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
+    echo "RH_REGISTRY_USER and RH_REGISTRY_TOKEN  must be set"
+    exit 1
+fi
+
+# Login to quay
+make docker-login \
+    DOCKER_LOGIN_USER="$QUAY_USER" \
+    DOCKER_LOGIN_TOKEN="$QUAY_TOKEN" \
+    DOCKER_REGISTRY="quay.io"
+
+# Login to registry.redhat
+make docker-login \
+    DOCKER_LOGIN_USER="$RH_REGISTRY_USER" \
+    DOCKER_LOGIN_TOKEN="$RH_REGISTRY_TOKEN" \
+    DOCKER_REGISTRY="registry.redhat.io"
+
+# build and push
+make docker-build docker-push \
+    DOCKER_BUILD_OPTS=--no-cache \
+    DOCKER_IMAGE_BASE=$IMAGE \
+    DOCKER_IMAGE_TAG=$IMAGE_TAG
+
+# push to logged in registries and tag for SHA
+docker tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+docker push "${IMAGE}:${SMOKE_TEST_TAG}"

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -20,12 +20,19 @@ DOCKER_DOCKERFILE ?= Dockerfile
 DOCKER_IMAGE_BASE ?= quay.io/$(USER)/myapp
 DOCKER_IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE ?= $(DOCKER_IMAGE_BASE):$(DOCKER_IMAGE_TAG)
+DOCKER_LOGIN_USER ?= $(USER)
+DOCKER_REGISTRY ?= quay.io
+# DOCKER_BUILD_OPTS
 # DOCKER_OPTS
 # DOCKER_RUN_ARGS
 
+.PHONY: docker-login
+docker-login:
+	$(DOCKER) login -u "$(DOCKER_LOGIN_USER)" -p "$(DOCKER_LOGIN_TOKEN)" $(DOCKER_REGISTRY)
+
 .PHONY: docker-build
 docker-build:  ## Build image DOCKER_IMAGE from DOCKER_DOCKERFILE using the DOCKER_CONTEXT_DIR
-	$(DOCKER) build -t "$(DOCKER_IMAGE)" -f $(DOCKER_DOCKERFILE) $(DOCKER_CONTEXT_DIR)
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t "$(DOCKER_IMAGE)" -f $(DOCKER_DOCKERFILE) $(DOCKER_CONTEXT_DIR)
 
 .PHONY: docker-push
 docker-push:  ## Push image to remote registry

--- a/pr_checks.sh
+++ b/pr_checks.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+APP_NAME="content-sources"  # name of app-sre "application" folder this component lives in
+COMPONENT_NAME="content-sources-backend"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+IMAGE="quay.io/cloudservices/content-sources-backend"  # image location on quay
+
+IQE_PLUGINS="hms-content"  # name of the IQE plugin for this app.
+IQE_MARKER_EXPRESSION=""  # This is the value passed to pytest -m
+IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
+
+
+# Install bonfire repo/initialize
+# https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh
+# This script automates the install / config of bonfire
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+
+# This script is used to build the image that is used in the PR Check
+source $CICD_ROOT/build.sh
+
+# This script is used to deploy the ephemeral environment for smoke tests.
+# The manual steps for this can be found in:
+# https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
+source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# Run smoke tests using a ClowdJobInvocation and iqe-tests
+source $CICD_ROOT/cji_smoke_test.sh
+
+# Post a comment with test run IDs to the PR
+# source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
Add a docker-login make target, for use in build_deploy.sh

build_deploy.sh will be used by appsre pipelines to push commits to
quay/redhat.io. The GH action building to quay can be removed (once
appinterface updates are accepted and repo created).

pr_checks leverages bonfire for PR image building, deployment, and test execution. appinterface pipeline definitions will execute this script against PRs.