### PR TITLE
Fixes 264: fix TestValidateMessage unit test

### DIFF
--- a/pkg/event/schema/schemas_test.go
+++ b/pkg/event/schema/schemas_test.go
@@ -309,10 +309,10 @@ func TestValidateMessage(t *testing.T) {
 					TopicPartition: kafka.TopicPartition{
 						Topic: pointy.String(TopicIntrospect),
 					},
-					Value: []byte(`{}`),
+					Value: []byte(`{"url":"https://example.com"}`),
 				},
 			},
-			Expected: fmt.Errorf("error validating schema: \"uuid\" value is required: / = map[], \"url\" value is required: / = map[]"),
+			Expected: fmt.Errorf("error validating schema: \"uuid\" value is required: / = map[url:https://example.com]"),
 		},
 		{
 			Name: "force error when message content fails validation",


### PR DESCRIPTION
- This change make the unit test deterministic, avoiding multiple error messages for the validation.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>