### PR TITLE
Fixes 242: set minReplicas to 3

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -15,7 +15,7 @@ objects:
       dependencies: []
       deployments:
         - name: service
-          minReplicas: 1
+          minReplicas: 3
           webServices:
             public:
               enabled: true

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -15,7 +15,12 @@ objects:
       dependencies: []
       deployments:
         - name: service
+          # NOTE minReplicas is deprecated, but not sure if this change exist further
+          # than the ephemeral environment. When both values exist, replicas has
+          # priority over minReplicas
+          # https://github.com/RedHatInsights/clowder/commit/aaf5643a7b1e769b53768e7c1a446d348d0a71f4
           minReplicas: 3
+          replicas: 3
           webServices:
             public:
               enabled: true


### PR DESCRIPTION
- set `minReplicas` to 3
- add new `replicas` field with the same value.
- add note to delete `minReplicas` when the new field is available in all the environments.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>