### PR TITLE
Fixes 206: Remove /api/content-sources/v*/ping endpoint

### DIFF
--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -68,7 +68,6 @@ func RegisterRoutes(engine *echo.Echo) {
 	}
 	for i := 0; i < len(paths); i++ {
 		group := engine.Group(paths[i])
-		group.GET("/ping", ping)
 		group.GET("/openapi.json", openapi)
 
 		daoRepo := dao.GetRepositoryConfigDao(db.DB)

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func serveRouter(req *http.Request) (int, []byte, error) {
@@ -36,14 +37,14 @@ func TestPing(t *testing.T) {
 	assert.Equal(t, expected, string(body))
 }
 
-func TestPingV1(t *testing.T) {
+func TestPingV1IsNotAvailable(t *testing.T) {
 	print(fullRootPath() + "/ping")
 	req, _ := http.NewRequest("GET", majorRootPath()+"/ping", nil)
 	code, body, err := serveRouter(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, code)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
 
-	expected := "{\"message\":\"pong\"}\n"
+	expected := "{\"message\":\"Not Found\"}\n"
 	assert.Equal(t, expected, string(body))
 }
 


### PR DESCRIPTION
- Update code to remove /api/content-sources/v*/ping endpoint
- Update unit test to verify the endpoint return a 404 Not Found error.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>