### PR TITLE
Fixes 143: Remove null fields from api responses

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,6 @@ linters:
     - gofmt
     - whitespace
     - govet
+issues:
+  exclude:
+    - composite

--- a/docs/openapi/Models/api.RepositoryResponseJSON.md
+++ b/docs/openapi/Models/api.RepositoryResponseJSON.md
@@ -1,0 +1,15 @@
+# api.RepositoryResponseJSON
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **account\_id** | **String** | Account ID of the owner | [optional] [default to null] |
+| **distribution\_arch** | **String** | Architecture to restrict client usage to | [optional] [default to null] |
+| **distribution\_versions** | **List** | Versions to restrict client usage to | [optional] [default to null] |
+| **name** | **String** | Name of the remote yum repository | [optional] [default to null] |
+| **org\_id** | **String** | Organization ID of the owner | [optional] [default to null] |
+| **url** | **String** | URL of the remote yum repository | [optional] [default to null] |
+| **uuid** | **String** | UUID of the object | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -23,7 +23,7 @@ type RepositoryRequest struct {
 }
 
 type RepositoryBulkCreateResponse struct {
-	ErrorMsg   *string             `json:"error"`      // Error during creation
+	ErrorMsg   string              `json:"error"`      // Error during creation
 	Repository *RepositoryResponse `json:"repository"` // Repository object information
 }
 

--- a/pkg/dao/repository.go
+++ b/pkg/dao/repository.go
@@ -105,7 +105,7 @@ func (r repositoryDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.Reposit
 			dbErr = DBErrorToApi(err)
 			errMsg := dbErr.Error()
 			result[i] = api.RepositoryBulkCreateResponse{
-				ErrorMsg:   &errMsg,
+				ErrorMsg:   errMsg,
 				Repository: nil,
 			}
 			tx.RollbackTo("beforecreate")
@@ -117,7 +117,7 @@ func (r repositoryDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.Reposit
 			dbErr = DBErrorToApi(err)
 			errMsg := dbErr.Error()
 			result[i] = api.RepositoryBulkCreateResponse{
-				ErrorMsg:   &errMsg,
+				ErrorMsg:   errMsg,
 				Repository: nil,
 			}
 			tx.RollbackTo("beforecreate")
@@ -128,7 +128,7 @@ func (r repositoryDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.Reposit
 		response.URL = newRepos[i].URL
 		if dbErr == nil {
 			result[i] = api.RepositoryBulkCreateResponse{
-				ErrorMsg:   nil,
+				ErrorMsg:   "",
 				Repository: &response,
 			}
 		}

--- a/pkg/handler/repository_rpm.go
+++ b/pkg/handler/repository_rpm.go
@@ -74,7 +74,7 @@ func (rh *RepositoryRpmHandler) searchRpmPreprocessInput(input *api.SearchRpmReq
 // @Produce      json
 // @Param		 uuid	path string true "Identifier of the Repository"
 // @Success      200 {object} api.RepositoryRpmCollectionResponse
-// @Router       /repositories/:uuid/rpms [get]
+// @Router       /repositories/{uuid}/rpms [get]
 func (rh *RepositoryRpmHandler) listRepositoriesRpm(c echo.Context) error {
 	// Read input information
 	var rpmInput RepositoryRpmRequest

--- a/pkg/handler/repository_test.go
+++ b/pkg/handler/repository_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/labstack/echo/v4"
-	"github.com/openlyinc/pointy"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -494,12 +493,18 @@ func (suite *ReposSuite) TestBulkCreate() {
 
 	expected := []api.RepositoryBulkCreateResponse{
 		{
-			ErrorMsg:   nil,
-			Repository: &api.RepositoryResponse{Name: "repo_1", URL: "https://example1.com"},
+			ErrorMsg: "",
+			Repository: &api.RepositoryResponse{
+				Name: "repo_1",
+				URL:  "https://example1.com",
+			},
 		},
 		{
-			ErrorMsg:   nil,
-			Repository: &api.RepositoryResponse{Name: "repo_2", URL: "https://example2.com"},
+			ErrorMsg: "",
+			Repository: &api.RepositoryResponse{
+				Name: "repo_2",
+				URL:  "https://example2.com",
+			},
 		},
 	}
 
@@ -543,11 +548,11 @@ func (suite *ReposSuite) TestBulkCreateOneFails() {
 
 	expected := []api.RepositoryBulkCreateResponse{
 		{
-			ErrorMsg:   nil,
+			ErrorMsg:   "",
 			Repository: nil,
 		},
 		{
-			ErrorMsg:   pointy.String("Bad validation"),
+			ErrorMsg:   "Bad validation",
 			Repository: nil,
 		},
 	}
@@ -576,7 +581,7 @@ func (suite *ReposSuite) TestBulkCreateOneFails() {
 	var response []api.RepositoryBulkCreateResponse
 	err = json.Unmarshal(body, &response)
 	assert.Nil(t, err)
-	assert.Nil(t, response[0].ErrorMsg)
+	assert.Equal(t, "", response[0].ErrorMsg)
 	assert.Nil(t, response[0].Repository)
 	assert.NotNil(t, response[1].ErrorMsg)
 	assert.Nil(t, response[1].Repository)

--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -62,7 +62,7 @@ func (rc *RepositoryConfiguration) BeforeUpdate(tx *gorm.DB) error {
 
 func (rc *RepositoryConfiguration) DedupeVersions(tx *gorm.DB) error {
 	var versionMap = make(map[string]bool)
-	var unique pq.StringArray
+	var unique = make(pq.StringArray, 0)
 	for i := 0; i < len(rc.Versions); i++ {
 		if _, found := versionMap[rc.Versions[i]]; !found {
 			versionMap[rc.Versions[i]] = true


### PR DESCRIPTION
There were three fields I could find that were returning null:
1. The bulk create error field, when there's no error.
~2. The bulk create repository field, when there is an error.~ leaving out because it's not causing a CI failure and it's not a simple fix
3. The distribution versions field after a successful creation, if no versions were specified.

I changed these to:
1. empty string
~2. empty object~
3. empty array