### PR TITLE
Fixes 165: Set list default sort order (name asc)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,7 +8,7 @@ type CollectionMetadataSettable interface {
 }
 
 type PaginationData struct {
-	Limit  int    `query:"limit" json:"limit" `    //Number of results to return
+	Limit  int    `query:"limit" json:"limit" `    // Number of results to return
 	Offset int    `query:"offset" json:"offset"`   // Offset into the total results
 	SortBy string `query:"sort_by" json:"sort_by"` // SortBy sets the sort order of the results
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,8 +8,9 @@ type CollectionMetadataSettable interface {
 }
 
 type PaginationData struct {
-	Limit  int `query:"limit" json:"limit" `  //Number of results to return
-	Offset int `query:"offset" json:"offset"` //Offset into the total results
+	Limit  int    `query:"limit" json:"limit" `    //Number of results to return
+	Offset int    `query:"offset" json:"offset"`   //Offset into the total results
+	SortBy string `query:"sort_by" json:"sort_by"` //SortBy describes in which order to sort results
 }
 
 type FilterData struct {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,7 +10,7 @@ type CollectionMetadataSettable interface {
 type PaginationData struct {
 	Limit  int    `query:"limit" json:"limit" `    //Number of results to return
 	Offset int    `query:"offset" json:"offset"`   //Offset into the total results
-	SortBy string `query:"sort_by" json:"sort_by"` //SortBy describes in which order to sort results
+	SortBy string `query:"sort_by" json:"sort_by"` // SortBy sets the sort order of the results
 }
 
 type FilterData struct {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -9,7 +9,7 @@ type CollectionMetadataSettable interface {
 
 type PaginationData struct {
 	Limit  int    `query:"limit" json:"limit" `    //Number of results to return
-	Offset int    `query:"offset" json:"offset"`   //Offset into the total results
+	Offset int    `query:"offset" json:"offset"`   // Offset into the total results
 	SortBy string `query:"sort_by" json:"sort_by"` // SortBy sets the sort order of the results
 }
 

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -32,7 +32,7 @@ type repositoryDaoImpl struct {
 
 func (p repositoryDaoImpl) FetchForUrl(url string) (error, Repository) {
 	repo := models.Repository{}
-	result := p.db.Where("URL = ?", url).First(&repo)
+	result := p.db.Where("URL = ?", url).Order("url asc").First(&repo)
 	if result.Error != nil {
 		return result.Error, Repository{}
 	}

--- a/pkg/dao/repository_config_test.go
+++ b/pkg/dao/repository_config_test.go
@@ -713,7 +713,7 @@ func (suite *RepositoryConfigSuite) TestListFilterMultipleArch() {
 	assert.Equal(t, quantity, len(response.Data))
 	assert.Equal(t, int64(40), count)
 
-	//By setting SortBy to "arch asc" we now expect the first page arches to be half and half s390x/x86_64
+	// By setting SortBy to "arch asc" we now expect the first page arches to be half and half s390x/x86_64
 	firstItem := response.Data[0].DistributionArch
 	lastItem := response.Data[len(response.Data)-1].DistributionArch
 

--- a/pkg/dao/repository_config_test.go
+++ b/pkg/dao/repository_config_test.go
@@ -754,7 +754,7 @@ func (suite *RepositoryConfigSuite) TestListFilterMultipleVersions() {
 	assert.Equal(t, quantity, len(response.Data))
 	assert.Equal(t, int64(quantity), count)
 
-	//By setting SortBy to "version asc" we expect the first page versions lengths to be half and half or 1 and 3
+	// By setting SortBy to "version asc" we expect the first page versions lengths to be half and half or 1 and 3
 	firstItem := len(response.Data[0].DistributionVersions)
 	lastItem := len(response.Data[len(response.Data)-1].DistributionVersions)
 

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -78,6 +78,12 @@ func TestParsePagination(t *testing.T) {
 	pageInfo = ParsePagination(getTestContext("?limit=37&offset=123"))
 	assert.Equal(t, 37, pageInfo.Limit)
 	assert.Equal(t, 123, pageInfo.Offset)
+
+	pageInfo = ParsePagination(getTestContext("?sort_by[]=status&sort_by[]=url:asc&sort_by[]=name:desc"))
+	assert.Equal(t, "status,url:asc,name:desc", pageInfo.SortBy)
+
+	pageInfo = ParsePagination(getTestContext("?sort_by=status"))
+	assert.Equal(t, "status", pageInfo.SortBy)
 }
 
 func TestCollectionResponse(t *testing.T) {

--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/lib/pq"
@@ -69,6 +70,7 @@ func (rc *RepositoryConfiguration) DedupeVersions(tx *gorm.DB) error {
 			unique = append(unique, rc.Versions[i])
 		}
 	}
+	sort.Strings(unique)
 	tx.Statement.SetColumn("Versions", unique)
 	return nil
 }


### PR DESCRIPTION
Adds some logic for ordering the repository list response. 

Current sort_by parameters: 
- 	name  // Default
- 	url 
- 	distribution_arch 
- 	distribution_versions
-	package_count
-	status

All parameters can optionally add either ":asc" or ":desc"

A sort_by list is possible by using the following template when constructing the url params: 

.../content-sources/v1/repositories/?sort_by[]=status&sort_by[]=url:asc&sort_by[]=name:desc

this will construct a sql query as follows: status asc, url asc, name desc

For more information: [console doc sorting standardization](https://consoledot.pages.redhat.com/docs/dev/developer-references/rest/sorting.html)