### PR TITLE
Fixes 186: Refactor test suites to run individual test files

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,9 +64,10 @@ func Get() *Configuration {
 }
 
 func readConfigFile(v *viper.Viper) {
-	v.SetConfigName("config")
+	v.SetConfigName("config.yaml")
 	v.SetConfigType("yaml")
 	v.AddConfigPath("./configs/")
+	v.AddConfigPath("../../configs/")
 
 	path, set := os.LookupEnv("CONFIG_PATH")
 	if set {

--- a/pkg/dao/repository_config_test.go
+++ b/pkg/dao/repository_config_test.go
@@ -3,16 +3,41 @@ package dao
 import (
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/lib/pq"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type RepositoryConfigSuite struct {
+	*DaoSuite
+}
+
+func (s *RepositoryConfigSuite) SetupTest() {
+	if db.DB == nil {
+		if err := db.Connect(); err != nil {
+			s.FailNow(err.Error())
+		}
+	}
+	s.db = db.DB
+	s.skipDefaultTransactionOld = s.db.SkipDefaultTransaction
+	s.db.SkipDefaultTransaction = false
+	s.tx = s.db.Begin()
+}
+
+func TestRepositoryConfigSuite(t *testing.T) {
+	m := DaoSuite{}
+	r := RepositoryConfigSuite{DaoSuite: &m}
+	suite.Run(t, &r)
+}
 
 func (suite *RepositoryConfigSuite) TestCreate() {
 	name := "Updated"

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -1,46 +1,21 @@
 package dao
 
 import (
-	"log"
-	"os"
-	"testing"
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
-	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-type RepositoryConfigSuite struct {
+type DaoSuite struct {
 	suite.Suite
 	db                        *gorm.DB
 	tx                        *gorm.DB
 	skipDefaultTransactionOld bool
-}
-
-type RpmSuite struct {
-	suite.Suite
-	db                        *gorm.DB
-	tx                        *gorm.DB
-	skipDefaultTransactionOld bool
-	repoConfig                *models.RepositoryConfiguration
-	repo                      *models.Repository
-	repoPrivate               *models.Repository
-}
-
-type RepositorySuite struct {
-	suite.Suite
-	db                        *gorm.DB
-	tx                        *gorm.DB
-	skipDefaultTransactionOld bool
-	repoConfig                *models.RepositoryConfiguration
-	repo                      *models.Repository
-	repoPrivate               *models.Repository
 }
 
 var orgIDTest = seeds.RandomOrgId()
@@ -120,124 +95,8 @@ var repoRpmTest2 = models.Rpm{
 	Checksum: "SHA1:6799a487f8eaf5c6ad6aba43e1dc4503e69e75bd",
 }
 
-//
-// SetUp and TearDown for RepositoryConfigSuite
-//
-
-func (s *RepositoryConfigSuite) SetupTest() {
-	if db.DB == nil {
-		if err := db.Connect(); err != nil {
-			s.FailNow(err.Error())
-		}
-	}
-	s.db = db.DB
-	s.skipDefaultTransactionOld = s.db.SkipDefaultTransaction
-	s.db.SkipDefaultTransaction = false
-	s.tx = s.db.Begin()
-}
-
-func (s *RepositoryConfigSuite) TearDownTest() {
-	s.tx.Rollback()
-	s.db.SkipDefaultTransaction = s.skipDefaultTransactionOld
-}
-
-//
-// SetUp and TearDown for RpmSuite
-//
-
-func (s *RpmSuite) SetupTest() {
-	if db.DB == nil {
-		if err := db.Connect(); err != nil {
-			s.FailNow(err.Error())
-		}
-	}
-	s.db = db.DB.Session(&gorm.Session{
-		SkipDefaultTransaction: false,
-	})
-	s.tx = s.db.Begin()
-
-	repo := repoPublicTest.DeepCopy()
-	if err := s.tx.Create(repo).Error; err != nil {
-		s.FailNow("Preparing Repository record: %w", err)
-	}
-	s.repo = repo
-
-	repoPrivate := repoPrivateTest.DeepCopy()
-	if err := s.tx.Create(repoPrivate).Error; err != nil {
-		s.FailNow("Preparing private Repository record: %w", err)
-	}
-	s.repoPrivate = repoPrivate
-
-	repoConfig := repoConfigTest1.DeepCopy()
-	repoConfig.RepositoryUUID = repo.Base.UUID
-	if err := s.tx.Create(repoConfig).Error; err != nil {
-		s.FailNow("Preparing RepositoryConfiguration record: %w", err)
-	}
-	s.repoConfig = repoConfig
-}
-
-func (s *RpmSuite) TearDownTest() {
+func (s *DaoSuite) TearDownTest() {
 	//Rollback and reset db.DB
 	s.tx.Rollback()
 	s.db.SkipDefaultTransaction = s.skipDefaultTransactionOld
-}
-
-//
-// SetUp and TearDown for RepositoryRpmSuite
-//
-func (s *RepositorySuite) SetupTest() {
-	if db.DB == nil {
-		if err := db.Connect(); err != nil {
-			s.FailNow(err.Error())
-		}
-	}
-	s.db = db.DB.Session(&gorm.Session{
-		SkipDefaultTransaction: false,
-		Logger: logger.New(
-			log.New(os.Stderr, "\r\n", log.LstdFlags),
-			logger.Config{
-				LogLevel: logger.Info,
-			}),
-	})
-	s.tx = s.db.Begin()
-
-	repo := repoPublicTest.DeepCopy()
-	if err := s.tx.Create(repo).Error; err != nil {
-		s.FailNow("Preparing Repository record UUID=" + repo.UUID)
-	}
-	s.repo = repo
-
-	repoConfig := repoConfigTest1.DeepCopy()
-	repoConfig.RepositoryUUID = repo.Base.UUID
-	if err := s.tx.Create(repoConfig).Error; err != nil {
-		s.FailNow("Preparing RepositoryConfiguration record UUID=" + repoConfig.UUID)
-	}
-	s.repoConfig = repoConfig
-
-	repoPrivate := repoPrivateTest.DeepCopy()
-	if err := s.tx.Create(&repoPrivate).Error; err != nil {
-		s.FailNow(err.Error())
-	}
-	s.repoPrivate = repoPrivate
-}
-
-func (s *RepositorySuite) TearDownTest() {
-	//Rollback and reset db.DB
-	s.tx.Rollback()
-	s.db.SkipDefaultTransaction = s.skipDefaultTransactionOld
-}
-
-//
-// TestDaoSuite Launch all the test suites for dao package
-//
-func TestRepositoryConfigSuite(t *testing.T) {
-	suite.Run(t, new(RepositoryConfigSuite))
-}
-
-func TestRpmSuite(t *testing.T) {
-	suite.Run(t, new(RpmSuite))
-}
-
-func TestRepositorySuite(t *testing.T) {
-	suite.Run(t, new(RepositorySuite))
 }

--- a/pkg/external_repos/store_test.go
+++ b/pkg/external_repos/store_test.go
@@ -1,6 +1,15 @@
 package external_repos
 
-import "github.com/stretchr/testify/assert"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestExternalRepoSuite(t *testing.T) {
+	suite.Run(t, new(ExternalRepoSuite))
+}
 
 func (s *ExternalRepoSuite) TestLoadFromFile() {
 	extRepos, error := LoadFromFile()

--- a/pkg/external_repos/suite_test.go
+++ b/pkg/external_repos/suite_test.go
@@ -1,8 +1,6 @@
 package external_repos
 
 import (
-	"testing"
-
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -30,8 +28,4 @@ func (s *ExternalRepoSuite) SetupTest() {
 func (s *ExternalRepoSuite) TearDownTest() {
 	s.tx.Rollback()
 	s.db.SkipDefaultTransaction = s.skipDefaultTransactionOld
-}
-
-func TestExternalRepoSuite(t *testing.T) {
-	suite.Run(t, new(ExternalRepoSuite))
 }

--- a/pkg/models/repository_configuration_test.go
+++ b/pkg/models/repository_configuration_test.go
@@ -2,14 +2,26 @@ package models
 
 import (
 	"strings"
+	"testing"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/lib/pq"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func smallRepo(suite *ModelsSuite) Repository {
+type RepositoryConfigSuite struct {
+	*ModelsSuite
+}
+
+func TestRepositoryConfigSuite(t *testing.T) {
+	m := ModelsSuite{}
+	r := RepositoryConfigSuite{&m}
+	suite.Run(t, &r)
+}
+
+func smallRepo(suite *RepositoryConfigSuite) Repository {
 	tx := suite.tx
 	t := suite.T()
 
@@ -21,7 +33,7 @@ func smallRepo(suite *ModelsSuite) Repository {
 	return repo
 }
 
-func (suite *ModelsSuite) TestRepositoryConfigurationCreate() {
+func (suite *RepositoryConfigSuite) TestRepositoryConfigurationCreate() {
 	var err error
 	tx := suite.tx
 	t := suite.T()
@@ -50,7 +62,7 @@ func (suite *ModelsSuite) TestRepositoryConfigurationCreate() {
 	assert.Equal(t, repoConfig.RepositoryUUID, found.RepositoryUUID)
 }
 
-func (suite *ModelsSuite) TestCreateInvalidVersion() {
+func (suite *RepositoryConfigSuite) TestCreateInvalidVersion() {
 	var repoConfig = RepositoryConfiguration{
 		Name:           "foo",
 		AccountID:      "1",
@@ -63,7 +75,7 @@ func (suite *ModelsSuite) TestCreateInvalidVersion() {
 	assert.True(suite.T(), strings.Contains(res.Error.Error(), "version"))
 }
 
-func (suite *ModelsSuite) TestCreateVersionWithAnyAndOther() {
+func (suite *RepositoryConfigSuite) TestCreateVersionWithAnyAndOther() {
 	var repoConfig = RepositoryConfiguration{
 		Name:           "foo",
 		AccountID:      "1",
@@ -76,7 +88,7 @@ func (suite *ModelsSuite) TestCreateVersionWithAnyAndOther() {
 	assert.True(suite.T(), strings.Contains(res.Error.Error(), "version"))
 }
 
-func (suite *ModelsSuite) TestCreateVersionWithEmptyArrayAndBlankArch() {
+func (suite *RepositoryConfigSuite) TestCreateVersionWithEmptyArrayAndBlankArch() {
 	var repoConfig = RepositoryConfiguration{
 		Name:           "foo",
 		AccountID:      "1",
@@ -92,7 +104,7 @@ func (suite *ModelsSuite) TestCreateVersionWithEmptyArrayAndBlankArch() {
 	assert.Equal(suite.T(), repoConfig.Arch, config.ANY_ARCH)
 }
 
-func (suite *ModelsSuite) TestCreateDuplicateVersion() {
+func (suite *RepositoryConfigSuite) TestCreateDuplicateVersion() {
 	var repoConfig = RepositoryConfiguration{
 		Name:           "duplicateVersions",
 		AccountID:      "1",
@@ -113,7 +125,7 @@ func (suite *ModelsSuite) TestCreateDuplicateVersion() {
 	assert.Equal(suite.T(), pq.StringArray{config.El7, config.El8, config.El9}, found.Versions)
 }
 
-func (suite *ModelsSuite) TestCreateInvalidArch() {
+func (suite *RepositoryConfigSuite) TestCreateInvalidArch() {
 	var repoConfig = RepositoryConfiguration{
 		Name:           "foo",
 		AccountID:      "1",

--- a/pkg/models/repository_rpm_test.go
+++ b/pkg/models/repository_rpm_test.go
@@ -1,8 +1,19 @@
 package models
 
-import "github.com/stretchr/testify/assert"
+import (
+	"testing"
 
-func (s *ModelsSuite) TestRepositoriesRpmsValidations() {
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestRepositoryRpmSuite(t *testing.T) {
+	m := ModelsSuite{}
+	r := RepositoryRpmSuite{&m}
+	suite.Run(t, &r)
+}
+
+func (s *RepositoryRpmSuite) TestRepositoriesRpmsValidations() {
 	t := s.T()
 	tx := s.tx
 

--- a/pkg/models/repository_test.go
+++ b/pkg/models/repository_test.go
@@ -1,12 +1,24 @@
 package models
 
 import (
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *ModelsSuite) TestRepositoriesCreate() {
+type RepositorySuite struct {
+	*ModelsSuite
+}
+
+func TestRepositorySuite(t *testing.T) {
+	m := ModelsSuite{}
+	r := RepositorySuite{&m}
+	suite.Run(t, &r)
+}
+
+func (s *RepositorySuite) TestRepositoriesCreate() {
 	var now = time.Now()
 	var repo = Repository{
 		URL:                    "https://example.com",

--- a/pkg/models/rpm_test.go
+++ b/pkg/models/rpm_test.go
@@ -1,12 +1,24 @@
 package models
 
 import (
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *ModelsSuite) TestRpmCreate() {
+type RpmSuite struct {
+	*ModelsSuite
+}
+
+func TestRpmSuite(t *testing.T) {
+	m := ModelsSuite{}
+	r := RpmSuite{&m}
+	suite.Run(t, &r)
+}
+
+func (s *RpmSuite) TestRpmCreate() {
 	t := s.T()
 	tx := s.tx
 
@@ -58,7 +70,7 @@ func (s *ModelsSuite) TestRpmCreate() {
 	assert.Equal(t, rpm.Epoch, found.Epoch)
 }
 
-func (s *ModelsSuite) TestRpmUpdate() {
+func (s *RpmSuite) TestRpmUpdate() {
 	t := s.T()
 	tx := s.tx
 
@@ -116,7 +128,7 @@ func (s *ModelsSuite) TestRpmUpdate() {
 	assert.Equal(t, repoRpm.Epoch, found.Epoch)
 }
 
-func (s *ModelsSuite) TestRpmDelete() {
+func (s *RpmSuite) TestRpmDelete() {
 	t := s.T()
 	tx := s.tx
 
@@ -163,7 +175,7 @@ func (s *ModelsSuite) TestRpmDelete() {
 	assert.Equal(t, "record not found", err.Error())
 }
 
-func (t *ModelsSuite) TestRpmDeepCopy() {
+func (t *RpmSuite) TestRpmDeepCopy() {
 	copy := rpmTest1.DeepCopy()
 
 	assert.NotNil(t.T(), copy)
@@ -180,7 +192,7 @@ func (t *ModelsSuite) TestRpmDeepCopy() {
 	assert.Equal(t.T(), copy.Summary, rpmTest1.Summary)
 }
 
-func (s *ModelsSuite) TestRpmValidations() {
+func (s *RpmSuite) TestRpmValidations() {
 	t := s.T()
 	tx := s.tx
 

--- a/pkg/models/suite_test.go
+++ b/pkg/models/suite_test.go
@@ -19,6 +19,10 @@ type ModelsSuite struct {
 	tx *gorm.DB
 }
 
+type RepositoryRpmSuite struct {
+	*ModelsSuite
+}
+
 // Not using seeds.RandomOrgId to avoid cycle dependency
 var orgIDTest = strconv.Itoa(rand.Intn(99999999))
 var accountIdTest = strconv.Itoa(rand.Intn(99999999))
@@ -67,6 +71,6 @@ func (s *ModelsSuite) TearDownTest() {
 	s.tx.Rollback()
 }
 
-func TestRunSuiteModels(t *testing.T) {
+func TestModelsSuite(t *testing.T) {
 	suite.Run(t, new(ModelsSuite))
 }

--- a/pkg/seeds/seeds_test.go
+++ b/pkg/seeds/seeds_test.go
@@ -1,9 +1,17 @@
 package seeds
 
 import (
+	"testing"
+
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
+
+// TestSeedSuite Launch the test suite
+func TestSeedSuite(t *testing.T) {
+	suite.Run(t, new(SeedSuite))
+}
 
 func (s *SeedSuite) TestSeedRepositoryConfigurations() {
 	t := s.T()

--- a/pkg/seeds/suite_test.go
+++ b/pkg/seeds/suite_test.go
@@ -1,8 +1,6 @@
 package seeds
 
 import (
-	"testing"
-
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -36,9 +34,4 @@ func (s *SeedSuite) SetupTest() {
 // TearDownTest Clean up the unit test
 func (s *SeedSuite) TearDownTest() {
 	s.tx.Rollback()
-}
-
-// TestSeedSuite Launch the test suite
-func TestSeedSuite(t *testing.T) {
-	suite.Run(t, new(SeedSuite))
 }


### PR DESCRIPTION
This PR makes it possible (in GoLand) to right-click on a testify-suite-using test file like `dao/repository_config.go`, click "Run", and only run the tests in that file.

This PR should get a review from both a GoLand user and a VSCode user. I'm not sure how it affects VSCode.

Also, I refactored the dao test suite to embedded a new `DaoSuite` type, which deduplicates some code. I did the same thing in the models test suite, but it's a more obvious change there.