### PR TITLE
Fixes 152: Smarter introspection job

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"sort"
 
@@ -47,21 +48,14 @@ func main() {
 		log.Debug().Msg("Successfully loaded external repositories.")
 	} else if args[1] == "introspect" {
 		if len(args) < 3 {
-			log.Panic().Err(err).Msg("Usage:  ./external_repos introspect [--force] URL")
+			log.Panic().Err(err).Msg("Usage:  ./external_repos introspect URL [--force]")
 			os.Exit(1)
 		}
-		// TODO Quick option implemented, refactor to use some library
-		var url string
-		if len(args) == 4 {
-			if args[2] != "--force" {
-				log.Info().Err(err).Msgf("Expected --force but got '%s'", args[2])
-				log.Panic().Err(err).Msg("Usage:  ./external_repos introspect [--force] URL")
-				os.Exit(1)
-			}
-			forceIntrospect = true
-			url = args[3]
-		} else {
-			url = args[2]
+		url := args[2]
+		if len(args) > 3 {
+			flagset := flag.NewFlagSet("introspect", flag.ExitOnError)
+			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
+			flagset.Parse(args[3:])
 		}
 		count, errors := external_repos.IntrospectUrl(url, forceIntrospect)
 		for i := 0; i < len(errors); i++ {
@@ -69,9 +63,10 @@ func main() {
 		}
 		log.Debug().Msgf("Inserted %d packages", count)
 	} else if args[1] == "introspect-all" {
-		// TODO Quick option implemented, refactor to use some library
-		if len(args) == 3 && args[2] == "--force" {
-			forceIntrospect = true
+		if len(args) > 2 {
+			flagset := flag.NewFlagSet("introspect-all", flag.ExitOnError)
+			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
+			flagset.Parse(args[2:])
 		}
 		count, errors := external_repos.IntrospectAll(forceIntrospect)
 		for i := 0; i < len(errors); i++ {

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -55,7 +55,10 @@ func main() {
 		if len(args) > 3 {
 			flagset := flag.NewFlagSet("introspect", flag.ExitOnError)
 			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
-			flagset.Parse(args[3:])
+			if err = flagset.Parse(args[3:]); err != nil {
+				log.Panic().Err(err).Msg("Usage:  ./external_repos introspect URL [--force]")
+				os.Exit(1)
+			}
 		}
 		count, errors := external_repos.IntrospectUrl(url, forceIntrospect)
 		for i := 0; i < len(errors); i++ {
@@ -66,7 +69,10 @@ func main() {
 		if len(args) > 2 {
 			flagset := flag.NewFlagSet("introspect-all", flag.ExitOnError)
 			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
-			flagset.Parse(args[2:])
+			if err = flagset.Parse(args[2:]); err != nil {
+				log.Panic().Err(err).Msg("Usage:  ./external_repos introspect-all [--force]")
+				os.Exit(1)
+			}
 		}
 		count, errors := external_repos.IntrospectAll(forceIntrospect)
 		for i := 0; i < len(errors); i++ {

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -67,7 +67,7 @@ func main() {
 		for i := 0; i < len(errors); i++ {
 			log.Panic().Err(errors[i]).Msg("Failed to introspect repository")
 		}
-		log.Debug().Msgf("Successfully Inserted %d packages", count)
+		log.Debug().Msgf("Inserted %d packages", count)
 	} else if args[1] == "introspect-all" {
 		// TODO Quick option implemented, refactor to use some library
 		if len(args) == 3 && args[2] == "--force" {

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -48,7 +48,7 @@ func main() {
 		log.Debug().Msg("Successfully loaded external repositories.")
 	} else if args[1] == "introspect" {
 		if len(args) < 3 {
-			log.Panic().Err(err).Msg("Usage:  ./external_repos introspect URL [--force]")
+			log.Error().Msg("Usage:  ./external_repos introspect URL [--force]")
 			os.Exit(1)
 		}
 		url := args[2]
@@ -56,7 +56,7 @@ func main() {
 			flagset := flag.NewFlagSet("introspect", flag.ExitOnError)
 			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
 			if err = flagset.Parse(args[3:]); err != nil {
-				log.Panic().Err(err).Msg("Usage:  ./external_repos introspect URL [--force]")
+				log.Error().Err(err).Msg("Usage:  ./external_repos introspect URL [--force]")
 				os.Exit(1)
 			}
 		}
@@ -70,7 +70,7 @@ func main() {
 			flagset := flag.NewFlagSet("introspect-all", flag.ExitOnError)
 			flagset.BoolVar(&forceIntrospect, "force", false, "Force introspection even if not needed")
 			if err = flagset.Parse(args[2:]); err != nil {
-				log.Panic().Err(err).Msg("Usage:  ./external_repos introspect-all [--force]")
+				log.Error().Err(err).Msg("Usage:  ./external_repos introspect-all [--force]")
 				os.Exit(1)
 			}
 		}

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -79,7 +79,7 @@ func main() {
 			log.Panic().Err(errors[i]).Msg("Failed to introspect repositories")
 		}
 
-		log.Debug().Msgf("Successfully Inserted %d packages", count)
+		log.Debug().Msgf("Inserted %d packages", count)
 	}
 }
 

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -82,7 +82,8 @@ objects:
                 name: tmpdir
       jobs:
         - name: introspect-all
-          schedule: "0 0 * * *"
+          # https://crontab.guru/
+          schedule: "0 0/8 * * *"
           concurrencyPolicy: "Forbid"
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -97,6 +97,15 @@ objects:
                   secretKeyRef:
                     name: content-sources-certs
                     key: cdn.redhat.com
+            livenessProbe:
+              exec:
+                command:
+                  - ( exec 2>/dev/null; [ "$( cat /proc/1/cmdline )" == "/content-sources" ] )
+              failureThreshold: 3
+              initialDelaySeconds: 480 # Use 8 minutes = 8*60 = 480
+              periodSeconds: 3
+              successThreshold: 1
+
       database:
         name: content-sources
         version: 13

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -97,15 +97,6 @@ objects:
                   secretKeyRef:
                     name: content-sources-certs
                     key: cdn.redhat.com
-            livenessProbe:
-              exec:
-                command:
-                  - ( exec 2>/dev/null; [ "$( cat /proc/1/cmdline )" == "/content-sources" ] )
-              failureThreshold: 3
-              initialDelaySeconds: 480 # Use 8 minutes = 8*60 = 480
-              periodSeconds: 3
-              successThreshold: 1
-
       database:
         name: content-sources
         version: 13

--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -1,53 +1,5 @@
 [
     {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
-        "base_url": ""
-    },
-    {
         "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
     },
     {

--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -1,5 +1,53 @@
 [
     {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
+        "base_url": ""
+    },
+    {
         "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
     },
     {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -136,8 +136,8 @@ func needsIntrospect(repo *dao.Repository) (bool, string) {
 		return false, "Cannot introspect nil Repository"
 	}
 
-	if repo.Status != dao.StatusValid {
-		return true, fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, repo.UUID)
+	if repo.Status != config.StatusValid {
+		return true, fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, repo.UUID)
 	}
 
 	if repo.LastIntrospectionTime == nil {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -148,19 +148,19 @@ func needsIntrospect(repo *dao.Repository) (bool, string) {
 	}
 
 	if repo.Status != config.StatusValid {
-		return true, fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, repo.UUID)
+		return true, fmt.Sprintf("Introspection started: the Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, repo.UUID)
 	}
 
 	if repo.LastIntrospectionTime == nil {
-		return true, fmt.Sprintf("Not expected LastIntrospectionTime = nil for Repository.UUID = %s", repo.UUID)
+		return true, fmt.Sprintf("Introspection started: not expected LastIntrospectionTime = nil for Repository.UUID = %s", repo.UUID)
 	}
 
 	threshold := repo.LastIntrospectionTime.Add(IntrospectTimeInterval)
 	if threshold.After(time.Now()) {
-		return false, fmt.Sprintf("Last instrospection happened before the threshold for Repository.UUID = %s", repo.UUID)
+		return false, fmt.Sprintf("Introspection skipped: Last instrospection happened before the threshold for Repository.UUID = %s", repo.UUID)
 	}
 
-	return true, fmt.Sprintf("Last introspection happened after the threshold for Repository.UUID = %s", repo.UUID)
+	return true, fmt.Sprintf("Introspection started: last introspection happened after the threshold for Repository.UUID = %s", repo.UUID)
 }
 
 func httpClient(useCert bool) (http.Client, error) {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -137,7 +137,7 @@ func needsIntrospect(repo *dao.Repository) (bool, string) {
 	}
 
 	if repo.Status != dao.StatusValid {
-		return true, fmt.Sprintf("The Status fiels is not %s for Repository.UUID = %s", dao.StatusValid, repo.UUID)
+		return true, fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, repo.UUID)
 	}
 
 	if repo.LastIntrospectionTime == nil {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -135,9 +135,8 @@ func needsIntrospect(repo *dao.Repository) bool {
 		return false
 	}
 
-	// TODO Remove the hardcoded value by a constant
 	// For no valid repositories return true
-	if repo.Status != "Valid" {
+	if repo.Status != dao.StatusValid {
 		return true
 	}
 

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -310,7 +310,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status fiels is not %s for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
 				},
 			},
 			{
@@ -319,7 +319,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status fiels is not %s for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
 				},
 			},
 			{
@@ -328,7 +328,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status fiels is not %s for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
 				},
 			},
 			// END: Cover all the no valid status

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -285,8 +285,8 @@ func TestNeedIntrospect(t *testing.T) {
 	}
 
 	var (
-		thresholdBefore24 time.Time = time.Now().Add(-(IntrospectTimeInterval - time.Hour)) // Substract 23 hours to the current time
-		thresholdAfter24  time.Time = time.Now().Add(-(IntrospectTimeInterval + time.Hour)) // Substract 25 hours to the current time
+		thresholdBefore24 time.Time = time.Now().Add(-(IntrospectTimeInterval - time.Hour)) // Subtract 23 hours to the current time
+		thresholdAfter24  time.Time = time.Now().Add(-(IntrospectTimeInterval + time.Hour)) // Subtract 25 hours to the current time
 		result            bool
 		reason            string
 		testCases         []TestCase = []TestCase{
@@ -343,7 +343,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("Not expected LastIntrospectionTime = nil for Repository.UUID = "),
+					reason: "Not expected LastIntrospectionTime = nil for Repository.UUID = ",
 				},
 			},
 			// When Status is Valid

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -306,29 +306,29 @@ func TestNeedIntrospect(t *testing.T) {
 			// It returns true
 			{
 				given: &dao.Repository{
-					Status: dao.StatusInvalid,
+					Status: config.StatusInvalid,
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			{
 				given: &dao.Repository{
-					Status: dao.StatusPending,
+					Status: config.StatusPending,
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			{
 				given: &dao.Repository{
-					Status: dao.StatusUnavailable,
+					Status: config.StatusUnavailable,
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", dao.StatusValid, ""),
+					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			// END: Cover all the no valid status
@@ -338,7 +338,7 @@ func TestNeedIntrospect(t *testing.T) {
 			// It returns true
 			{
 				given: &dao.Repository{
-					Status:                dao.StatusValid,
+					Status:                config.StatusValid,
 					LastIntrospectionTime: nil,
 				},
 				expected: TestCaseExpected{
@@ -351,7 +351,7 @@ func TestNeedIntrospect(t *testing.T) {
 			// It returns false indicating that no introspection is needed
 			{
 				given: &dao.Repository{
-					Status:                dao.StatusValid,
+					Status:                config.StatusValid,
 					LastIntrospectionTime: &thresholdBefore24,
 				},
 				expected: TestCaseExpected{
@@ -364,7 +364,7 @@ func TestNeedIntrospect(t *testing.T) {
 			// It returns true indicating that an introspection is needed
 			{
 				given: &dao.Repository{
-					Status:                dao.StatusValid,
+					Status:                config.StatusValid,
 					LastIntrospectionTime: &thresholdAfter24,
 				},
 				expected: TestCaseExpected{

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -273,3 +273,62 @@ func TestUpdateIntrospectionStatusMetadata(t *testing.T) {
 		assert.Equal(t, expectedUpdateTime, repoResult.LastIntrospectionUpdateTime)
 	}
 }
+
+func TestNeedIntrospect(t *testing.T) {
+	var (
+		result    bool
+		repo      dao.Repository
+		threshold time.Time
+	)
+
+	// When repo is nill
+	// It returns false
+	result = needsIntrospect(nil)
+	assert.False(t, result)
+
+	// TODO Update strings with constants
+	// When Status is not Valid
+	// It returns true
+	NoValidStatus := []string{"Invalid", "Unavailable", "Pending"}
+	for _, status := range NoValidStatus {
+		repo = dao.Repository{
+			Status: status,
+		}
+		result = needsIntrospect(&repo)
+		assert.True(t, result)
+	}
+
+	// TODO Update strings with constants
+	// When Status is Valid
+	//  and LastIntrospectionTime is nill
+	// It returns true
+	repo = dao.Repository{
+		Status:                "Valid",
+		LastIntrospectionTime: nil,
+	}
+	result = needsIntrospect(&repo)
+	assert.True(t, result)
+
+	// TODO Update strings with constants
+	// When Status is Valid
+	//  and LastIntrospectionTime does not reach the threshold interval (24hours)
+	// It returns false indicating that no introspection is needed
+	threshold = time.Now().Add(-(IntrospectTimeInterval - time.Hour)) // Substract 23 hours to the current time
+	repo = dao.Repository{
+		Status:                "Valid",
+		LastIntrospectionTime: &threshold,
+	}
+	result = needsIntrospect(&repo)
+	assert.False(t, result)
+
+	// When Status is Valid
+	//  and LastIntrospectionTime does reach the threshold interval (24hours)
+	// It returns true indicating that an introspection is needed
+	threshold = time.Now().Add(-(IntrospectTimeInterval + time.Hour)) // Substract 25 hours to the current time
+	repo = dao.Repository{
+		Status:                "Valid",
+		LastIntrospectionTime: &threshold,
+	}
+	result = needsIntrospect(&repo)
+	assert.True(t, result)
+}

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -291,7 +291,7 @@ func TestNeedIntrospect(t *testing.T) {
 		reason            string
 		testCases         []TestCase = []TestCase{
 			// When repo is nil
-			// It returns false
+			// it returns false
 			{
 				given: nil,
 				expected: TestCaseExpected{
@@ -303,7 +303,7 @@ func TestNeedIntrospect(t *testing.T) {
 			// BEGIN: Cover all the no valid status
 
 			// When Status is not Valid
-			// It returns true
+			// it returns true
 			{
 				given: &dao.Repository{
 					Status: config.StatusInvalid,
@@ -334,8 +334,8 @@ func TestNeedIntrospect(t *testing.T) {
 			// END: Cover all the no valid status
 
 			// When Status is Valid
-			//  and LastIntrospectionTime is nill
-			// It returns true
+			// and LastIntrospectionTime is nill
+			// it returns true
 			{
 				given: &dao.Repository{
 					Status:                config.StatusValid,
@@ -347,8 +347,8 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 			},
 			// When Status is Valid
-			//  and LastIntrospectionTime does not reach the threshold interval (24hours)
-			// It returns false indicating that no introspection is needed
+			// and LastIntrospectionTime does not reach the threshold interval (24hours)
+			// it returns false indicating that no introspection is needed
 			{
 				given: &dao.Repository{
 					Status:                config.StatusValid,
@@ -360,8 +360,8 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 			},
 			// When Status is Valid
-			//  and LastIntrospectionTime does reach the threshold interval (24hours)
-			// It returns true indicating that an introspection is needed
+			// and LastIntrospectionTime does reach the threshold interval (24hours)
+			// it returns true indicating that an introspection is needed
 			{
 				given: &dao.Repository{
 					Status:                config.StatusValid,

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -310,7 +310,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
+					reason: fmt.Sprintf("Introspection started: the Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			{
@@ -319,7 +319,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
+					reason: fmt.Sprintf("Introspection started: the Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			{
@@ -328,7 +328,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: fmt.Sprintf("The Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
+					reason: fmt.Sprintf("Introspection started: the Status field content differs from '%s' for Repository.UUID = %s", config.StatusValid, ""),
 				},
 			},
 			// END: Cover all the no valid status
@@ -343,7 +343,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: "Not expected LastIntrospectionTime = nil for Repository.UUID = ",
+					reason: "Introspection started: not expected LastIntrospectionTime = nil for Repository.UUID = ",
 				},
 			},
 			// When Status is Valid
@@ -356,7 +356,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: false,
-					reason: "Last instrospection happened before the threshold for Repository.UUID = ",
+					reason: "Introspection skipped: Last instrospection happened before the threshold for Repository.UUID = ",
 				},
 			},
 			// When Status is Valid
@@ -369,7 +369,7 @@ func TestNeedIntrospect(t *testing.T) {
 				},
 				expected: TestCaseExpected{
 					result: true,
-					reason: "Last introspection happened after the threshold for Repository.UUID = ",
+					reason: "Introspection started: last introspection happened after the threshold for Repository.UUID = ",
 				},
 			},
 		}


### PR DESCRIPTION
- It runs every 8 hours, starting at 0:00 hours.
- It executes for every repository with Status != 'Valid'.
- It does not execute for a repository with Status == 'Valid' hat was introspected into the last 24 hours.
- Unit tests for the above.
- Removed: Add livenessProbe to the pod job specification: it was stepped back.
