### PR TITLE
Fixes 149: Check revision number before introspection

### DIFF
--- a/db/migrations/20220512132042_create_repository_configurations_table.up.sql
+++ b/db/migrations/20220512132042_create_repository_configurations_table.up.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS repositories (
     url VARCHAR(255) NOT NULL,
     last_read_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
     last_read_error VARCHAR(255) DEFAULT NULL,
-    public boolean NOT NULL DEFAULT FALSE
+    public boolean NOT NULL DEFAULT FALSE,
+    revision VARCHAR (255)
 );
 
 ALTER TABLE repositories

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/content-services/content-sources-backend
 go 1.16
 
 require (
-	github.com/content-services/yummy v0.0.5
+	github.com/content-services/yummy v0.0.6
 	github.com/getkin/kin-openapi v0.97.0
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,10 +329,10 @@ github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/
 github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgUV4GP9qXPfu4=
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
-github.com/content-services/yummy v0.0.4 h1:Ir0o9iA6c/9Y8BQZHTTBmR5WMbt3xKwgkml1zl6yW6M=
-github.com/content-services/yummy v0.0.4/go.mod h1:M0fu6BmpEPyC5ijW/5IFZ3DUaN7W0DC2Q3vKWmDzVeA=
 github.com/content-services/yummy v0.0.5 h1:iUSUjGUHNlRq7u+LWDpdhZv0aFP1s/fvLvSGCt2qNfE=
 github.com/content-services/yummy v0.0.5/go.mod h1:M0fu6BmpEPyC5ijW/5IFZ3DUaN7W0DC2Q3vKWmDzVeA=
+github.com/content-services/yummy v0.0.6 h1:iKjIk5FHcapBMpl3KofQKlf4rrG6v8Liuxukg6F/dWg=
+github.com/content-services/yummy v0.0.6/go.mod h1:M0fu6BmpEPyC5ijW/5IFZ3DUaN7W0DC2Q3vKWmDzVeA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -25,6 +25,7 @@ type RpmDao interface {
 type PublicRepositoryDao interface {
 	FetchForUrl(url string) (error, PublicRepository)
 	List() (error, []PublicRepository)
+	UpdateRepository(pubRepo PublicRepository) error
 }
 
 type ExternalResourceDao interface {

--- a/pkg/dao/public_repositories.go
+++ b/pkg/dao/public_repositories.go
@@ -6,8 +6,9 @@ import (
 )
 
 type PublicRepository struct {
-	UUID string
-	URL  string
+	UUID     string
+	URL      string
+	Revision string
 }
 
 func GetPublicRepositoryDao(db *gorm.DB) PublicRepositoryDao {
@@ -27,8 +28,9 @@ func (p publicRepositoryDaoImpl) FetchForUrl(url string) (error, PublicRepositor
 		return result.Error, PublicRepository{}
 	}
 	return nil, PublicRepository{
-		UUID: repo.UUID,
-		URL:  repo.URL,
+		UUID:     repo.UUID,
+		URL:      repo.URL,
+		Revision: repo.Revision,
 	}
 }
 
@@ -46,4 +48,23 @@ func (p publicRepositoryDaoImpl) List() (error, []PublicRepository) {
 		})
 	}
 	return nil, publicRepos
+}
+
+func (p publicRepositoryDaoImpl) UpdateRepository(pubRepo PublicRepository) error {
+	var repo models.Repository
+
+	result := p.db.Where("uuid = ?", pubRepo.UUID).First(&repo)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	repo.URL = pubRepo.URL
+	repo.Revision = pubRepo.Revision
+
+	result = p.db.Model(&repo).Updates(repo.MapForUpdate())
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
 }

--- a/pkg/dao/public_repositories_test.go
+++ b/pkg/dao/public_repositories_test.go
@@ -53,6 +53,39 @@ func (s *PublicRepositorySuite) TestList() {
 	dao := GetPublicRepositoryDao(tx)
 	err, repoList := dao.List()
 	assert.NoError(t, err)
-	assert.Equal(t, int(1), len(repoList))
+	assert.Equal(t, 1, len(repoList))
 	assert.Equal(t, expected, repoList)
+}
+
+func (s *PublicRepositorySuite) TestUpdateRepository() {
+	tx := s.tx
+	t := s.T()
+
+	var (
+		err  error
+		repo PublicRepository
+	)
+
+	dao := GetPublicRepositoryDao(tx)
+	err, repo = dao.FetchForUrl(s.repo.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, PublicRepository{
+		UUID: s.repo.UUID,
+		URL:  s.repo.URL,
+	}, repo)
+
+	err = dao.UpdateRepository(PublicRepository{
+		UUID:     s.repo.UUID,
+		URL:      s.repo.URL,
+		Revision: "123456",
+	})
+	assert.NoError(t, err)
+
+	err, repo = dao.FetchForUrl(s.repo.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, PublicRepository{
+		UUID:     s.repo.UUID,
+		URL:      s.repo.URL,
+		Revision: "123456",
+	}, repo)
 }

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -2,6 +2,7 @@ package external_repos
 
 import (
 	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/yummy/pkg/yum"
 )
 
@@ -20,4 +21,19 @@ func (m MockRpmDao) InsertForRepository(repoUuid string, pkgs []yum.Package) (in
 
 func (m MockRpmDao) Search(orgID string, request api.SearchRpmRequest, limit int) ([]api.SearchRpmResponse, error) {
 	return []api.SearchRpmResponse{}, nil
+}
+
+type MockPublicRepositoryDao struct {
+}
+
+func (m MockPublicRepositoryDao) List() (error, []dao.PublicRepository) {
+	return nil, []dao.PublicRepository{}
+}
+
+func (m MockPublicRepositoryDao) FetchForUrl(url string) (error, dao.PublicRepository) {
+	return nil, dao.PublicRepository{}
+}
+
+func (m MockPublicRepositoryDao) UpdateRepository(pubRepo dao.PublicRepository) error {
+	return nil
 }

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -26,6 +26,8 @@ func TestIsRedHatUrl(t *testing.T) {
 var templateRepomdXml []byte
 
 func TestIntrospect(t *testing.T) {
+	revisionNumber := "1658448098524979"
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/content/repodata/primary.xml.gz":
@@ -95,9 +97,22 @@ func TestIntrospect(t *testing.T) {
 			UUID: repoUUID,
 			URL:  server.URL + "/content",
 		},
+		MockPublicRepositoryDao{},
 		MockRpmDao{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(13), count)
+
+	// Without any changes to the repo, there should be no package updates
+	count, err = Introspect(
+		dao.PublicRepository{
+			UUID:     repoUUID,
+			URL:      server.URL + "/content",
+			Revision: revisionNumber,
+		},
+		MockPublicRepositoryDao{},
+		MockRpmDao{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count)
 }
 
 func TestHttpClient(t *testing.T) {

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -14,6 +14,7 @@ type Repository struct {
 	URL           string     `gorm:"unique;not null;default:null"`
 	LastReadTime  *time.Time `gorm:"default:null"`
 	LastReadError *string    `gorm:"default:null"`
+	Revision      string     `gorm:"default:null"`
 	Public        bool
 
 	RepositoryConfigurations []RepositoryConfiguration `gorm:"foreignKey:RepositoryUUID"`
@@ -72,6 +73,7 @@ func (r *Repository) MapForUpdate() map[string]interface{} {
 	forUpdate["LastReadError"] = r.LastReadError
 	forUpdate["URL"] = r.URL
 	forUpdate["Public"] = r.Public
+	forUpdate["Revision"] = r.Revision
 
 	return forUpdate
 }


### PR DESCRIPTION
Adds
- A check before introspection to see if the repository revision number has changed. If not, don't introspect because it is assumed the repository hasn't changed since the last introspection. 
  - If it has not changed, it won't error, just "successfully update 0 packages". 
- A "revision" column to the "repositories" table that saves the previous revision number.

I tested this by creating a yum repo locally and then serving it with apache. Then I could change the revision number to whatever I wanted.

Depends on this yummy PR: https://github.com/content-services/yummy/pull/6

~~To use this yummy PR, check it out locally and then add `replace github.com/content-services/yummy => path/to/local/yummy`, to `go.mod`, above `require`~~

Still needs:

- [ ] better tests I think