### PR TITLE
Fixes 122: Add validation to Repository update

### DIFF
--- a/pkg/dao/repository.go
+++ b/pkg/dao/repository.go
@@ -230,7 +230,7 @@ func (r repositoryDaoImpl) Update(orgID string, uuid string, repoParams api.Repo
 	}
 
 	repoConfig.Repository = models.Repository{}
-	if err := r.db.Save(&repoConfig).Error; err != nil {
+	if err := r.db.Model(&repoConfig).Updates(repoConfig.MapForUpdate()).Error; err != nil {
 		return DBErrorToApi(err)
 	}
 	return nil

--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -35,12 +35,26 @@ func (rc *RepositoryConfiguration) MapForUpdate() map[string]interface{} {
 	return forUpdate
 }
 
-// BeforeCreate perform validations of Repository Configurations
+// BeforeCreate perform validations and sets UUID of Repository Configurations
 func (rc *RepositoryConfiguration) BeforeCreate(tx *gorm.DB) (err error) {
 	if err := rc.Base.BeforeCreate(tx); err != nil {
 		return err
 	}
+	if err := rc.validate(); err != nil {
+		return err
+	}
+	return nil
+}
 
+// BeforeUpdate perform validations of Repository Configurations
+func (rc *RepositoryConfiguration) BeforeUpdate(tx *gorm.DB) (err error) {
+	if err := rc.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rc *RepositoryConfiguration) validate() (err error) {
 	if rc.Name == "" {
 		err = Error{Message: "Name cannot be blank.", Validation: true}
 		return err

--- a/pkg/models/rpm.go
+++ b/pkg/models/rpm.go
@@ -25,8 +25,7 @@ type Rpm struct {
 	Repositories []Repository `gorm:"many2many:repositories_rpms"`
 }
 
-// BeforeCreate hook for ReposirotyRpm records
-// Return error if any else nil
+// BeforeCreate hook performs validations and sets UUID of RepositoryRpm
 func (r *Rpm) BeforeCreate(tx *gorm.DB) (err error) {
 	if err := r.Base.BeforeCreate(tx); err != nil {
 		return err


### PR DESCRIPTION
Adds validation to updating repositories.

This could also be done using a `BeforeSave` hook that would run before both Update and Create, but keeping the hooks separate seems more future-proof to me.