### PR TITLE
Fixes 134: Set names for init-containers and typo fix

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -23,11 +23,13 @@ objects:
       podSpec:
         initContainers:
           - env:
+            name: db-migrate
             inheritEnv: true
             args:
               - /dbmigrate
               - up
           - env:
+            name: external-repos-import
             inheritEnv: true
             args:
               - /external-repos import

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -32,7 +32,8 @@ objects:
             name: external-repos-import
             inheritEnv: true
             args:
-              - /external-repos import
+              - /external-repos
+              - import
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
The Clowder template require names for initContainers if more than one is specified

```
  STDERR:
The ClowdApp "content-sources" is invalid: 

* spec.Deployments[0].PodSpec.InitContainers[0]: Forbidden: multiple initcontainers must have a name

* spec.Deployments[0].PodSpec.InitContainers[1]: Forbidden: multiple initcontainers must have a name
```


see the Clowder API [spec](https://redhatinsights.github.io/clowder/clowder/dev/api_reference.html#k8s-api-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-initcontainer)

