### PR TITLE
Fixes 187: speed up seeds_test

### DIFF
--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -14,9 +14,10 @@ import (
 )
 
 type SeedOptions struct {
-	OrgID    string
-	Arch     *string
-	Versions *[]string
+	OrgID     string
+	BatchSize int
+	Arch      *string
+	Versions  *[]string
 }
 
 const (
@@ -45,6 +46,10 @@ func randomRepositoryRpmArch() string {
 func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) error {
 	var repos []models.Repository
 	var repoConfigurations []models.RepositoryConfiguration
+
+	if options.BatchSize != 0 {
+		db.CreateBatchSize = options.BatchSize
+	}
 
 	for i := 0; i < size; i++ {
 		repo := models.Repository{

--- a/pkg/seeds/seeds_test.go
+++ b/pkg/seeds/seeds_test.go
@@ -9,8 +9,9 @@ func (s *SeedSuite) TestSeedRepositoryConfigurations() {
 	t := s.T()
 	tx := s.tx
 
-	err := SeedRepositoryConfigurations(tx, 1001, SeedOptions{
-		OrgID: RandomOrgId(),
+	err := SeedRepositoryConfigurations(tx, 101, SeedOptions{
+		BatchSize: 100,
+		OrgID:     RandomOrgId(),
 	})
 	assert.Nil(t, err, "Error seeding RepositoryConfigurations")
 }


### PR DESCRIPTION
Currently seed test is the slowest test file, taking over a second.  

Some of this is due to 'batch size' for inserting, and a desire to test a number greater than that.  

This ticket makes the batch size configurable so the seeding can test with a loweramount