### PR TITLE
Fixes 109: Store and return introspection status metadata

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -594,6 +594,22 @@ const docTemplate = `{
                         "8"
                     ]
                 },
+                "last_introspection_error": {
+                    "description": "Error of last attempted introspection",
+                    "type": "string"
+                },
+                "last_introspection_time": {
+                    "description": "Timestamp of last attempted introspection",
+                    "type": "string"
+                },
+                "last_success_introspection_time": {
+                    "description": "Timestamp of last successful introspection",
+                    "type": "string"
+                },
+                "last_update_introspection_time": {
+                    "description": "Timestamp of last introspection that had updates",
+                    "type": "string"
+                },
                 "name": {
                     "description": "Name of the remote yum repository",
                     "type": "string"
@@ -602,6 +618,10 @@ const docTemplate = `{
                     "description": "Organization ID of the owner",
                     "type": "string",
                     "readOnly": true
+                },
+                "status": {
+                    "description": "Status of repository introspection (Valid, Invalid, Unavailable, Pending)",
+                    "type": "string"
                 },
                 "url": {
                     "description": "URL of the remote yum repository",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -140,6 +140,22 @@
                         },
                         "type": "array"
                     },
+                    "last_introspection_error": {
+                        "description": "Error of last attempted introspection",
+                        "type": "string"
+                    },
+                    "last_introspection_time": {
+                        "description": "Timestamp of last attempted introspection",
+                        "type": "string"
+                    },
+                    "last_success_introspection_time": {
+                        "description": "Timestamp of last successful introspection",
+                        "type": "string"
+                    },
+                    "last_update_introspection_time": {
+                        "description": "Timestamp of last introspection that had updates",
+                        "type": "string"
+                    },
                     "name": {
                         "description": "Name of the remote yum repository",
                         "type": "string"
@@ -147,6 +163,10 @@
                     "org_id": {
                         "description": "Organization ID of the owner",
                         "readOnly": true,
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status of repository introspection (Valid, Invalid, Unavailable, Pending)",
                         "type": "string"
                     },
                     "url": {

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -45,14 +45,13 @@ func main() {
 		if len(args) < 3 {
 			log.Fatal().Msg("Usage:  ./external_repos introspect URL")
 		}
-		count, err := external_repos.IntrospectUrl(args[2])
-		if err != nil {
-			log.Panic().Err(err).Msg("Failed to introspect repositories")
+		count, errors := external_repos.IntrospectUrl(args[2])
+		for i := 0; i < len(errors); i++ {
+			log.Panic().Err(errors[i]).Msg("Failed to introspect repository")
 		}
 		log.Debug().Msgf("Successfully Inserted %d packages", count)
 	} else if args[1] == "introspect-all" {
 		count, errors := external_repos.IntrospectAll()
-
 		for i := 0; i < len(errors); i++ {
 			log.Panic().Err(errors[i]).Msg("Failed to introspect repositories")
 		}

--- a/db/migrations/20220512132042_create_repository_configurations_table.up.sql
+++ b/db/migrations/20220512132042_create_repository_configurations_table.up.sql
@@ -8,10 +8,13 @@ CREATE TABLE IF NOT EXISTS repositories (
     created_at TIMESTAMP WITH TIME ZONE,
     updated_at TIMESTAMP WITH TIME ZONE,
     url VARCHAR(255) NOT NULL,
-    last_read_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
-    last_read_error VARCHAR(255) DEFAULT NULL,
     public boolean NOT NULL DEFAULT FALSE,
-    revision VARCHAR (255)
+    revision VARCHAR (255),
+    last_introspection_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    last_introspection_success_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    last_introspection_update_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    last_introspection_error VARCHAR(255) DEFAULT NULL,
+    status VARCHAR (255)
 );
 
 ALTER TABLE repositories

--- a/docs/openapi/Models/api.RepositoryResponse.md
+++ b/docs/openapi/Models/api.RepositoryResponse.md
@@ -6,8 +6,13 @@
 | **account\_id** | **String** | Account ID of the owner | [optional] [default to null] |
 | **distribution\_arch** | **String** | Architecture to restrict client usage to | [optional] [default to null] |
 | **distribution\_versions** | **List** | Versions to restrict client usage to | [optional] [default to null] |
+| **last\_introspection\_error** | **String** | Error of last attempted introspection | [optional] [default to null] |
+| **last\_introspection\_time** | **String** | Timestamp of last attempted introspection | [optional] [default to null] |
+| **last\_success\_introspection\_time** | **String** | Timestamp of last successful introspection | [optional] [default to null] |
+| **last\_update\_introspection\_time** | **String** | Timestamp of last introspection that had updates | [optional] [default to null] |
 | **name** | **String** | Name of the remote yum repository | [optional] [default to null] |
 | **org\_id** | **String** | Organization ID of the owner | [optional] [default to null] |
+| **status** | **String** | Status of repository introspection (Valid, Invalid, Unavailable, Pending) | [optional] [default to null] |
 | **url** | **String** | URL of the remote yum repository | [optional] [default to null] |
 | **uuid** | **String** | UUID of the object | [optional] [default to null] |
 

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -2,13 +2,18 @@ package api
 
 // RepositoryResponse holds data returned by a repositories API response
 type RepositoryResponse struct {
-	UUID                 string   `json:"uuid" readonly:"true"`                // UUID of the object
-	Name                 string   `json:"name"`                                // Name of the remote yum repository
-	URL                  string   `json:"url"`                                 // URL of the remote yum repository
-	DistributionVersions []string `json:"distribution_versions" example:"7,8"` // Versions to restrict client usage to
-	DistributionArch     string   `json:"distribution_arch" example:"x86_64"`  // Architecture to restrict client usage to
-	AccountID            string   `json:"account_id" readonly:"true"`          // Account ID of the owner
-	OrgID                string   `json:"org_id" readonly:"true"`              // Organization ID of the owner
+	UUID                         string   `json:"uuid" readonly:"true"`                // UUID of the object
+	Name                         string   `json:"name"`                                // Name of the remote yum repository
+	URL                          string   `json:"url"`                                 // URL of the remote yum repository
+	DistributionVersions         []string `json:"distribution_versions" example:"7,8"` // Versions to restrict client usage to
+	DistributionArch             string   `json:"distribution_arch" example:"x86_64"`  // Architecture to restrict client usage to
+	AccountID                    string   `json:"account_id" readonly:"true"`          // Account ID of the owner
+	OrgID                        string   `json:"org_id" readonly:"true"`              // Organization ID of the owner
+	LastIntrospectionTime        string   `json:"last_introspection_time"`             // Timestamp of last attempted introspection
+	LastIntrospectionSuccessTime string   `json:"last_success_introspection_time"`     // Timestamp of last successful introspection
+	LastIntrospectionUpdateTime  string   `json:"last_update_introspection_time"`      // Timestamp of last introspection that had updates
+	LastIntrospectionError       string   `json:"last_introspection_error"`            // Error of last attempted introspection
+	Status                       string   `json:"status"`                              // Status of repository introspection (Valid, Invalid, Unavailable, Pending)
 }
 
 // RepositoryRequest holds data received from request to create/update repository

--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -1,5 +1,12 @@
 package config
 
+const (
+	StatusValid       = "Valid"       // Repository introspected successfully
+	StatusUnavailable = "Unavailable" // Repository introspected at least once, but now errors
+	StatusInvalid     = "Invalid"     // Repository has never introspected due to error
+	StatusPending     = "Pending"     // Repository not introspected yet
+)
+
 type DistributionVersion struct {
 	Name  string `json:"name"`  // Human-readable form of the version
 	Label string `json:"label"` // Static label of the version

--- a/pkg/dao/repository_config.go
+++ b/pkg/dao/repository_config.go
@@ -68,6 +68,7 @@ func (r repositoryConfigDaoImpl) Create(newRepoReq api.RepositoryRequest) (api.R
 	var created api.RepositoryResponse
 	ModelToApiFields(newRepoConfig, &created)
 	created.URL = newRepo.URL
+	created.Status = newRepo.Status
 
 	return created, nil
 }
@@ -126,6 +127,7 @@ func (r repositoryConfigDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.R
 
 		ModelToApiFields(newRepoConfigs[i], &response)
 		response.URL = newRepos[i].URL
+		response.Status = newRepos[i].Status
 		if dbErr == nil {
 			result[i] = api.RepositoryBulkCreateResponse{
 				ErrorMsg:   "",
@@ -197,6 +199,7 @@ func (r repositoryConfigDaoImpl) List(
 func (r repositoryConfigDaoImpl) Fetch(orgID string, uuid string) (api.RepositoryResponse, error) {
 	repo := api.RepositoryResponse{}
 	repoConfig, err := r.fetchRepoConfig(orgID, uuid)
+
 	if err != nil {
 		return repo, err
 	}
@@ -303,7 +306,20 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 	apiRepo.DistributionArch = repoConfig.Arch
 	apiRepo.AccountID = repoConfig.AccountID
 	apiRepo.OrgID = repoConfig.OrgID
-	apiRepo.URL = repoConfig.Repository.URL
+	apiRepo.Status = repoConfig.Repository.Status
+
+	if repoConfig.Repository.LastIntrospectionTime != nil {
+		apiRepo.LastIntrospectionTime = repoConfig.Repository.LastIntrospectionTime.String()
+	}
+	if repoConfig.Repository.LastIntrospectionSuccessTime != nil {
+		apiRepo.LastIntrospectionSuccessTime = repoConfig.Repository.LastIntrospectionSuccessTime.String()
+	}
+	if repoConfig.Repository.LastIntrospectionUpdateTime != nil {
+		apiRepo.LastIntrospectionUpdateTime = repoConfig.Repository.LastIntrospectionUpdateTime.String()
+	}
+	if repoConfig.Repository.LastIntrospectionError != nil {
+		apiRepo.LastIntrospectionError = *repoConfig.Repository.LastIntrospectionError
+	}
 }
 
 // Converts the database models to our response objects

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -524,7 +524,20 @@ func (s *RpmSuite) TestInsertForRepositoryWithExistingChecksums() {
 
 	records, err = dao.InsertForRepository(s.repoPrivate.Base.UUID, p[1:(pagedRpmInsertsLimit>>1)+1])
 	assert.NoError(t, err)
-	assert.Equal(t, int64((pagedRpmInsertsLimit>>1)-1), records)
+	assert.Equal(t, int64((pagedRpmInsertsLimit >> 1)), records)
+	err = s.tx.
+		Table("rpms").
+		Joins("inner join repositories_rpms on repositories_rpms.rpm_uuid = rpms.uuid").
+		Select("count(*) as rpm_count").
+		Where("repositories_rpms.repository_uuid = ?", s.repoPrivate.UUID).
+		Pluck("rpm_count", &rpm_count).
+		Error
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(p[1:(pagedRpmInsertsLimit>>1)+1])), rpm_count)
+
+	records, err = dao.InsertForRepository(s.repoPrivate.Base.UUID, p[1:(pagedRpmInsertsLimit>>1)+1])
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), records)
 	err = s.tx.
 		Table("rpms").
 		Joins("inner join repositories_rpms on repositories_rpms.rpm_uuid = rpms.uuid").

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -45,16 +45,20 @@ type RepositorySuite struct {
 
 var orgIDTest = seeds.RandomOrgId()
 var accountIdTest = seeds.RandomAccountId()
+var timestamp = time.Now()
 
 var repoPublicTest = models.Repository{
 	Base: models.Base{
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	},
-	URL:           "https://www.redhat.com",
-	LastReadTime:  nil,
-	LastReadError: nil,
-	Public:        true,
+	URL:                          "https://www.public.example.com",
+	Public:                       true,
+	LastIntrospectionTime:        &timestamp,
+	LastIntrospectionUpdateTime:  &timestamp,
+	LastIntrospectionSuccessTime: &timestamp,
+	LastIntrospectionError:       nil,
+	Status:                       config.StatusValid,
 }
 
 var repoPrivateTest = models.Repository{
@@ -62,10 +66,13 @@ var repoPrivateTest = models.Repository{
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	},
-	URL:           "https://www.redhat.private.com",
-	LastReadTime:  nil,
-	LastReadError: nil,
-	Public:        false,
+	URL:                          "https://www.private.example.com",
+	Public:                       false,
+	LastIntrospectionTime:        &timestamp,
+	LastIntrospectionUpdateTime:  &timestamp,
+	LastIntrospectionSuccessTime: &timestamp,
+	LastIntrospectionError:       nil,
+	Status:                       config.StatusValid,
 }
 
 var repoConfigTest1 = models.RepositoryConfiguration{

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -134,13 +134,18 @@ func createRepoCollection(size, limit, offset int) api.RepositoryCollectionRespo
 	repos := make([]api.RepositoryResponse, size)
 	for i := 0; i < size; i++ {
 		repo := api.RepositoryResponse{
-			UUID:                 fmt.Sprintf("%d", i),
-			Name:                 fmt.Sprintf("repo_%d", i),
-			URL:                  fmt.Sprintf("http://repo-%d.com", i),
-			DistributionVersions: []string{config.El7},
-			DistributionArch:     config.X8664,
-			AccountID:            mockAccountNumber,
-			OrgID:                mockOrgId,
+			UUID:                         fmt.Sprintf("%d", i),
+			Name:                         fmt.Sprintf("repo_%d", i),
+			URL:                          fmt.Sprintf("http://repo-%d.com", i),
+			DistributionVersions:         []string{config.El7},
+			DistributionArch:             config.X8664,
+			AccountID:                    mockAccountNumber,
+			OrgID:                        mockOrgId,
+			LastIntrospectionTime:        "2022-08-31 14:17:50.257623 -0400 EDT",
+			LastIntrospectionSuccessTime: "2022-08-31 14:17:50.257623 -0400 EDT",
+			LastIntrospectionUpdateTime:  "2022-08-31 14:17:50.257623 -0400 EDT",
+			LastIntrospectionError:       "",
+			Status:                       "Valid",
 		}
 		repos[i] = repo
 	}
@@ -216,6 +221,12 @@ func (suite *ReposSuite) TestSimple() {
 	assert.Equal(t, collection.Data[0].Name, response.Data[0].Name)
 	assert.Equal(t, collection.Data[0].URL, response.Data[0].URL)
 	assert.Equal(t, collection.Data[0].AccountID, response.Data[0].AccountID)
+	assert.Equal(t, collection.Data[0].DistributionVersions, response.Data[0].DistributionVersions)
+	assert.Equal(t, collection.Data[0].DistributionArch, response.Data[0].DistributionArch)
+	assert.Equal(t, collection.Data[0].LastIntrospectionUpdateTime, response.Data[0].LastIntrospectionUpdateTime)
+	assert.Equal(t, collection.Data[0].LastIntrospectionTime, response.Data[0].LastIntrospectionTime)
+	assert.Equal(t, collection.Data[0].LastIntrospectionSuccessTime, response.Data[0].LastIntrospectionSuccessTime)
+	assert.Equal(t, collection.Data[0].LastIntrospectionError, response.Data[0].LastIntrospectionError)
 }
 
 func (suite *ReposSuite) TestListNoRepositories() {

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -11,11 +11,14 @@ import (
 // TODO Review the content for this table.
 type Repository struct {
 	Base
-	URL           string     `gorm:"unique;not null;default:null"`
-	LastReadTime  *time.Time `gorm:"default:null"`
-	LastReadError *string    `gorm:"default:null"`
-	Revision      string     `gorm:"default:null"`
-	Public        bool
+	URL                          string `gorm:"unique;not null;default:null"`
+	Revision                     string `gorm:"default:null"`
+	Public                       bool
+	LastIntrospectionTime        *time.Time `gorm:"default:null"`
+	LastIntrospectionSuccessTime *time.Time `gorm:"default:null"`
+	LastIntrospectionUpdateTime  *time.Time `gorm:"default:null"`
+	LastIntrospectionError       *string    `gorm:"default:null"`
+	Status                       string     `gorm:"default:Pending"`
 
 	RepositoryConfigurations []RepositoryConfiguration `gorm:"foreignKey:RepositoryUUID"`
 	Rpms                     []Rpm                     `gorm:"many2many:repositories_rpms"`
@@ -42,19 +45,36 @@ func (in *Repository) DeepCopyInto(out *Repository) {
 		return
 	}
 	in.Base.DeepCopyInto(&out.Base)
-	var lastReadTime *time.Time = nil
-	if in.LastReadTime != nil {
-		lastReadTime = &time.Time{}
-		*lastReadTime = *in.LastReadTime
+
+	var (
+		lastIntrospectionTime        *time.Time
+		lastIntrospectionUpdateTime  *time.Time
+		lastIntrospectionSuccessTime *time.Time
+		lastIntrospectionError       *string
+	)
+
+	if in.LastIntrospectionTime != nil {
+		lastIntrospectionTime = &time.Time{}
+		*lastIntrospectionTime = *in.LastIntrospectionTime
 	}
-	var lastReadError *string = nil
-	if in.LastReadError != nil {
-		lastReadError = pointy.String(*in.LastReadError)
+	if in.LastIntrospectionUpdateTime != nil {
+		lastIntrospectionUpdateTime = &time.Time{}
+		*lastIntrospectionUpdateTime = *in.LastIntrospectionUpdateTime
+	}
+	if in.LastIntrospectionSuccessTime != nil {
+		lastIntrospectionSuccessTime = &time.Time{}
+		*lastIntrospectionSuccessTime = *in.LastIntrospectionSuccessTime
+	}
+	if in.LastIntrospectionError != nil {
+		lastIntrospectionError = pointy.String(*in.LastIntrospectionError)
 	}
 	out.URL = in.URL
-	out.LastReadTime = lastReadTime
-	out.LastReadError = lastReadError
 	out.Public = in.Public
+	out.LastIntrospectionTime = lastIntrospectionTime
+	out.LastIntrospectionSuccessTime = lastIntrospectionSuccessTime
+	out.LastIntrospectionUpdateTime = lastIntrospectionUpdateTime
+	out.LastIntrospectionError = lastIntrospectionError
+	out.Status = in.Status
 
 	// Duplicate the slices
 	out.RepositoryConfigurations = make([]RepositoryConfiguration, len(in.RepositoryConfigurations))
@@ -69,11 +89,14 @@ func (in *Repository) DeepCopyInto(out *Repository) {
 
 func (r *Repository) MapForUpdate() map[string]interface{} {
 	forUpdate := make(map[string]interface{})
-	forUpdate["LastReadTime"] = r.LastReadTime
-	forUpdate["LastReadError"] = r.LastReadError
 	forUpdate["URL"] = r.URL
 	forUpdate["Public"] = r.Public
 	forUpdate["Revision"] = r.Revision
+	forUpdate["LastIntrospectionTime"] = r.LastIntrospectionTime
+	forUpdate["LastIntrospectionError"] = r.LastIntrospectionError
+	forUpdate["LastIntrospectionSuccessTime"] = r.LastIntrospectionSuccessTime
+	forUpdate["LastIntrospectionUpdateTime"] = r.LastIntrospectionUpdateTime
+	forUpdate["Status"] = r.Status
 
 	return forUpdate
 }

--- a/pkg/models/repository_rpm_test.go
+++ b/pkg/models/repository_rpm_test.go
@@ -9,9 +9,9 @@ func (s *ModelsSuite) TestRepositoriesRpmsValidations() {
 	const spName = "testrepositoriesrpmsvalidations"
 
 	testRepository := Repository{
-		URL:           "https://my-repository.com",
-		LastReadTime:  nil,
-		LastReadError: nil,
+		URL:                    "https://example.com",
+		LastIntrospectionTime:  nil,
+		LastIntrospectionError: nil,
 	}
 	testRpm := Rpm{
 		Name:     "test-package",

--- a/pkg/models/repository_test.go
+++ b/pkg/models/repository_test.go
@@ -9,9 +9,9 @@ import (
 func (s *ModelsSuite) TestRepositoriesCreate() {
 	var now = time.Now()
 	var repo = Repository{
-		URL:           "https://example.com",
-		LastReadTime:  &now,
-		LastReadError: nil,
+		URL:                    "https://example.com",
+		LastIntrospectionTime:  &now,
+		LastIntrospectionError: nil,
 	}
 	var found = Repository{}
 	tx := s.tx

--- a/pkg/models/suite_test.go
+++ b/pkg/models/suite_test.go
@@ -40,9 +40,9 @@ var repoTest1 = Repository{
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	},
-	URL:           "https://www.redhat.com",
-	LastReadTime:  nil,
-	LastReadError: nil,
+	URL:                    "https://www.redhat.com",
+	LastIntrospectionTime:  nil,
+	LastIntrospectionError: nil,
 }
 
 var rpmTest1 = Rpm{


### PR DESCRIPTION
Adds introspection status timestamps, status, and last error to repository. Updated on introspection and returned in list and fetch responses.

To test, create some repositories and list/fetch them. See the new fields. Then, introspect the repositories and list/fetch them again to see how the timestamps/error/status change.