### PR TITLE
Fixes 172: fix make build and make run rules

### DIFF
--- a/mk/go-rules.mk
+++ b/mk/go-rules.mk
@@ -49,3 +49,8 @@ test: ## Run tests
 .PHONY: test-ci
 test-ci: ## Run tests for ci
 	go test $(MOD_VENDOR) ./...
+
+# Add dependencies from binaries to all the the sources
+# so any change is detected for the build rule
+$(patsubst cmd/%,$(GO_OUTPUT)/%,$(wildcard cmd/*)): $(shell find $(PROJECT_DIR)/cmd -type f -name '*.go') $(shell find $(PROJECT_DIR)/pkg -type f -name '*.go')
+


### PR DESCRIPTION
When a source code is updated or just touched, now `make build` and `make run` detect it has changed and the binaries are rerebuilt.