### PR TITLE
Fixes 185: Save revision properly

### DIFF
--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -12,7 +12,6 @@ type Repository struct {
 	UUID                         string
 	URL                          string
 	Revision                     string
-	Public                       bool
 	LastIntrospectionTime        *time.Time
 	LastIntrospectionSuccessTime *time.Time
 	LastIntrospectionUpdateTime  *time.Time
@@ -32,22 +31,26 @@ type repositoryDaoImpl struct {
 
 func (p repositoryDaoImpl) FetchForUrl(url string) (error, Repository) {
 	repo := models.Repository{}
+	internalRepo := Repository{}
 	result := p.db.Where("URL = ?", url).Order("url asc").First(&repo)
 	if result.Error != nil {
 		return result.Error, Repository{}
 	}
-	return nil, modelToInternal(repo)
+	modelToInternal(repo, &internalRepo)
+	return nil, internalRepo
 }
 
 func (p repositoryDaoImpl) List() (error, []Repository) {
 	var dbRepos []models.Repository
 	var repos []Repository
+	var repo Repository
 	result := p.db.Find(&dbRepos)
 	if result.Error != nil {
 		return result.Error, repos
 	}
 	for i := 0; i < len(dbRepos); i++ {
-		repos = append(repos, modelToInternal(dbRepos[i]))
+		modelToInternal(dbRepos[i], &repo)
+		repos = append(repos, repo)
 	}
 	return nil, repos
 }
@@ -60,9 +63,9 @@ func (p repositoryDaoImpl) Update(repoIn Repository) error {
 		return result.Error
 	}
 
-	repo := internalToModel(repoIn)
+	internalToModel(repoIn, &dbRepo)
 
-	result = p.db.Model(&repo).Updates(repo.MapForUpdate())
+	result = p.db.Model(&dbRepo).Updates(dbRepo.MapForUpdate())
 	if result.Error != nil {
 		return result.Error
 	}
@@ -71,31 +74,38 @@ func (p repositoryDaoImpl) Update(repoIn Repository) error {
 }
 
 // modelToInternal returns internal Repository with fields of model
-func modelToInternal(model models.Repository) Repository {
-	var internal Repository
+func modelToInternal(model models.Repository, internal *Repository) {
 	internal.UUID = model.UUID
 	internal.URL = model.URL
-	internal.Public = model.Public
 	internal.Revision = model.Revision
 	internal.LastIntrospectionError = model.LastIntrospectionError
 	internal.LastIntrospectionTime = model.LastIntrospectionTime
 	internal.LastIntrospectionUpdateTime = model.LastIntrospectionUpdateTime
 	internal.LastIntrospectionSuccessTime = model.LastIntrospectionSuccessTime
 	internal.Status = model.Status
-	return internal
 }
 
-// internalToModel returns model Repository with fields of internal
-func internalToModel(internal Repository) models.Repository {
-	var model models.Repository
-	model.UUID = internal.UUID
-	model.URL = internal.URL
-	model.Public = internal.Public
-	model.Revision = internal.Revision
-	model.LastIntrospectionError = internal.LastIntrospectionError
-	model.LastIntrospectionTime = internal.LastIntrospectionTime
-	model.LastIntrospectionUpdateTime = internal.LastIntrospectionUpdateTime
-	model.LastIntrospectionSuccessTime = internal.LastIntrospectionSuccessTime
-	model.Status = internal.Status
-	return model
+// internalToModel updates model Repository with non-zero fields of internal
+func internalToModel(internal Repository, model *models.Repository) {
+	if internal.URL != "" {
+		model.URL = internal.URL
+	}
+	if internal.Revision != "" {
+		model.Revision = internal.Revision
+	}
+	if internal.LastIntrospectionError != nil {
+		model.LastIntrospectionError = internal.LastIntrospectionError
+	}
+	if internal.LastIntrospectionTime != nil {
+		model.LastIntrospectionTime = internal.LastIntrospectionTime
+	}
+	if internal.LastIntrospectionUpdateTime != nil {
+		model.LastIntrospectionUpdateTime = internal.LastIntrospectionUpdateTime
+	}
+	if internal.LastIntrospectionSuccessTime != nil {
+		model.LastIntrospectionSuccessTime = internal.LastIntrospectionSuccessTime
+	}
+	if internal.Status != "" {
+		model.Status = internal.Status
+	}
 }

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -24,7 +24,6 @@ func (s *RepositorySuite) TestFetchForUrl() {
 	assert.Equal(t, Repository{
 		UUID:                         s.repo.UUID,
 		URL:                          s.repo.URL,
-		Public:                       s.repo.Public,
 		Status:                       s.repo.Status,
 		LastIntrospectionTime:        s.repo.LastIntrospectionTime,
 		LastIntrospectionUpdateTime:  s.repo.LastIntrospectionUpdateTime,
@@ -38,7 +37,6 @@ func (s *RepositorySuite) TestFetchForUrl() {
 	assert.Equal(t, Repository{
 		UUID:                         s.repoPrivate.UUID,
 		URL:                          s.repoPrivate.URL,
-		Public:                       s.repoPrivate.Public,
 		Status:                       s.repo.Status,
 		LastIntrospectionTime:        s.repo.LastIntrospectionTime,
 		LastIntrospectionUpdateTime:  s.repo.LastIntrospectionUpdateTime,
@@ -62,7 +60,6 @@ func (s *RepositorySuite) TestList() {
 	expected := Repository{
 		UUID:                         s.repo.UUID,
 		URL:                          s.repo.URL,
-		Public:                       s.repo.Public,
 		Status:                       s.repo.Status,
 		LastIntrospectionTime:        s.repo.LastIntrospectionTime,
 		LastIntrospectionUpdateTime:  s.repo.LastIntrospectionUpdateTime,
@@ -97,7 +94,6 @@ func (s *RepositorySuite) TestUpdateRepository() {
 		LastIntrospectionUpdateTime:  s.repo.LastIntrospectionUpdateTime,
 		LastIntrospectionSuccessTime: s.repo.LastIntrospectionSuccessTime,
 		LastIntrospectionError:       s.repo.LastIntrospectionError,
-		Public:                       s.repo.Public,
 	}, repo)
 
 	expectedTimestamp := time.Now()
@@ -105,7 +101,6 @@ func (s *RepositorySuite) TestUpdateRepository() {
 		UUID:                         s.repo.UUID,
 		URL:                          s.repo.URL,
 		Revision:                     "123456",
-		Public:                       !s.repo.Public,
 		LastIntrospectionTime:        &expectedTimestamp,
 		LastIntrospectionSuccessTime: &expectedTimestamp,
 		LastIntrospectionUpdateTime:  &expectedTimestamp,
@@ -120,11 +115,30 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	assert.NoError(t, err)
 	assert.Equal(t, expected.UUID, repo.UUID)
 	assert.Equal(t, expected.URL, repo.URL)
-	assert.Equal(t, expected.Public, repo.Public)
 	assert.Equal(t, "123456", repo.Revision)
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionTime.Format("060102"))
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionUpdateTime.Format("060102"))
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionSuccessTime.Format("060102"))
 	assert.Equal(t, expected.LastIntrospectionError, repo.LastIntrospectionError)
 	assert.Equal(t, config.StatusUnavailable, repo.Status)
+
+	// Test does not change zero values
+	zeroValues := Repository{
+		UUID: s.repo.UUID,
+		URL:  s.repo.URL,
+	}
+
+	err = dao.Update(zeroValues)
+	assert.NoError(t, err)
+
+	err, repo = dao.FetchForUrl(s.repo.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, s.repo.UUID, repo.UUID)
+	assert.Equal(t, s.repo.URL, repo.URL)
+	assert.Equal(t, expected.Revision, repo.Revision)
+	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionTime.Format("060102"))
+	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionUpdateTime.Format("060102"))
+	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionSuccessTime.Format("060102"))
+	assert.Equal(t, expected.LastIntrospectionError, repo.LastIntrospectionError)
+	assert.Equal(t, expected.Status, repo.Status)
 }


### PR DESCRIPTION
The `Update` function in the repository dao was not working correctly when passed zero values. It would update the model with the zero values.

It may be best to have the [internal Repository object](https://github.com/content-services/content-sources-backend/blob/main/pkg/dao/repositories.go#L10) split into two the way that the RepoConfig layer has RepositoryRequest and RepositoryResponse. This way we can distinguish between what should be updated and what shouldn't be with `nil`. I can make a change like that here if we want.

For now I fixed this in the least disruptive way possible because it's blocking #92 

To test:
Introspect and repository and the Revision field should be saved correctly. Without this change, it would be blank.