### PR TITLE
Fixes 96: Add bulk create

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -108,6 +108,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/bulk_create/": {
+            "post": {
+                "description": "bulk create repositories",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Bulk create repositories",
+                "operationId": "bulkCreateRepositories",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.RepositoryRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.RepositoryBulkCreateResponse"
+                            }
+                        },
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "resource URL"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}": {
             "get": {
                 "description": "Get information about a Repository",
@@ -173,7 +220,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -194,7 +244,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": "No Content",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -231,7 +284,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -280,6 +336,18 @@ const docTemplate = `{
                 "prev": {
                     "description": "Path to previous page of results",
                     "type": "string"
+                }
+            }
+        },
+        "api.RepositoryBulkCreateResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "description": "Error during creation",
+                    "type": "string"
+                },
+                "repository": {
+                    "$ref": "#/definitions/api.RepositoryResponse"
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -22,6 +22,18 @@
                 },
                 "type": "object"
             },
+            "api.RepositoryBulkCreateResponse": {
+                "properties": {
+                    "error": {
+                        "description": "Error during creation",
+                        "type": "string"
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/api.RepositoryResponse"
+                    }
+                },
+                "type": "object"
+            },
             "api.RepositoryCollectionResponse": {
                 "properties": {
                     "data": {
@@ -331,6 +343,54 @@
                 ]
             }
         },
+        "/repositories/bulk_create/": {
+            "post": {
+                "description": "bulk create repositories",
+                "operationId": "bulkCreateRepositories",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "items": {
+                                    "$ref": "#/components/schemas/api.RepositoryRequest"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.RepositoryBulkCreateResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "description": "resource URL",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Bulk create repositories",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
         "/repositories/{uuid}": {
             "delete": {
                 "operationId": "deleteRepository",
@@ -347,6 +407,13 @@
                 ],
                 "responses": {
                     "204": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "description": "No Content"
                     }
                 },
@@ -414,6 +481,13 @@
                 },
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "description": "OK"
                     }
                 },
@@ -450,6 +524,13 @@
                 },
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "description": "OK"
                     }
                 },

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -22,6 +22,11 @@ type RepositoryRequest struct {
 	OrgID                *string   `json:"org_id" readonly:"true" swaggerignore:"true"`     // Organization ID of the owner
 }
 
+type RepositoryBulkCreateResponse struct {
+	ErrorMsg   *string             `json:"error"` // Error during creation
+	Repository *RepositoryResponse `json:"repository"`
+}
+
 func (r *RepositoryRequest) FillDefaults() {
 	//Fill in default values in case of PUT request, doesn't have to be valid, let the db validate that
 	defaultName := ""

--- a/pkg/dao/error.go
+++ b/pkg/dao/error.go
@@ -1,5 +1,7 @@
 package dao
 
+import "fmt"
+
 type Error struct {
 	Message       string
 	NotFound      bool
@@ -8,4 +10,8 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.Message
+}
+
+func (e *Error) Wrap(msg string) {
+	e.Message = fmt.Sprintf("%s: %v", msg, e.Error())
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -6,6 +6,7 @@ import (
 
 type RepositoryDao interface {
 	Create(newRepo api.RepositoryRequest) (api.RepositoryResponse, error)
+	BulkCreate(newRepositories []api.RepositoryRequest) ([]api.RepositoryBulkCreateResponse, error)
 	Update(orgID string, uuid string, repoParams api.RepositoryRequest) error
 	Fetch(orgID string, uuid string) (api.RepositoryResponse, error)
 	List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -1,6 +1,8 @@
 package dao
 
 import (
+	"strconv"
+
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/models"
@@ -60,7 +62,7 @@ func (suite *RepositorySuite) TestRepositoryCreateAlreadyExists() {
 	err = tx.Limit(1).Find(&repo).Error
 	assert.NoError(t, err)
 
-	err = seeds.SeedRepositoryConfigurations(tx /*, &repo[0]*/, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(tx, 1, seeds.SeedOptions{OrgID: org_id})
 	assert.NoError(t, err)
 
 	found := models.RepositoryConfiguration{}
@@ -154,6 +156,75 @@ func (suite *RepositorySuite) TestRepositoryCreateBlankTest() {
 	}
 }
 
+func (suite *RepositorySuite) TestBulkCreate() {
+	t := suite.T()
+	tx := suite.tx
+
+	orgID := "1"
+	accountID := "2"
+
+	amountToCreate := 15
+
+	requests := make([]api.RepositoryRequest, amountToCreate)
+	for i := 0; i < amountToCreate; i++ {
+		name := "repo_" + strconv.Itoa(i)
+		url := "https://repo_" + strconv.Itoa(i)
+		requests[i] = api.RepositoryRequest{
+			Name:      &name,
+			URL:       &url,
+			OrgID:     &orgID,
+			AccountID: &accountID,
+		}
+	}
+
+	rr, err := GetRepositoryDao(tx).BulkCreate(requests)
+	assert.Nil(t, err)
+	assert.Equal(t, amountToCreate, len(rr))
+
+	for i := 0; i < amountToCreate; i++ {
+		var foundRepoConfig models.RepositoryConfiguration
+		result := tx.Where("name = ? ", requests[i].Name).Find(&foundRepoConfig)
+		assert.Nil(t, result.Error)
+		assert.NotEmpty(t, foundRepoConfig.UUID)
+	}
+}
+
+func (suite *RepositorySuite) TestBulkCreateOneFails() {
+	t := suite.T()
+	tx := suite.tx
+
+	orgID := "1"
+	accountID := "2"
+
+	requests := []api.RepositoryRequest{
+		{
+			Name:      pointy.String("repo_1"),
+			URL:       pointy.String("repo_1_url"),
+			OrgID:     &orgID,
+			AccountID: &accountID,
+		},
+		{
+			Name:      pointy.String(""),
+			URL:       pointy.String("repo_2_url"),
+			OrgID:     &orgID,
+			AccountID: &accountID,
+		},
+	}
+
+	rr, err := GetRepositoryDao(tx).BulkCreate(requests)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, len(rr))
+
+	daoError, ok := err.(*Error)
+	assert.True(t, ok)
+	assert.True(t, daoError.BadValidation)
+
+	foundRepoConfig := models.RepositoryConfiguration{}
+	err = tx.First(&foundRepoConfig).Error
+	assert.Error(t, err)
+}
+
 func (suite *RepositorySuite) TestUpdate() {
 	name := "Updated"
 	url := "http://someUrl.com"
@@ -161,7 +232,7 @@ func (suite *RepositorySuite) TestUpdate() {
 	org_id := "900023"
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx /*, &repo*/, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: org_id})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	suite.tx.


### PR DESCRIPTION
Adds bulk create

**Example:**
POST `/api/content_sources/v1/repositories/bulk_create`

Body:
```
[
  {
    "name": "test1",
    "url": "test1",
  },
  {
    "name": "test2",
    "url": "test2",
  }
]
```

Response:
```
[
    {
       "error": nil,
       "repository": {...repo}
    },
    
    {
    
       "error":nil,
       "repository": {...repo}
    }, ...
 ]

OR when there's an error

[
  {
       "error": "error",
       "repository": nil,
    },
{
       "error": nil,
       "repository": nil,
    },

]
```

Still needs

- [x] Handler tests
- [x] Fix error response
