### PR TITLE
Fixes 159: Update validation API to support editing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "git.mergeEditor": false,
     "go.testEnvVars": {
         "CONFIG_PATH": "${workspaceFolder}/configs"
     }

--- a/api/docs.go
+++ b/api/docs.go
@@ -681,6 +681,10 @@ const docTemplate = `{
                 "url": {
                     "description": "URL of the remote yum repository",
                     "type": "string"
+                },
+                "uuid": {
+                    "description": "If set, this is an \"Update\" validation",
+                    "type": "string"
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -225,6 +225,10 @@
                     "url": {
                         "description": "URL of the remote yum repository",
                         "type": "string"
+                    },
+                    "uuid": {
+                        "description": "If set, this is an \"Update\" validation",
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/docs/openapi/Models/api.RepositoryValidationRequest.md
+++ b/docs/openapi/Models/api.RepositoryValidationRequest.md
@@ -5,6 +5,7 @@
 |------------ | ------------- | ------------- | -------------|
 | **name** | **String** | Name of the remote yum repository | [optional] [default to null] |
 | **url** | **String** | URL of the remote yum repository | [optional] [default to null] |
+| **uuid** | **String** | If set, this is an \&quot;Update\&quot; validation | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/pkg/api/repository_parameters.go
+++ b/pkg/api/repository_parameters.go
@@ -11,6 +11,7 @@ type RepositoryParameterResponse struct {
 type RepositoryValidationRequest struct {
 	Name *string `json:"name"` // Name of the remote yum repository
 	URL  *string `json:"url"`  // URL of the remote yum repository
+	UUID *string `json:"uuid"` // If set, this is an "Update" validation
 }
 
 type RepositoryValidationResponse struct {

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -13,7 +13,7 @@ type RepositoryConfigDao interface {
 	List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)
 	Delete(orgID string, uuid string) error
 	SavePublicRepos(urls []string) error
-	ValidateParameters(orgId string, params api.RepositoryValidationRequest) (api.RepositoryValidationResponse, error)
+	ValidateParameters(orgId string, params api.RepositoryValidationRequest, excludedUUIDS []string) (api.RepositoryValidationResponse, error)
 }
 
 type RpmDao interface {

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -92,7 +92,7 @@ func (r *MockRepositoryConfigDao) Delete(orgID string, uuid string) error {
 	return args.Error(0)
 }
 
-func (r *MockRepositoryConfigDao) ValidateParameters(orgId string, req api.RepositoryValidationRequest) (api.RepositoryValidationResponse, error) {
+func (r *MockRepositoryConfigDao) ValidateParameters(orgId string, req api.RepositoryValidationRequest, excludedUUIDs []string) (api.RepositoryValidationResponse, error) {
 	r.Called(orgId, req)
 	return api.RepositoryValidationResponse{}, nil
 }

--- a/pkg/handler/repository_parameters_test.go
+++ b/pkg/handler/repository_parameters_test.go
@@ -67,9 +67,11 @@ func (suite *RepositoryParameterSuite) TestValidate() {
 	requestBody := []api.RepositoryValidationRequest{
 		{
 			Name: pointy.String("myValidateRepo"),
+			UUID: pointy.String("steve-the-id"),
 		},
 		{
-			URL: pointy.String("http://myrepo.com"),
+			URL:  pointy.String("http://myrepo.com"),
+			UUID: pointy.String("paul-the-id"),
 		},
 		{},
 	}


### PR DESCRIPTION
This adds the ability for the validation API to EXCLUDE the sent UUIDs from its name/url uniqueness check, thus allowing the ability to use this API to validate against within the repository edit screen. 

This solves the problem of false positive (where the uniqueness check would fail) when validating a repo effectively against itself or others in the edit group.

An example: 

Previously this: 
```json
[
   {
        "name": "google",
        "url": "https://www.google.com"
        // "uuid": "a68feaa3-9746-4719-8e33-3ff4688fed85",
    },
    {
        "name": "apple",
        "url": "https://apple.com", 
        //  "uuid": "9d6fb177-ff10-41fc-81d4-ea12ae963042",
    }
]
```

would result in:
```json
[
    {
        "name": {
            "skipped": false,
            "valid": false,
            "error": "A repository with the name 'google' already exists."
        },
        "url": {
            "skipped": false,
            "valid": false,
            "error": "A repository with the URL 'https://www.google.com' already exists.",
            "http_code": 0,
            "metadata_present": false
        }
    },
    {
        "name": {
            "skipped": false,
            "valid": false,
            "error": "A repository with the name 'apple' already exists."
        },
        "url": {
            "skipped": false,
            "valid": false,
            "error": "A repository with the URL 'https://apple.com' already exists.",
            "http_code": 0,
            "metadata_present": false
        }
    }
]
```

Now well editing the above targeted repos, by adding in the commented UUIDs to exclude, we get the following: 
```json
[
    {
        "name": {
            "skipped": false,
            "valid": true,
            "error": ""
        },
        "url": {
            "skipped": false,
            "valid": true,
            "error": "",
            "http_code": 200,
            "metadata_present": true
        }
    },
    {
        "name": {
            "skipped": false,
            "valid": true,
            "error": ""
        },
        "url": {
            "skipped": false,
            "valid": true,
            "error": "",
            "http_code": 200,
            "metadata_present": true
        }
    }
]
```

Which is the expected outcome for validating when editing.
