### PR TITLE
Refs 105: Update clowdapp name

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: content-sources
+  name: content-sources-backend
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: content-sources
+    name: content-sources-backend
   spec:
     envName: ${ENV_NAME}
     testing:

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -29,8 +29,7 @@ source $CICD_ROOT/build.sh
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # Run smoke tests using a ClowdJobInvocation and iqe-tests
-COMPONENT_NAME="content-sources"  # name of app used in deploy-iqe-cji
 source $CICD_ROOT/cji_smoke_test.sh
 
 # Post a comment with test run IDs to the PR
-# source $CICD_ROOT/post_test_results.sh
+source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
The name should match the resourceTemplate component name in app-interface for consistent `bonfire deploy` and `bonfire deploy-iqe-cji` behavior.

