### PR TITLE
Fixes 207: return 404 when uuid syntax invalid

### DIFF
--- a/pkg/dao/repository_config_test.go
+++ b/pkg/dao/repository_config_test.go
@@ -543,6 +543,12 @@ func (suite *RepositoryConfigSuite) TestFetchNotFound() {
 	daoError, ok := err.(*Error)
 	assert.True(t, ok)
 	assert.True(t, daoError.NotFound)
+
+	_, err = GetRepositoryConfigDao(suite.tx).Fetch(orgID, "bad uuid")
+	assert.NotNil(t, err)
+	daoError, ok = err.(*Error)
+	assert.True(t, ok)
+	assert.True(t, daoError.NotFound)
 }
 
 func (suite *RepositoryConfigSuite) TestList() {


### PR DESCRIPTION
To test:
Make a PUT/PATCH/DELETE request where the UUID has invalid syntax i.e. /repostories/bad-uuid

Previously, the API would return 500 error and complain about invalid UUID syntax. Now, it returns a 404.