### PR TITLE
Fixes 162: Let search packages by uuid

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -731,6 +731,13 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "uuids": {
+                    "description": "List of RepositoryConfig uuids to serach",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/docs.go
+++ b/api/docs.go
@@ -733,7 +733,7 @@ const docTemplate = `{
                     }
                 },
                 "uuids": {
-                    "description": "List of RepositoryConfig uuids to serach",
+                    "description": "List of RepositoryConfig UUIDs to search",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -275,7 +275,7 @@
                         "type": "array"
                     },
                     "uuids": {
-                        "description": "List of RepositoryConfig uuids to serach",
+                        "description": "List of RepositoryConfig UUIDs to search",
                         "items": {
                             "type": "string"
                         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -273,6 +273,13 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "uuids": {
+                        "description": "List of RepositoryConfig uuids to serach",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object"

--- a/docs/openapi/Models/api.SearchRpmRequest.md
+++ b/docs/openapi/Models/api.SearchRpmRequest.md
@@ -5,6 +5,7 @@
 |------------ | ------------- | ------------- | -------------|
 | **search** | **String** | Search string to search rpm names | [optional] [default to null] |
 | **urls** | **List** | URLs of repositories to search | [optional] [default to null] |
+| **uuids** | **List** | List of RepositoryConfig uuids to serach | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/openapi/Models/api.SearchRpmRequest.md
+++ b/docs/openapi/Models/api.SearchRpmRequest.md
@@ -5,7 +5,7 @@
 |------------ | ------------- | ------------- | -------------|
 | **search** | **String** | Search string to search rpm names | [optional] [default to null] |
 | **urls** | **List** | URLs of repositories to search | [optional] [default to null] |
-| **uuids** | **List** | List of RepositoryConfig uuids to serach | [optional] [default to null] |
+| **uuids** | **List** | List of RepositoryConfig UUIDs to search | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/pkg/api/repository_rpm.go
+++ b/pkg/api/repository_rpm.go
@@ -19,7 +19,7 @@ type RepositoryRpmCollectionResponse struct {
 
 type SearchRpmRequest struct {
 	URLs   []string `json:"urls,omitempty"`  // URLs of repositories to search
-	Uuids  []string `json:"uuids,omitempty"` // List of RepositoryConfig uuids to serach
+	UUIDs  []string `json:"uuids,omitempty"` // List of RepositoryConfig UUIDs to search
 	Search string   `json:"search"`          // Search string to search rpm names
 }
 

--- a/pkg/api/repository_rpm.go
+++ b/pkg/api/repository_rpm.go
@@ -18,8 +18,9 @@ type RepositoryRpmCollectionResponse struct {
 }
 
 type SearchRpmRequest struct {
-	URLs   []string `json:"urls"`   // URLs of repositories to search
-	Search string   `json:"search"` //Search string to search rpm names
+	URLs   []string `json:"urls,omitempty"`  // URLs of repositories to search
+	Uuids  []string `json:"uuids,omitempty"` // List of RepositoryConfig uuids to serach
+	Search string   `json:"search"`          // Search string to search rpm names
 }
 
 type SearchRpmResponse struct {

--- a/pkg/dao/rpm.go
+++ b/pkg/dao/rpm.go
@@ -181,7 +181,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 	// https://github.com/go-gorm/gorm/issues/5318
 	dataResponse := []api.SearchRpmResponse{}
 	orGroupPublicOrPrivate := r.db.Where("repository_configurations.org_id = ?", orgID).Or("repositories.public")
-	groupUrlOrUuid := r.getGroupUrlOrUuid(urls, uuids)
+	orGroupUrlOrUuid := r.getGroupUrlOrUuid(urls, uuids)
 	db := r.db.Debug().
 		Select("DISTINCT ON(rpms.name) rpms.name as package_name", "rpms.summary").
 		Table(models.TableNameRpm).
@@ -190,7 +190,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 		Joins("left join repository_configurations on repository_configurations.repository_uuid = repositories.uuid").
 		Where(orGroupPublicOrPrivate).
 		Where("rpms.name LIKE ?", fmt.Sprintf("%s%%", request.Search)).
-		Where(groupUrlOrUuid).
+		Where(orGroupUrlOrUuid).
 		Order("rpms.name ASC").
 		Limit(limit).
 		Scan(&dataResponse)

--- a/pkg/dao/rpm.go
+++ b/pkg/dao/rpm.go
@@ -149,7 +149,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 	if orgID == "" {
 		return nil, fmt.Errorf("orgID can not be an empty string")
 	}
-	if len(request.URLs) == 0 && len(request.Uuids) == 0 {
+	if len(request.URLs) == 0 && len(request.UUIDs) == 0 {
 		return nil, fmt.Errorf("must contain at least 1 URL or 1 UUID")
 	}
 
@@ -160,7 +160,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 		urls[i*2] = url
 		urls[i*2+1] = url + "/"
 	}
-	uuids := request.Uuids
+	uuids := request.UUIDs
 
 	// This implement the following SELECT statement:
 	//

--- a/pkg/dao/rpm.go
+++ b/pkg/dao/rpm.go
@@ -181,7 +181,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 	// https://github.com/go-gorm/gorm/issues/5318
 	dataResponse := []api.SearchRpmResponse{}
 	orGroupPublicOrPrivate := r.db.Where("repository_configurations.org_id = ?", orgID).Or("repositories.public")
-	db := r.db.Debug().
+	db := r.db.
 		Select("DISTINCT ON(rpms.name) rpms.name as package_name", "rpms.summary").
 		Table(models.TableNameRpm).
 		Joins("inner join repositories_rpms on repositories_rpms.rpm_uuid = rpms.uuid").

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -393,7 +393,7 @@ func (s *RpmSuite) TestRpmSearchError() {
 	var searchRpmResponse []api.SearchRpmResponse
 	dao := GetRpmDao(tx, nil)
 	// We are going to launch database operations that evoke errors, so we need to restore
-	// the state previously the error to let the test do more actions
+	// the state previous to the error to let the test do more actions
 	tx.SavePoint(txSP)
 
 	searchRpmResponse, err = dao.Search("", api.SearchRpmRequest{Search: "", URLs: []string{"https:/noreturn.org"}}, 100)

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -245,7 +245,7 @@ func (s *RpmSuite) TestRpmSearch() {
 			given: TestCaseGiven{
 				orgId: orgIDTest,
 				input: api.SearchRpmRequest{
-					Uuids: []string{
+					UUIDs: []string{
 						uuids[0],
 					},
 					Search: "demo-",
@@ -268,7 +268,7 @@ func (s *RpmSuite) TestRpmSearch() {
 						urls[0],
 						urls[1],
 					},
-					Uuids: []string{
+					UUIDs: []string{
 						uuids[0],
 					},
 					Search: "demo-",


### PR DESCRIPTION
This change will let to search rpm packages by specifying a list of repository_configurations uuids; it is combined as a logic or with the list of urls.

For /api/content_sources/v1/rpms/names route it will let to:

```json
{
    "urls": ["https://MzjLlbBGbpZTNGIIVnoN.com/IuQyV"],
    "uuids": ["98f88705-ba61-496f-9ed9-12268df2f790"],
    "search": "a"
}
```

or

```json
{
    "urls": ["https://MzjLlbBGbpZTNGIIVnoN.com/IuQyV"],
    "search": "a"
}
```

or

```json
{
    "uuids": ["98f88705-ba61-496f-9ed9-12268df2f790"],
    "search": "a"
}
```

a list of urls or uuids should be present, or both, but not none of them.

List of changes:

- Update request structure.
- Update dao object to consider the list of uuids.
- Update tests.
- Update api documentation.