### PR TITLE
Fixes 194: Update with zero values in repository dao

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -26,7 +26,7 @@ type RpmDao interface {
 type RepositoryDao interface {
 	FetchForUrl(url string) (error, Repository)
 	List() (error, []Repository)
-	Update(repo Repository) error
+	Update(repo RepositoryUpdate) error
 }
 
 type ExternalResourceDao interface {

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -20,6 +20,19 @@ type Repository struct {
 	PackageCount                 int
 }
 
+// RepositoryUpdate internal representation of repository, nil field value means do not change
+type RepositoryUpdate struct {
+	UUID                         string
+	URL                          *string
+	Revision                     *string
+	LastIntrospectionTime        *time.Time
+	LastIntrospectionSuccessTime *time.Time
+	LastIntrospectionUpdateTime  *time.Time
+	LastIntrospectionError       *string
+	Status                       *string
+	PackageCount                 *int
+}
+
 func GetRepositoryDao(db *gorm.DB) RepositoryDao {
 	return repositoryDaoImpl{
 		db: db,
@@ -56,7 +69,7 @@ func (p repositoryDaoImpl) List() (error, []Repository) {
 	return nil, repos
 }
 
-func (p repositoryDaoImpl) Update(repoIn Repository) error {
+func (p repositoryDaoImpl) Update(repoIn RepositoryUpdate) error {
 	var dbRepo models.Repository
 
 	result := p.db.Where("uuid = ?", repoIn.UUID).First(&dbRepo)
@@ -87,13 +100,13 @@ func modelToInternal(model models.Repository, internal *Repository) {
 	internal.PackageCount = model.PackageCount
 }
 
-// internalToModel updates model Repository with non-zero fields of internal
-func internalToModel(internal Repository, model *models.Repository) {
-	if internal.URL != "" {
-		model.URL = internal.URL
+// internalToModel updates model Repository with fields of internal
+func internalToModel(internal RepositoryUpdate, model *models.Repository) {
+	if internal.URL != nil {
+		model.URL = *internal.URL
 	}
-	if internal.Revision != "" {
-		model.Revision = internal.Revision
+	if internal.Revision != nil {
+		model.Revision = *internal.Revision
 	}
 	if internal.LastIntrospectionError != nil {
 		model.LastIntrospectionError = internal.LastIntrospectionError
@@ -107,10 +120,10 @@ func internalToModel(internal Repository, model *models.Repository) {
 	if internal.LastIntrospectionSuccessTime != nil {
 		model.LastIntrospectionSuccessTime = internal.LastIntrospectionSuccessTime
 	}
-	if internal.Status != "" {
-		model.Status = internal.Status
+	if internal.Status != nil {
+		model.Status = *internal.Status
 	}
-	if internal.PackageCount != 0 {
-		model.PackageCount = internal.PackageCount
+	if internal.PackageCount != nil {
+		model.PackageCount = *internal.PackageCount
 	}
 }

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -101,16 +101,16 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	}, repo)
 
 	expectedTimestamp := time.Now()
-	expected := Repository{
+	expected := RepositoryUpdate{
 		UUID:                         s.repo.UUID,
-		URL:                          s.repo.URL,
-		Revision:                     "123456",
+		URL:                          pointy.String(s.repo.URL),
+		Revision:                     pointy.String("123456"),
 		LastIntrospectionTime:        &expectedTimestamp,
 		LastIntrospectionSuccessTime: &expectedTimestamp,
 		LastIntrospectionUpdateTime:  &expectedTimestamp,
 		LastIntrospectionError:       pointy.String("expected error"),
-		Status:                       config.StatusUnavailable,
-		PackageCount:                 123,
+		PackageCount:                 pointy.Int(123),
+		Status:                       pointy.String(config.StatusUnavailable),
 	}
 
 	err = dao.Update(expected)
@@ -119,7 +119,7 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	err, repo = dao.FetchForUrl(s.repo.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.UUID, repo.UUID)
-	assert.Equal(t, expected.URL, repo.URL)
+	assert.Equal(t, *expected.URL, repo.URL)
 	assert.Equal(t, "123456", repo.Revision)
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionTime.Format("060102"))
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionUpdateTime.Format("060102"))
@@ -128,10 +128,11 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	assert.Equal(t, config.StatusUnavailable, repo.Status)
 	assert.Equal(t, 123, repo.PackageCount)
 
-	// Test does not change zero values
-	zeroValues := Repository{
-		UUID: s.repo.UUID,
-		URL:  s.repo.URL,
+	// Test that it updates zero values but not nil values
+	zeroValues := RepositoryUpdate{
+		UUID:     s.repo.UUID,
+		URL:      &s.repo.URL,
+		Revision: pointy.String(""),
 	}
 
 	err = dao.Update(zeroValues)
@@ -141,11 +142,11 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	assert.NoError(t, err)
 	assert.Equal(t, s.repo.UUID, repo.UUID)
 	assert.Equal(t, s.repo.URL, repo.URL)
-	assert.Equal(t, expected.Revision, repo.Revision)
+	assert.Equal(t, *zeroValues.Revision, repo.Revision)
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionTime.Format("060102"))
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionUpdateTime.Format("060102"))
 	assert.Equal(t, expectedTimestamp.Format("060102"), repo.LastIntrospectionSuccessTime.Format("060102"))
 	assert.Equal(t, expected.LastIntrospectionError, repo.LastIntrospectionError)
-	assert.Equal(t, expected.Status, repo.Status)
-	assert.Equal(t, 123, repo.PackageCount)
+	assert.Equal(t, *expected.PackageCount, repo.PackageCount)
+	assert.Equal(t, *expected.Status, repo.Status)
 }

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -36,7 +36,7 @@ func (m *MockRepositoryDao) FetchForUrl(url string) (error, dao.Repository) {
 	return nil, dao.Repository{}
 }
 
-func (m *MockRepositoryDao) Update(repo dao.Repository) error {
+func (m *MockRepositoryDao) Update(repo dao.RepositoryUpdate) error {
 	args := m.Called(repo)
 	return args.Error(0)
 }

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -96,14 +96,15 @@ func TestIntrospect(t *testing.T) {
 
 	repoUUID := uuid.NewString()
 
-	repo := dao.Repository{
+	expected := dao.Repository{
 		UUID:         repoUUID,
 		URL:          server.URL + "/content",
 		Revision:     revisionNumber,
 		PackageCount: 13,
 	}
+	repoUpdate := RepoToRepoUpdate(expected)
 
-	mockRepoDao.On("Update", repo).Return(nil).Times(1)
+	mockRepoDao.On("Update", repoUpdate).Return(nil).Times(1)
 
 	count, err := Introspect(
 		dao.Repository{
@@ -266,7 +267,7 @@ func TestUpdateIntrospectionStatusMetadata(t *testing.T) {
 			Status:                 givenStatus,
 		}
 		repoResult := updateIntrospectionStatusMetadata(repoIn, givenCount, testCases[i].given.err, &timestamp)
-		assert.Equal(t, expectedStatus, repoResult.Status)
+		assert.Equal(t, expectedStatus, *repoResult.Status)
 		assert.Equal(t, expectedErr, repoResult.LastIntrospectionError)
 		assert.Equal(t, expectedTime, repoResult.LastIntrospectionTime)
 		assert.Equal(t, expectedSuccessTime, repoResult.LastIntrospectionSuccessTime)


### PR DESCRIPTION
Previously, zero values were being used to indicate that a field should not be updated on `dao.Repository`. For example, if `Repository.Revision == ""`, don't update. Theoretically, if a Revision number was actually `""`, this value could not be updated. 

This PR introduces a `RepositoryUpdate` structure that uses pointers for all values. Using this, `nil` indicates "do not update", so that `dao.Repository` can now be updated with zero values.

One way to test this would be to host a local yum repo where you can change the revision number. Try changing it then removing it and you should see it update in the database accordingly, after introspection.