### PR TITLE
Refs 264: Fix one missed case in the unit test

### DIFF
--- a/pkg/event/schema/schemas_test.go
+++ b/pkg/event/schema/schemas_test.go
@@ -329,12 +329,12 @@ func TestValidateMessage(t *testing.T) {
 						Topic: pointy.String(TopicIntrospect),
 					},
 					Value: []byte(`{
-						"uuid":"",
+						"uuid":"de1a6cd4-5b76-11ed-9863-482ae3863d30",
 						"url":""
 					}`),
 				},
 			},
-			Expected: fmt.Errorf("error validating schema: min length of 36 characters required: : /uuid = , min length of 10 characters required: : /url = , invalid uri: uri missing scheme prefix: /url = "),
+			Expected: fmt.Errorf("error validating schema: min length of 10 characters required: : /url = , invalid uri: uri missing scheme prefix: /url = "),
 		},
 		// Validate bytes return true
 		{


### PR DESCRIPTION
- fix test "force error when message content fails validation", it was providing
  two errors which order is not deterministic; this change fix that providing only
  one failure, making the result deterministic.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>