### PR TITLE
Fixes 119: fix some tests failing on seeded database

### DIFF
--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -386,6 +386,7 @@ func (suite *RepositorySuite) TestUpdateBlank() {
 
 	found := models.RepositoryConfiguration{}
 	err = tx.Preload("Repository").First(&found, "uuid = ?", repoConfig.UUID).Error
+	require.NoError(t, err)
 
 	type testCases struct {
 		given    api.RepositoryRequest

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -26,10 +26,8 @@ func (suite *RepositorySuite) TestCreate() {
 	var foundCount int64 = -1
 	foundConfig := []models.RepositoryConfiguration{}
 	err = tx.Limit(1).Find(&foundConfig).Error
-	assert.NoError(t, err)
-	if err == nil {
-		tx.Count(&foundCount)
-	}
+	require.NoError(t, err)
+	tx.Count(&foundCount)
 	assert.Equal(t, int64(0), foundCount)
 
 	toCreate := api.RepositoryRequest{
@@ -221,6 +219,7 @@ func (suite *RepositorySuite) TestBulkCreateOneFails() {
 	foundRepoConfig := []models.RepositoryConfiguration{}
 	err = tx.Model(&models.RepositoryConfiguration{}).
 		Where("repositories.url in (?)", urls).
+		Where("repository_configurations.org_id = ?", orgID).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid").
 		Count(&count).
 		Find(&foundRepoConfig).Error

--- a/pkg/dao/repository_test.go
+++ b/pkg/dao/repository_test.go
@@ -15,8 +15,8 @@ import (
 func (suite *RepositorySuite) TestCreate() {
 	name := "Updated"
 	url := "http://someUrl.com"
-	orgId := seeds.RandomOrgId()
-	accountId := "222"
+	orgID := seeds.RandomOrgId()
+	accountId := seeds.RandomAccountId()
 	distributionArch := "x86_64"
 	var err error
 
@@ -35,7 +35,7 @@ func (suite *RepositorySuite) TestCreate() {
 	toCreate := api.RepositoryRequest{
 		Name:             &name,
 		URL:              &url,
-		OrgID:            &orgId,
+		OrgID:            &orgID,
 		AccountID:        &accountId,
 		DistributionArch: &distributionArch,
 		DistributionVersions: &[]string{
@@ -47,7 +47,7 @@ func (suite *RepositorySuite) TestCreate() {
 	created, err := dao.Create(toCreate)
 	assert.Nil(t, err)
 
-	foundRepo, err := dao.Fetch(orgId, created.UUID)
+	foundRepo, err := dao.Fetch(orgID, created.UUID)
 	assert.Nil(t, err)
 	assert.Equal(t, url, foundRepo.URL)
 }
@@ -55,7 +55,7 @@ func (suite *RepositorySuite) TestCreate() {
 func (suite *RepositorySuite) TestRepositoryCreateAlreadyExists() {
 	t := suite.T()
 	tx := suite.tx
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
 	err = seeds.SeedRepository(tx, 1)
@@ -64,7 +64,7 @@ func (suite *RepositorySuite) TestRepositoryCreateAlreadyExists() {
 	err = tx.Limit(1).Find(&repo).Error
 	assert.NoError(t, err)
 
-	err = seeds.SeedRepositoryConfigurations(tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.NoError(t, err)
 
 	found := models.RepositoryConfiguration{}
@@ -149,7 +149,7 @@ func (suite *RepositorySuite) TestBulkCreate() {
 	t := suite.T()
 	tx := suite.tx
 
-	orgID := "1"
+	orgID := seeds.RandomOrgId()
 
 	amountToCreate := 15
 
@@ -180,7 +180,7 @@ func (suite *RepositorySuite) TestBulkCreateOneFails() {
 	t := suite.T()
 	tx := suite.tx
 
-	orgID := orgIdTest
+	orgID := orgIDTest
 	accountID := accountIdTest
 
 	requests := []api.RepositoryRequest{
@@ -232,10 +232,10 @@ func (suite *RepositorySuite) TestUpdate() {
 	name := "Updated"
 	url := "http://someUrl.com"
 	t := suite.T()
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	suite.tx.
@@ -258,7 +258,7 @@ func (suite *RepositorySuite) TestUpdateEmpty() {
 	arch := ""
 	t := suite.T()
 	tx := suite.tx
-	org_id := seeds.RandomOrgId()
+	orgID := seeds.RandomOrgId()
 	var err error
 
 	// Create a RepositoryConfiguration record
@@ -268,13 +268,13 @@ func (suite *RepositorySuite) TestUpdateEmpty() {
 
 	repoConfig := repoConfigTest1.DeepCopy()
 	repoConfig.RepositoryUUID = repoPublic.UUID
-	repoConfig.OrgID = org_id
+	repoConfig.OrgID = orgID
 	err = tx.Create(&repoConfig).Error
 	require.NoError(t, err)
 
 	// Retrieve the just created RepositoryConfiguration record
 	found := models.RepositoryConfiguration{}
-	err = tx.Where("org_id = ?", org_id).First(&found, "uuid = ?", repoConfig.UUID).Error
+	err = tx.Where("org_id = ?", orgID).First(&found, "uuid = ?", repoConfig.UUID).Error
 	require.NoError(t, err)
 	assert.Equal(t, found.UUID, repoConfig.UUID)
 	assert.Equal(t, found.AccountID, repoConfig.AccountID)
@@ -345,10 +345,10 @@ func (suite *RepositorySuite) TestDuplicateUpdate() {
 func (suite *RepositorySuite) TestUpdateNotFound() {
 	name := "unique"
 	t := suite.T()
-	orgId := seeds.RandomOrgId()
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgId})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	suite.tx.First(&found)
@@ -373,7 +373,7 @@ func (suite *RepositorySuite) TestUpdateBlank() {
 	name := "Updated"
 	url := "http://someUrl.com"
 	blank := ""
-	orgID := orgIdTest
+	orgID := orgIDTest
 
 	repo := repoPublicTest.DeepCopy()
 	err = tx.Create(&repo).Error
@@ -427,10 +427,10 @@ func (suite *RepositorySuite) TestUpdateBlank() {
 
 func (suite *RepositorySuite) TestFetch() {
 	t := suite.T()
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	suite.tx.
@@ -446,10 +446,10 @@ func (suite *RepositorySuite) TestFetch() {
 
 func (suite *RepositorySuite) TestFetchNotFound() {
 	t := suite.T()
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 	found := models.RepositoryConfiguration{}
 	suite.tx.First(&found)
@@ -760,10 +760,10 @@ func (suite *RepositorySuite) TestSavePublicUrls() {
 func (suite *RepositorySuite) TestDelete() {
 	t := suite.T()
 	tx := suite.tx
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 
 	repoConfig := models.RepositoryConfiguration{}
@@ -784,10 +784,10 @@ func (suite *RepositorySuite) TestDelete() {
 
 func (suite *RepositorySuite) TestDeleteNotFound() {
 	t := suite.T()
-	org_id := "900023"
+	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: org_id})
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 
 	found := models.RepositoryConfiguration{}

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -53,7 +53,7 @@ func (s *RpmSuite) TestRpmList() {
 
 	var repoRpmList api.RepositoryRpmCollectionResponse
 	var count int64
-	repoRpmList, count, err = dao.List(orgIdTest, s.repoConfig.Base.UUID, 0, 0)
+	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, count, int64(2))
 	assert.Equal(t, repoRpmList.Meta.Count, count)
@@ -152,7 +152,7 @@ func (s *RpmSuite) TestRpmSearch() {
 		// The returned items are ordered by epoch
 		{
 			given: TestCaseGiven{
-				orgId: orgIdTest,
+				orgId: orgIDTest,
 				input: api.SearchRpmRequest{
 					URLs: []string{
 						urls[0],
@@ -176,7 +176,7 @@ func (s *RpmSuite) TestRpmSearch() {
 		// The limit is applied correctly, and the order is respected
 		{
 			given: TestCaseGiven{
-				orgId: orgIdTest,
+				orgId: orgIDTest,
 				input: api.SearchRpmRequest{
 					URLs: []string{
 						urls[0],
@@ -196,7 +196,7 @@ func (s *RpmSuite) TestRpmSearch() {
 		// Search for the url[2] private repository
 		{
 			given: TestCaseGiven{
-				orgId: orgIdTest,
+				orgId: orgIDTest,
 				input: api.SearchRpmRequest{
 					URLs: []string{
 						urls[2],
@@ -219,7 +219,7 @@ func (s *RpmSuite) TestRpmSearch() {
 		// Search for url[0] and url[1] filtering for demo-% packages and it returns 1 entry
 		{
 			given: TestCaseGiven{
-				orgId: orgIdTest,
+				orgId: orgIDTest,
 				input: api.SearchRpmRequest{
 					URLs: []string{
 						urls[0],
@@ -354,7 +354,7 @@ func (s *RpmSuite) TestRpmSearchError() {
 	assert.Equal(t, err.Error(), "orgID can not be an empty string")
 	tx.RollbackTo(txSP)
 
-	searchRpmResponse, err = dao.Search(orgIdTest, api.SearchRpmRequest{Search: ""}, 100)
+	searchRpmResponse, err = dao.Search(orgIDTest, api.SearchRpmRequest{Search: ""}, 100)
 	require.Error(t, err)
 	assert.Equal(t, int(0), len(searchRpmResponse))
 	assert.Equal(t, err.Error(), "request.URLs must contain at least 1 URL")

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -96,9 +96,9 @@ func (s *RpmSuite) TestRpmSearch() {
 
 	// Prepare Repository records
 	repositories := make([]models.Repository, 3)
-	repoTest1.DeepCopyInto(&repositories[0])
-	repoTest1.DeepCopyInto(&repositories[1])
-	repoTest1.DeepCopyInto(&repositories[2])
+	repoPublicTest.DeepCopyInto(&repositories[0])
+	repoPublicTest.DeepCopyInto(&repositories[1])
+	repoPublicTest.DeepCopyInto(&repositories[2])
 	repositories[0].URL = urls[0]
 	repositories[1].URL = urls[1]
 	repositories[2].URL = urls[2]

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -45,7 +45,7 @@ type PublicRepositorySuite struct {
 const orgIdTest = "acme"
 const accountIdTest = "817342"
 
-var repoTest1 = models.Repository{
+var repoPublicTest = models.Repository{
 	Base: models.Base{
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
@@ -77,7 +77,7 @@ var repoConfigTest1 = models.RepositoryConfiguration{
 	Versions:       pq.StringArray{config.El7, config.El8},
 	AccountID:      accountIdTest,
 	OrgID:          orgIdTest,
-	RepositoryUUID: repoTest1.Base.UUID,
+	RepositoryUUID: repoPublicTest.Base.UUID,
 }
 
 var repoRpmTest1 = models.Rpm{
@@ -144,7 +144,7 @@ func (s *RpmSuite) SetupTest() {
 	})
 	s.tx = s.db.Begin()
 
-	repo := repoTest1.DeepCopy()
+	repo := repoPublicTest.DeepCopy()
 	if err := s.tx.Create(repo).Error; err != nil {
 		s.FailNow("Preparing Repository record: %w", err)
 	}
@@ -189,7 +189,7 @@ func (s *PublicRepositorySuite) SetupTest() {
 	})
 	s.tx = s.db.Begin()
 
-	repo := repoTest1.DeepCopy()
+	repo := repoPublicTest.DeepCopy()
 	if err := s.tx.Create(repo).Error; err != nil {
 		s.FailNow("Preparing Repository record UUID=" + repo.UUID)
 	}

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -42,8 +43,8 @@ type PublicRepositorySuite struct {
 	repoPrivate               *models.Repository
 }
 
-const orgIdTest = "acme"
-const accountIdTest = "817342"
+var orgIDTest = seeds.RandomOrgId()
+var accountIdTest = seeds.RandomAccountId()
 
 var repoPublicTest = models.Repository{
 	Base: models.Base{
@@ -76,7 +77,7 @@ var repoConfigTest1 = models.RepositoryConfiguration{
 	Arch:           "x86_64",
 	Versions:       pq.StringArray{config.El7, config.El8},
 	AccountID:      accountIdTest,
-	OrgID:          orgIdTest,
+	OrgID:          orgIDTest,
 	RepositoryUUID: repoPublicTest.Base.UUID,
 }
 

--- a/pkg/handler/repository_test.go
+++ b/pkg/handler/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/labstack/echo/v4"
 	"github.com/openlyinc/pointy"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -97,8 +98,8 @@ func (r *MockRepositoryDao) ValidateParameters(orgId string, req api.RepositoryV
 	return api.RepositoryValidationResponse{}, nil
 }
 
-const mockAccountNumber = "0000"
-const mockOrgId = "1111"
+var mockAccountNumber = seeds.RandomAccountId()
+var mockOrgId = seeds.RandomOrgId()
 
 func encodedIdentity(t *testing.T) string {
 	mockIdentity := identity.XRHID{

--- a/pkg/models/suite_test.go
+++ b/pkg/models/suite_test.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,8 +19,9 @@ type ModelsSuite struct {
 	tx *gorm.DB
 }
 
-const orgIdTest = "acme"
-const accountIdTest = "817342"
+// Not using seeds.RandomOrgId to avoid cycle dependency
+var orgIDTest = strconv.Itoa(rand.Intn(99999999))
+var accountIdTest = strconv.Itoa(rand.Intn(99999999))
 
 var repoConfigTest1 = RepositoryConfiguration{
 	Base: Base{
@@ -29,7 +32,7 @@ var repoConfigTest1 = RepositoryConfiguration{
 	Arch:      config.X8664,
 	Versions:  pq.StringArray{config.El7, config.El8, config.El9},
 	AccountID: accountIdTest,
-	OrgID:     orgIdTest,
+	OrgID:     orgIDTest,
 }
 
 var repoTest1 = Repository{

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -176,6 +176,10 @@ func RandomOrgId() string {
 	return strconv.Itoa(rand.Intn(99999999))
 }
 
+func RandomAccountId() string {
+	return strconv.Itoa(rand.Intn(99999999))
+}
+
 // createOrgId aims to mainly create most entities in the same org
 // but also create some in other random orgs
 func createOrgId(existingOrgId string) string {

--- a/pkg/seeds/seeds_test.go
+++ b/pkg/seeds/seeds_test.go
@@ -10,7 +10,7 @@ func (s *SeedSuite) TestSeedRepositoryConfigurations() {
 	tx := s.tx
 
 	err := SeedRepositoryConfigurations(tx, 1001, SeedOptions{
-		OrgID: "acme",
+		OrgID: RandomOrgId(),
 	})
 	assert.Nil(t, err, "Error seeding RepositoryConfigurations")
 }
@@ -27,7 +27,7 @@ func (s *SeedSuite) TestSeedRepository() {
 func (s *SeedSuite) TestSeedRpms() {
 	t := s.T()
 	var err error
-	org_id := "90023"
+	org_id := RandomOrgId()
 	tx := s.tx
 
 	err = SeedRepositoryConfigurations(tx, 1001, SeedOptions{


### PR DESCRIPTION
- Update TestUpdateEmpty to make it more predictable.
- Fix TestSavePublicUrls test.
- Update TestUpdateBlank to make it more predictable.
- Update TestBulkCreateOneFails to make it more predictable.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>