### PR TITLE
Fixes 144: remove unused rpm entries more efficiently

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -20,6 +20,7 @@ type RpmDao interface {
 	List(orgID string, uuidRepo string, limit int, offset int) (api.RepositoryRpmCollectionResponse, int64, error)
 	Search(orgID string, request api.SearchRpmRequest, limit int) ([]api.SearchRpmResponse, error)
 	InsertForRepository(repoUuid string, pkgs []yum.Package) (int64, error)
+	OrphanCleanup() error
 }
 
 type RepositoryDao interface {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -117,6 +117,10 @@ func IntrospectAll() (int64, []error) {
 			errors = append(errors, err)
 		}
 	}
+	err = rpmDao.OrphanCleanup()
+	if err != nil {
+		errors = append(errors, err)
+	}
 	return total, errors
 }
 

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -37,3 +37,7 @@ func (m MockRepositoryDao) FetchForUrl(url string) (error, dao.Repository) {
 func (m MockRepositoryDao) Update(repo dao.Repository) error {
 	return nil
 }
+
+func (m MockRpmDao) OrphanCleanup() error {
+	return nil
+}


### PR DESCRIPTION
only once after each introspect-all.  Also makes a test a tad more readable IMO