### PR TITLE
Fixes 205: Return error as last item

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -24,8 +24,8 @@ type RpmDao interface {
 }
 
 type RepositoryDao interface {
-	FetchForUrl(url string) (error, Repository)
-	List() (error, []Repository)
+	FetchForUrl(url string) (Repository, error)
+	List() ([]Repository, error)
 	Update(repo RepositoryUpdate) error
 }
 

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -43,30 +43,30 @@ type repositoryDaoImpl struct {
 	db *gorm.DB
 }
 
-func (p repositoryDaoImpl) FetchForUrl(url string) (error, Repository) {
+func (p repositoryDaoImpl) FetchForUrl(url string) (Repository, error) {
 	repo := models.Repository{}
 	internalRepo := Repository{}
 	result := p.db.Where("URL = ?", url).Order("url asc").First(&repo)
 	if result.Error != nil {
-		return result.Error, Repository{}
+		return Repository{}, result.Error
 	}
 	modelToInternal(repo, &internalRepo)
-	return nil, internalRepo
+	return internalRepo, nil
 }
 
-func (p repositoryDaoImpl) List() (error, []Repository) {
+func (p repositoryDaoImpl) List() ([]Repository, error) {
 	var dbRepos []models.Repository
 	var repos []Repository
 	var repo Repository
 	result := p.db.Find(&dbRepos)
 	if result.Error != nil {
-		return result.Error, repos
+		return repos, result.Error
 	}
 	for i := 0; i < len(dbRepos); i++ {
 		modelToInternal(dbRepos[i], &repo)
 		repos = append(repos, repo)
 	}
-	return nil, repos
+	return repos, nil
 }
 
 func (p repositoryDaoImpl) Update(repoIn RepositoryUpdate) error {

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -76,7 +76,7 @@ func (s *RepositorySuite) TestFetchForUrl() {
 
 	urlPublic := s.repo.URL
 	dao := GetRepositoryDao(tx)
-	err, repo = dao.FetchForUrl(urlPublic)
+	repo, err = dao.FetchForUrl(urlPublic)
 	assert.NoError(t, err)
 	assert.Equal(t, Repository{
 		UUID:                         s.repo.UUID,
@@ -90,7 +90,7 @@ func (s *RepositorySuite) TestFetchForUrl() {
 	}, repo)
 
 	urlPrivate := s.repoPrivate.URL
-	err, repo = dao.FetchForUrl(urlPrivate)
+	repo, err = dao.FetchForUrl(urlPrivate)
 	assert.NoError(t, err)
 	assert.Equal(t, Repository{
 		UUID:                         s.repoPrivate.UUID,
@@ -104,7 +104,7 @@ func (s *RepositorySuite) TestFetchForUrl() {
 	}, repo)
 
 	url := "https://it-does-not-exist.com/base"
-	err, repo = dao.FetchForUrl(url)
+	repo, err = dao.FetchForUrl(url)
 	assert.Error(t, err)
 	assert.Equal(t, Repository{
 		UUID: "",
@@ -128,7 +128,7 @@ func (s *RepositorySuite) TestList() {
 	}
 
 	dao := GetRepositoryDao(tx)
-	err, repoList := dao.List()
+	repoList, err := dao.List()
 	assert.NoError(t, err)
 	assert.Contains(t, repoList, expected)
 }
@@ -143,7 +143,7 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	)
 
 	dao := GetRepositoryDao(tx)
-	err, repo = dao.FetchForUrl(s.repo.URL)
+	repo, err = dao.FetchForUrl(s.repo.URL)
 	assert.NoError(t, err)
 
 	assert.Equal(t, Repository{
@@ -173,7 +173,7 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	err = dao.Update(expected)
 	assert.NoError(t, err)
 
-	err, repo = dao.FetchForUrl(s.repo.URL)
+	repo, err = dao.FetchForUrl(s.repo.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.UUID, repo.UUID)
 	assert.Equal(t, *expected.URL, repo.URL)
@@ -195,7 +195,7 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	err = dao.Update(zeroValues)
 	assert.NoError(t, err)
 
-	err, repo = dao.FetchForUrl(s.repo.URL)
+	repo, err = dao.FetchForUrl(s.repo.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, s.repo.UUID, repo.UUID)
 	assert.Equal(t, s.repo.URL, repo.URL)

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -28,7 +28,7 @@ func IntrospectUrl(url string, force bool) (int64, []error) {
 	var errs []error
 	rpmDao := dao.GetRpmDao(db.DB, nil)
 	repoDao := dao.GetRepositoryDao(db.DB)
-	err, repo := repoDao.FetchForUrl(url)
+	repo, err := repoDao.FetchForUrl(url)
 	if err != nil {
 		return 0, []error{err}
 	}
@@ -109,7 +109,7 @@ func IntrospectAll(force bool) (int64, []error) {
 	var count int64
 	rpmDao := dao.GetRpmDao(db.DB, nil)
 	repoDao := dao.GetRepositoryDao(db.DB)
-	err, repos := repoDao.List()
+	repos, err := repoDao.List()
 
 	if err != nil {
 		return 0, []error{err}

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -28,12 +28,12 @@ type MockRepositoryDao struct {
 	mock.Mock
 }
 
-func (m *MockRepositoryDao) List() (error, []dao.Repository) {
-	return nil, []dao.Repository{}
+func (m *MockRepositoryDao) List() ([]dao.Repository, error) {
+	return []dao.Repository{}, nil
 }
 
-func (m *MockRepositoryDao) FetchForUrl(url string) (error, dao.Repository) {
-	return nil, dao.Repository{}
+func (m *MockRepositoryDao) FetchForUrl(url string) (dao.Repository, error) {
+	return dao.Repository{}, nil
 }
 
 func (m *MockRepositoryDao) Update(repo dao.RepositoryUpdate) error {


### PR DESCRIPTION
Update functions and methods to align with return error type as the last item for tuple returns.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>