### PR TITLE
Fixes 202: Log info and debug requests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,7 +168,7 @@ func ConfigureLogging() {
 	if Get().Logging.Console {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
-	log.Logger.Level(level)
+	log.Logger = log.Logger.Level(level)
 	zerolog.SetGlobalLevel(level)
 	zerolog.DefaultContextLogger = &log.Logger
 }


### PR DESCRIPTION
Now when a successful request is made, there should be "debug" and/or "info" logs in the console. Previously, only errors were logged.