### PR TITLE
Fixes 212: Add sort/search to rpm List

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -88,6 +88,12 @@ const docTemplate = `{
                         "description": "Filter repositories by name using an exact match",
                         "name": "url",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sets the sort order of the results.",
+                        "name": "sort_by",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -342,6 +348,30 @@ const docTemplate = `{
                         "name": "uuid",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit the number of items returned",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset into the list of results to return in the response",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term for name.",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sets the sort order of the results.",
+                        "name": "sort_by",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -509,6 +509,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Sets the sort order of the results.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -769,6 +777,38 @@
                         "in": "path",
                         "name": "uuid",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Limit the number of items returned",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Offset into the list of results to return in the response",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Search term for name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sets the sort order of the results.",
+                        "in": "query",
+                        "name": "sort_by",
                         "schema": {
                             "type": "string"
                         }

--- a/pkg/api/repository_rpm.go
+++ b/pkg/api/repository_rpm.go
@@ -17,6 +17,12 @@ type RepositoryRpmCollectionResponse struct {
 	Links Links            `json:"links"` // Links to other pages of results
 }
 
+type RepositoryRpmRequest struct {
+	UUID   string `param:"uuid"`    // Identifier of the repository
+	Search string `query:"search"`  // Search string based query to optionally filter-on
+	SortBy string `query:"sort_by"` // SortBy sets the sort order of the result
+}
+
 type SearchRpmRequest struct {
 	URLs   []string `json:"urls,omitempty"`  // URLs of repositories to search
 	UUIDs  []string `json:"uuids,omitempty"` // List of RepositoryConfig UUIDs to search

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -1,0 +1,40 @@
+package dao
+
+import "strings"
+
+func convertSortByToSQL(SortBy string, SortMap map[string]string) string {
+	sqlOrderBy := ""
+
+	sortByArray := strings.Split(SortBy, ",")
+	lengthOfSortByParams := len(sortByArray)
+
+	for i := 0; i < lengthOfSortByParams; i++ {
+		sortBy := sortByArray[i]
+
+		split := strings.Split(sortBy, ":")
+		ascOrDesc := " asc"
+
+		if len(split) > 1 && split[1] == "desc" {
+			ascOrDesc = " desc"
+		}
+
+		sortField, ok := SortMap[strings.TrimSpace(split[0])]
+
+		// Only update if the SortMap above returns a valid value
+		if ok {
+			// Concatenate (e.g. "url desc," + "name" + " asc")
+			sqlOrderBy = sqlOrderBy + sortField + ascOrDesc
+
+			// Add a comma if this isn't the last item in the "sortByArray".
+			if i+1 < lengthOfSortByParams {
+				sqlOrderBy = sqlOrderBy + ", "
+			}
+		}
+	}
+
+	if sqlOrderBy == "" {
+		sqlOrderBy = "name asc"
+	}
+
+	return sqlOrderBy
+}

--- a/pkg/dao/helpers_test.go
+++ b/pkg/dao/helpers_test.go
@@ -1,0 +1,37 @@
+package dao
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *RepositorySuite) TestConvertSortByToSQL() {
+	t := s.T()
+
+	sortMap := map[string]string{
+		"name":          "name",
+		"url":           "url",
+		"package_count": "banana",
+		"status":        "status",
+	}
+
+	asc := ":asc"
+	desc := ":desc"
+
+	result := convertSortByToSQL("name", sortMap)
+	assert.Equal(t, "name asc", result)
+
+	result = convertSortByToSQL("notInSortMap", sortMap)
+	assert.Equal(t, "name asc", result)
+
+	result = convertSortByToSQL("url"+asc, sortMap)
+	assert.Equal(t, "url asc", result)
+
+	result = convertSortByToSQL("package_count", sortMap)
+	assert.Equal(t, "banana asc", result)
+
+	result = convertSortByToSQL("status"+desc, sortMap)
+	assert.Equal(t, "status desc", result)
+
+	result = convertSortByToSQL(" status , name:desc", sortMap)
+	assert.Equal(t, "status asc, name desc", result)
+}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -17,7 +17,7 @@ type RepositoryConfigDao interface {
 }
 
 type RpmDao interface {
-	List(orgID string, uuidRepo string, limit int, offset int) (api.RepositoryRpmCollectionResponse, int64, error)
+	List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryRpmCollectionResponse, int64, error)
 	Search(orgID string, request api.SearchRpmRequest, limit int) ([]api.SearchRpmResponse, error)
 	InsertForRepository(repoUuid string, pkgs []yum.Package) (int64, error)
 	OrphanCleanup() error

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -96,10 +96,25 @@ func (s *RpmSuite) TestRpmList() {
 
 	var repoRpmList api.RepositoryRpmCollectionResponse
 	var count int64
-	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0)
+	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0, "", "")
 	assert.NoError(t, err)
 	assert.Equal(t, count, int64(2))
 	assert.Equal(t, repoRpmList.Meta.Count, count)
+	assert.Equal(t, repoRpmList.Data[0].Name, repoRpmTest2.Name) // Asserts name:asc by default
+
+	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0, "test-package", "")
+	assert.NoError(t, err)
+	assert.Equal(t, count, int64(1))
+	assert.Equal(t, repoRpmList.Meta.Count, count)
+
+	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0, "", "name:desc")
+	assert.NoError(t, err)
+	assert.Equal(t, count, int64(2))
+	assert.Equal(t, repoRpmList.Data[0].Name, repoRpmTest1.Name) // Asserts name:desc
+
+	repoRpmList, count, err = dao.List(orgIDTest, s.repoConfig.Base.UUID, 0, 0, "non-existing-repo", "")
+	assert.NoError(t, err)
+	assert.Equal(t, count, int64(0))
 }
 
 func (s *RpmSuite) TestRpmSearch() {

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -12,7 +12,7 @@ import (
 type MockRpmDao struct {
 }
 
-func (m MockRpmDao) List(orgID string, uuidRepo string, limit int, offset int) (api.RepositoryRpmCollectionResponse, int64, error) {
+func (m MockRpmDao) List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryRpmCollectionResponse, int64, error) {
 	return api.RepositoryRpmCollectionResponse{}, 0, nil
 }
 

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -52,6 +52,7 @@ func getAccountIdOrgId(c echo.Context) (string, string) {
 // @Param		 search query string false "Search term for name and url."
 // @Param		 name query string false "Filter repositories by name using an exact match"
 // @Param		 url query string false "Filter repositories by name using an exact match"
+// @Param		 sort_by query string false "Sets the sort order of the results."
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.RepositoryCollectionResponse


### PR DESCRIPTION
Adds sort/search functionality to the rpm list endpoint. 

This PR is paired with the front-end PR found [here.](https://github.com/content-services/content-sources-frontend/pull/46)

Still needs: 
- [x] Tests