### PR TITLE
Fixes 247: Fix unit test TestFetchForUrl

### DIFF
--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -93,7 +93,7 @@ func (s *RepositorySuite) TestFetchForUrl() {
 	// Trim the trailing slash, and verify we still find the repo
 	noSlashUrl := strings.TrimSuffix(urlPublic, "/")
 	assert.NotEqual(t, noSlashUrl, urlPublic)
-	err, repo = dao.FetchForUrl(noSlashUrl)
+	repo, err = dao.FetchForUrl(noSlashUrl)
 	assert.NoError(t, err)
 	assert.Equal(t, s.repo.UUID, repo.UUID)
 


### PR DESCRIPTION
- Fix a typecheck error in the unit tests.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>