### PR TITLE
Fixes 116: Add create response object and openAPI spec fixes

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -69,30 +69,16 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": ""
-                    }
-                }
-            }
-        },
-        "/repositories/:uuid": {
-            "delete": {
-                "tags": [
-                    "repositories"
-                ],
-                "summary": "Delete a repository",
-                "operationId": "deleteRepository",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Identifier of the Repository",
-                        "name": "uuid",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": ""
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.RepositoryResponse"
+                        },
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "resource URL"
+                            }
+                        }
                     }
                 }
             }
@@ -122,7 +108,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.RepositoryResponse"
+                        }
                     }
                 }
             },
@@ -159,6 +148,27 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Delete a repository",
+                "operationId": "deleteRepository",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identifier of the Repository",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
                         "description": ""
                     }
                 }
@@ -259,8 +269,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "['7'",
-                        "'8']"
+                        "7",
+                        "8"
                     ]
                 },
                 "name": {
@@ -292,8 +302,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "['7'",
-                        "'8']"
+                        "7",
+                        "8"
                     ]
                 },
                 "name": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -50,8 +50,8 @@
                     "distribution_versions": {
                         "description": "Versions to restrict client usage to",
                         "example": [
-                            "['7'",
-                            "'8']"
+                            "7",
+                            "8"
                         ],
                         "items": {
                             "type": "string"
@@ -83,8 +83,8 @@
                     "distribution_versions": {
                         "description": "Versions to restrict client usage to",
                         "example": [
-                            "['7'",
-                            "'8']"
+                            "7",
+                            "8"
                         ],
                         "items": {
                             "type": "string"
@@ -186,7 +186,22 @@
                 },
                 "responses": {
                     "201": {
-                        "description": ""
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryResponse"
+                                }
+                            }
+                        },
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "description": "resource URL",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     }
                 },
                 "summary": "Create Repository",
@@ -195,7 +210,7 @@
                 ]
             }
         },
-        "/repositories/:uuid": {
+        "/repositories/{uuid}": {
             "delete": {
                 "operationId": "deleteRepository",
                 "parameters": [
@@ -210,7 +225,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": ""
                     }
                 },
@@ -218,9 +233,7 @@
                 "tags": [
                     "repositories"
                 ]
-            }
-        },
-        "/repositories/{uuid}": {
+            },
             "get": {
                 "description": "Get information about a Repository",
                 "operationId": "getRepository",
@@ -237,7 +250,14 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": ""
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
                     }
                 },
                 "summary": "Get Repository",

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -4,22 +4,22 @@ package api
 type RepositoryResponse struct {
 	UUID                 string   `json:"uuid" readonly:"true"`
 	Name                 string   `json:"name"`
-	URL                  string   `json:"url"`                                       //URL of the remote yum repository
-	DistributionVersions []string `json:"distribution_versions" example:"['7','8']"` //Versions to restrict client usage to
-	DistributionArch     string   `json:"distribution_arch" example:"x86_64"`        //Architecture to restrict client usage to
-	AccountID            string   `json:"account_id" readonly:"true"`                //Account ID of the owner
-	OrgID                string   `json:"org_id" readonly:"true"`                    //Organization ID of the owner
+	URL                  string   `json:"url"`                                 // URL of the remote yum repository
+	DistributionVersions []string `json:"distribution_versions" example:"7,8"` // Versions to restrict client usage to
+	DistributionArch     string   `json:"distribution_arch" example:"x86_64"`  // Architecture to restrict client usage to
+	AccountID            string   `json:"account_id" readonly:"true"`          // Account ID of the owner
+	OrgID                string   `json:"org_id" readonly:"true"`              // Organization ID of the owner
 }
 
 // RepositoryRequest holds data received from request to create/update repository
 type RepositoryRequest struct {
 	UUID                 *string   `json:"uuid" readonly:"true" swaggerignore:"true"`
 	Name                 *string   `json:"name"`
-	URL                  *string   `json:"url"`                                             //URL of the remote yum repository
-	DistributionVersions *[]string `json:"distribution_versions" example:"['7','8']"`       //Versions to restrict client usage to
-	DistributionArch     *string   `json:"distribution_arch" example:"x86_64"`              //Architecture to restrict client usage to
-	AccountID            *string   `json:"account_id" readonly:"true" swaggerignore:"true"` //Account ID of the owner
-	OrgID                *string   `json:"org_id" readonly:"true" swaggerignore:"true"`     //Organization ID of the owner
+	URL                  *string   `json:"url"`                                             // URL of the remote yum repository
+	DistributionVersions *[]string `json:"distribution_versions" example:"7,8"`             // Versions to restrict client usage to
+	DistributionArch     *string   `json:"distribution_arch" example:"x86_64"`              // Architecture to restrict client usage to
+	AccountID            *string   `json:"account_id" readonly:"true" swaggerignore:"true"` // Account ID of the owner
+	OrgID                *string   `json:"org_id" readonly:"true" swaggerignore:"true"`     // Organization ID of the owner
 }
 
 func (r *RepositoryRequest) FillDefaults() {

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -5,7 +5,7 @@ import (
 )
 
 type RepositoryDao interface {
-	Create(newRepo api.RepositoryRequest) error
+	Create(newRepo api.RepositoryRequest) (api.RepositoryResponse, error)
 	Update(orgID string, uuid string, repoParams api.RepositoryRequest) error
 	Fetch(orgID string, uuid string) (api.RepositoryResponse, error)
 	List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)

--- a/pkg/dao/repository.go
+++ b/pkg/dao/repository.go
@@ -31,7 +31,7 @@ func DBErrorToApi(e error) error {
 	return &Error{Message: e.Error()}
 }
 
-func (r repositoryDaoImpl) Create(newRepo api.RepositoryRequest) error {
+func (r repositoryDaoImpl) Create(newRepo api.RepositoryRequest) (api.RepositoryResponse, error) {
 	newRepoConfig := models.RepositoryConfiguration{
 		AccountID: *newRepo.AccountID,
 		OrgID:     *newRepo.OrgID,
@@ -39,9 +39,13 @@ func (r repositoryDaoImpl) Create(newRepo api.RepositoryRequest) error {
 	ApiFieldsToModel(&newRepo, &newRepoConfig)
 
 	if err := db.DB.Create(&newRepoConfig).Error; err != nil {
-		return DBErrorToApi(err)
+		return api.RepositoryResponse{}, DBErrorToApi(err)
 	}
-	return nil
+
+	var created api.RepositoryResponse
+	ModelToApiFields(newRepoConfig, &created)
+
+	return created, nil
 }
 
 func (r repositoryDaoImpl) List(

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -39,7 +39,7 @@ func (suite *ReposSuite) TestCreate() {
 
 	found := models.RepositoryConfiguration{}
 
-	err := GetRepositoryDao().Create(api.RepositoryRequest{
+	_, err := GetRepositoryDao().Create(api.RepositoryRequest{
 		Name:      &name,
 		URL:       &url,
 		OrgID:     &orgId,
@@ -61,7 +61,7 @@ func (suite *ReposSuite) TestCreateAlreadyExists() {
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
 
-	err = GetRepositoryDao().Create(api.RepositoryRequest{
+	_, err = GetRepositoryDao().Create(api.RepositoryRequest{
 		Name:      &found.Name,
 		URL:       &found.URL,
 		OrgID:     &found.OrgID,
@@ -110,7 +110,7 @@ func (suite *ReposSuite) TestCreateBlankTest() {
 		},
 	}
 	for i := 0; i < len(blankItems); i++ {
-		err := GetRepositoryDao().Create(blankItems[i])
+		_, err := GetRepositoryDao().Create(blankItems[i])
 		assert.NotNil(t, err)
 		daoError, ok := err.(*Error)
 		assert.True(t, ok)
@@ -169,7 +169,7 @@ func (suite *ReposSuite) TestDuplicateUpdate() {
 	found := models.RepositoryConfiguration{}
 	db.DB.First(&found)
 
-	err = GetRepositoryDao().Create(api.RepositoryRequest{OrgID: &found.OrgID, AccountID: &found.AccountID, Name: &name, URL: &name})
+	_, err = GetRepositoryDao().Create(api.RepositoryRequest{OrgID: &found.OrgID, AccountID: &found.AccountID, Name: &name, URL: &name})
 	assert.Nil(t, err)
 
 	err = GetRepositoryDao().Update(found.OrgID, found.UUID,


### PR DESCRIPTION
Adds:
1. Create returns api.RepositoryResponse object
2. With 201 status, create will return Location header with the url to the resource. I see many sources online saying this is part of the spec, so I thought we might want it.

Fixes:
1. Fetch spec success now says it returns api.RepositoryResponse object
2. Delete spec now says it returns 204 instead of 200
3. Spec examples for distributions_versions were being formatted strangely

old
```
"example": [ 
  "['7'",
  "'8']"
 ]
```

new (I think this is preferred?)
```
"example": [ 
  "7",
  "8"
 ]
```
