### PR TITLE
Fixes 175: rename api path to content-sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ make run
 Hit the api:
 
 ```
-curl http://localhost:8000/api/content_sources/v1.0/repositories/ ```
+curl http://localhost:8000/api/content-sources/v1.0/repositories/ ```
 ```
 
 ### Generating new openapi docs:

--- a/api/docs.go
+++ b/api/docs.go
@@ -812,7 +812,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "v1.0.0",
 	Host:             "api.example.com",
-	BasePath:         "/api/content_sources/v1.0/",
+	BasePath:         "/api/content-sources/v1.0/",
 	Schemes:          []string{},
 	Title:            "ContentSourcesBackend",
 	Description:      "API of the Content Sources application on [console.redhat.com](https://console.redhat.com)\n",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -816,7 +816,7 @@
     },
     "servers": [
         {
-            "url": "https://api.example.com/api/content_sources/v1.0/"
+            "url": "https://api.example.com/api/content-sources/v1.0/"
         }
     ]
 }

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -19,7 +19,7 @@ objects:
           webServices:
             public:
               enabled: true
-              apiPath: content_sources
+              apiPath: content-sources
           podSpec:
             initContainers:
               - env:

--- a/docs/openapi/Apis/RepositoriesApi.md
+++ b/docs/openapi/Apis/RepositoriesApi.md
@@ -1,6 +1,6 @@
 # RepositoriesApi
 
-All URIs are relative to *https://api.example.com/api/content_sources/v1.0*
+All URIs are relative to *https://api.example.com/api/content-sources/v1.0*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/docs/openapi/Apis/RpmsApi.md
+++ b/docs/openapi/Apis/RpmsApi.md
@@ -1,6 +1,6 @@
 # RpmsApi
 
-All URIs are relative to *https://api.example.com/api/content_sources/v1.0*
+All URIs are relative to *https://api.example.com/api/content-sources/v1.0*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -3,7 +3,7 @@
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *https://api.example.com/api/content_sources/v1.0*
+All URIs are relative to *https://api.example.com/api/content-sources/v1.0*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ziflex/lecho/v3"
 )
 
+const DefaultAppName = "content-sources"
+
 type Configuration struct {
 	Database Database
 	Logging  Logging
@@ -188,7 +190,7 @@ func SkipLiveness(c echo.Context) bool {
 	if p == "/ping" {
 		return true
 	}
-	if strings.HasPrefix(p, "/api/content_sources/") &&
+	if strings.HasPrefix(p, "/api/"+DefaultAppName+"/") &&
 		len(strings.Split(p, "/")) == 5 &&
 		strings.Split(p, "/")[4] == "ping" {
 		return true

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -28,7 +28,6 @@ const DefaultArch = ""
 const DefaultVersion = ""
 const DefaultAvailableForArch = ""
 const DefaultAvailableForVersion = ""
-const DefaultAppName = "content_sources"
 const MaxLimit = 200
 const ApiVersion = "1.0"
 const ApiVersionMajor = "1"
@@ -42,7 +41,7 @@ const ApiVersionMajor = "1"
 // @license.name Apache 2.0
 // @license.url https://www.apache.org/licenses/LICENSE-2.0
 // @Host api.example.com
-// @BasePath /api/content_sources/v1.0/
+// @BasePath /api/content-sources/v1.0/
 // @query.collection.format multi
 // @securityDefinitions.apikey RhIdentity
 // @in header
@@ -95,7 +94,7 @@ func rootPrefix() string {
 
 	appName, present := os.LookupEnv("APP_NAME")
 	if !present {
-		appName = DefaultAppName
+		appName = config.DefaultAppName
 	}
 	return filepath.Join("/", pathPrefix, appName)
 }

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,7 +48,7 @@ func TestPingV1(t *testing.T) {
 }
 
 func TestOpenapi(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/api/content_sources/v1.0/openapi.json", nil)
+	req, _ := http.NewRequest("GET", "/api/"+config.DefaultAppName+"/v1.0/openapi.json", nil)
 	code, body, err := serveRouter(req)
 
 	assert.Nil(t, err)
@@ -66,7 +67,7 @@ func getTestContext(params string) echo.Context {
 }
 
 func TestRootRoute(t *testing.T) {
-	assert.Equal(t, fullRootPath(), "/api/content_sources/v1.0")
+	assert.Equal(t, fullRootPath(), "/api/"+config.DefaultAppName+"/v1.0")
 }
 
 func TestParsePagination(t *testing.T) {
@@ -104,5 +105,5 @@ func TestCollectionResponse(t *testing.T) {
 
 func TestCreateLink(t *testing.T) {
 	link := createLink(getTestContext(""), 99)
-	assert.Equal(t, "/api/content_sources/v1.0/repositories/?limit=100&offset=99", link)
+	assert.Equal(t, "/api/"+config.DefaultAppName+"/v1.0/repositories/?limit=100&offset=99", link)
 }

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -96,7 +97,7 @@ func (rh *RepositoryHandler) createRepository(c echo.Context) error {
 		return echo.NewHTTPError(httpCodeForError(err), "Error creating repository: "+err.Error())
 	}
 
-	c.Response().Header().Set("Location", "/api/content_sources/v1.0/repositories/"+response.UUID)
+	c.Response().Header().Set("Location", "/api/"+config.DefaultAppName+"/v1.0/repositories/"+response.UUID)
 	return c.JSON(http.StatusCreated, response)
 }
 


### PR DESCRIPTION
because insights does not like content_sources
This also refactors a bit to only set the app name once in code