### PR TITLE
Fixes 266: use gorm config for batch creation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ type Options struct {
 }
 
 const (
-	DefaultPagedRpmInsertsLimit = 200
+	DefaultPagedRpmInsertsLimit = 500
 )
 
 var LoadedConfig Configuration
@@ -135,12 +135,12 @@ func Load() {
 
 const RhCertEnv = "RH_CDN_CERT_PAIR"
 
-// ConfigureCertificate loads in a cert keypair
-//
-//	from either, an environment variable if specified, or a file path
-//	if no certificate is specified, we return no error
-//	however if a certificate is specified but cannot be loaded
-//	an error is returned.
+// ConfigureCertificate loads in a cert keypair from either, an
+// environment variable if specified, or a file path
+// if no certificate is specified, we return no error
+// however if a certificate is specified but cannot be loaded
+// an error is returned.
+>>>>>>> 9f35dd3 (Fixes 266: use gorm config for batch creation)
 func ConfigureCertificate() (*tls.Certificate, error) {
 	var (
 		err       error

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,7 +140,6 @@ const RhCertEnv = "RH_CDN_CERT_PAIR"
 // if no certificate is specified, we return no error
 // however if a certificate is specified but cannot be loaded
 // an error is returned.
->>>>>>> 9f35dd3 (Fixes 266: use gorm config for batch creation)
 func ConfigureCertificate() (*tls.Certificate, error) {
 	var (
 		err       error

--- a/pkg/dao/rpm.go
+++ b/pkg/dao/rpm.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
-	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/yummy/pkg/yum"
 	"gorm.io/gorm"
@@ -13,8 +12,7 @@ import (
 )
 
 type rpmDaoImpl struct {
-	db                   *gorm.DB
-	pagedRpmInsertsLimit int
+	db *gorm.DB
 }
 
 type RpmDaoOptions struct {
@@ -22,27 +20,9 @@ type RpmDaoOptions struct {
 }
 
 func GetRpmDao(db *gorm.DB, options *RpmDaoOptions) RpmDao {
-	var (
-		pagedRpmInsertsLimit int = config.DefaultPagedRpmInsertsLimit
-	)
-
-	// Read pagedRpmInsertsLimit option
-	{
-		var value int
-		if options != nil && options.PagedRpmInsertsLimit != nil {
-			value = *options.PagedRpmInsertsLimit
-		} else {
-			value = config.Get().Options.PagedRpmInsertsLimit
-		}
-		if value > 0 {
-			pagedRpmInsertsLimit = value
-		}
-	}
-
 	// Return DAO instance
 	return rpmDaoImpl{
-		db:                   db,
-		pagedRpmInsertsLimit: pagedRpmInsertsLimit,
+		db: db,
 	}
 }
 
@@ -221,31 +201,6 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest, limit int
 	return dataResponse, nil
 }
 
-// PagedRpmInsert insert all passed in rpms quickly, ignoring any duplicates
-func (r rpmDaoImpl) PagedRpmInsert(pkgs *[]models.Rpm) error {
-	chunk := r.pagedRpmInsertsLimit
-	var result *gorm.DB
-	if len(*pkgs) == 0 {
-		return nil
-	}
-
-	for i := 0; i < len(*pkgs); i += chunk {
-		end := i + chunk
-		if i+chunk > len(*pkgs) {
-			end = len(*pkgs)
-		}
-		result = r.db.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "checksum"}},
-			DoNothing: true,
-		}).Create((*pkgs)[i:end])
-
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-	return result.Error
-}
-
 func (r rpmDaoImpl) fetchRepo(uuid string) (models.Repository, error) {
 	found := models.Repository{}
 	if err := r.db.
@@ -258,9 +213,9 @@ func (r rpmDaoImpl) fetchRepo(uuid string) (models.Repository, error) {
 }
 
 // InsertForRepository inserts a set of yum packages for a given repository
-//   and removes any that are not in the list.  This will involve inserting the RPMs
-//   if not present, and adding or removing any associations to the Repository
-//   Returns a count of new RPMs added to the system (not the repo), as well as any error
+// and removes any that are not in the list.  This will involve inserting the RPMs
+// if not present, and adding or removing any associations to the Repository
+// Returns a count of new RPMs added to the system (not the repo), as well as any error
 func (r rpmDaoImpl) InsertForRepository(repoUuid string, pkgs []yum.Package) (int64, error) {
 	var (
 		err               error
@@ -293,7 +248,11 @@ func (r rpmDaoImpl) InsertForRepository(repoUuid string, pkgs []yum.Package) (in
 	dbPkgs := FilteredConvert(pkgs, existingChecksums)
 
 	// Insert the filtered packages in rpms table
-	if err = r.PagedRpmInsert(&dbPkgs); err != nil {
+	result := r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "checksum"}},
+		DoNothing: true,
+	}).Create(dbPkgs)
+	if result.Error != nil {
 		return 0, fmt.Errorf("failed to PagedRpmInsert: %w", err)
 	}
 
@@ -313,7 +272,7 @@ func (r rpmDaoImpl) InsertForRepository(repoUuid string, pkgs []yum.Package) (in
 
 	// Add the RepositoryRpm entries we do need
 	associations := prepRepositoryRpms(repo, rpmUuids)
-	result := r.db.Clauses(clause.OnConflict{
+	result = r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "repository_uuid"}, {Name: "rpm_uuid"}},
 		DoNothing: true}).
 		Create(&associations)
@@ -351,7 +310,7 @@ func difference(a, b []string) []string {
 
 // deleteUnneeded Removes any RepositoryRpm entries that are not in the list of rpm_uuids
 func (r rpmDaoImpl) deleteUnneeded(repo models.Repository, rpm_uuids []string) error {
-	//First get uuids that are there:
+	// First get uuids that are there:
 	var (
 		existing_rpm_uuids []string
 	)
@@ -417,7 +376,7 @@ func stringInSlice(a string, list []string) bool {
 }
 
 // FilteredConvert Given a list of yum.Package objects, it converts them to model.Rpm packages
-//	while filtering out any checksums that are in the excludedChecksums parameter
+// while filtering out any checksums that are in the excludedChecksums parameter
 func FilteredConvert(yumPkgs []yum.Package, excludeChecksums []string) []models.Rpm {
 	var dbPkgs []models.Rpm
 	for _, yumPkg := range yumPkgs {

--- a/pkg/dao/rpm.go
+++ b/pkg/dao/rpm.go
@@ -15,11 +15,7 @@ type rpmDaoImpl struct {
 	db *gorm.DB
 }
 
-type RpmDaoOptions struct {
-	PagedRpmInsertsLimit *int
-}
-
-func GetRpmDao(db *gorm.DB, options *RpmDaoOptions) RpmDao {
+func GetRpmDao(db *gorm.DB) RpmDao {
 	// Return DAO instance
 	return rpmDaoImpl{
 		db: db,

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/content-services/yummy/pkg/yum"
 	"github.com/google/uuid"
-	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -77,7 +76,7 @@ func (s *RpmSuite) TestRpmList() {
 	// Prepare RepositoryRpm records
 	rpm1 := repoRpmTest1.DeepCopy()
 	rpm2 := repoRpmTest2.DeepCopy()
-	dao := GetRpmDao(s.tx, nil)
+	dao := GetRpmDao(s.tx)
 
 	err = s.tx.Create(&rpm1).Error
 	assert.NoError(t, err)
@@ -367,9 +366,7 @@ func (s *RpmSuite) TestRpmSearch() {
 	}
 
 	// Running all the test cases
-	dao := GetRpmDao(tx, &RpmDaoOptions{
-		PagedRpmInsertsLimit: pointy.Int(100),
-	})
+	dao := GetRpmDao(tx)
 	for ict, caseTest := range testCases {
 		t.Log(caseTest.name)
 		var searchRpmResponse []api.SearchRpmResponse
@@ -476,7 +473,7 @@ func (s *RpmSuite) TestRpmSearchError() {
 	txSP := strings.ToLower("TestRpmSearchError")
 
 	var searchRpmResponse []api.SearchRpmResponse
-	dao := GetRpmDao(tx, nil)
+	dao := GetRpmDao(tx)
 	// We are going to launch database operations that evoke errors, so we need to restore
 	// the state previous to the error to let the test do more actions
 	tx.SavePoint(txSP)
@@ -526,7 +523,7 @@ func (s *RpmSuite) genericInsertForRepository(testCase TestInsertForRepositoryCa
 	t := s.Suite.T()
 	tx := s.tx
 
-	dao := GetRpmDao(tx, &RpmDaoOptions{})
+	dao := GetRpmDao(tx)
 
 	p := s.prepareScenarioRpms(testCase.given, 10)
 	records, err := dao.InsertForRepository(s.repo.Base.UUID, p)
@@ -585,9 +582,7 @@ func (s *RpmSuite) TestInsertForRepositoryWithExistingChecksums() {
 	pagedRpmInsertsLimit := 10
 	groupCount := 5
 
-	dao := GetRpmDao(tx, &RpmDaoOptions{
-		PagedRpmInsertsLimit: pointy.Int(pagedRpmInsertsLimit),
-	})
+	dao := GetRpmDao(tx)
 	p := s.prepareScenarioRpms(scenarioThreshold, pagedRpmInsertsLimit)
 	records, err := dao.InsertForRepository(s.repo.Base.UUID, p[0:groupCount])
 	assert.NoError(t, err)
@@ -626,9 +621,7 @@ func (s *RpmSuite) TestInsertForRepositoryWithWrongRepoUUID() {
 
 	pagedRpmInsertsLimit := 100
 
-	dao := GetRpmDao(tx, &RpmDaoOptions{
-		PagedRpmInsertsLimit: pointy.Int(pagedRpmInsertsLimit),
-	})
+	dao := GetRpmDao(tx)
 	p := s.prepareScenarioRpms(scenario3, pagedRpmInsertsLimit)
 	records, err := dao.InsertForRepository(uuid.NewString(), p)
 
@@ -644,7 +637,7 @@ func (s *RpmSuite) TestOrphanCleanup() {
 
 	// Prepare RepositoryRpm records
 	rpm1 := repoRpmTest1.DeepCopy()
-	dao := GetRpmDao(s.tx, nil)
+	dao := GetRpmDao(s.tx)
 
 	err = s.tx.Create(&rpm1).Error
 	assert.NoError(t, err)
@@ -667,7 +660,7 @@ func (s *RpmSuite) TestOrphanCleanup() {
 func (s *RpmSuite) TestEmptyOrphanCleanup() {
 	var count int64
 	var countAfter int64
-	dao := GetRpmDao(s.tx, nil)
+	dao := GetRpmDao(s.tx)
 	err := dao.OrphanCleanup() // Clear out any existing orphaned rpms in the db
 	assert.NoError(s.T(), err)
 

--- a/pkg/dao/rpm_test.go
+++ b/pkg/dao/rpm_test.go
@@ -438,6 +438,8 @@ func makeYumPackage(size int) []yum.Package {
 }
 
 func (s *RpmSuite) prepareScenarioRpms(scenario int, limit int) []yum.Package {
+	s.db.CreateBatchSize = limit
+
 	switch scenario {
 	case scenario0:
 		{
@@ -500,7 +502,7 @@ type TestInsertForRepositoryCase struct {
 var testCases []TestInsertForRepositoryCase = []TestInsertForRepositoryCase{
 	{
 		given:    scenario0,
-		expected: "empty slice found",
+		expected: "",
 	},
 	{
 		given:    scenario3,
@@ -524,12 +526,9 @@ func (s *RpmSuite) genericInsertForRepository(testCase TestInsertForRepositoryCa
 	t := s.Suite.T()
 	tx := s.tx
 
-	pagedRpmInsertsLimit := 100
-	dao := GetRpmDao(tx, &RpmDaoOptions{
-		PagedRpmInsertsLimit: pointy.Int(pagedRpmInsertsLimit),
-	})
+	dao := GetRpmDao(tx, &RpmDaoOptions{})
 
-	p := s.prepareScenarioRpms(testCase.given, pagedRpmInsertsLimit)
+	p := s.prepareScenarioRpms(testCase.given, 10)
 	records, err := dao.InsertForRepository(s.repo.Base.UUID, p)
 
 	var rpmCount int = 0

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -46,7 +46,7 @@ func Connect() error {
 	var err error
 	dbURL := GetUrl()
 	DB, err = gorm.Open(pg.Open(dbURL), &gorm.Config{Logger: gorm_zerolog.Logger{}})
-
+	DB.CreateBatchSize = config.DefaultPagedRpmInsertsLimit
 	return err
 }
 

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -27,7 +27,7 @@ const (
 //	Returns the number of new RPMs inserted system-wide and any error encountered
 func IntrospectUrl(url string, force bool) (int64, []error) {
 	var errs []error
-	rpmDao := dao.GetRpmDao(db.DB, nil)
+	rpmDao := dao.GetRpmDao(db.DB)
 	repoDao := dao.GetRepositoryDao(db.DB)
 	repo, err := repoDao.FetchForUrl(url)
 	if err != nil {
@@ -109,7 +109,7 @@ func IntrospectAll(force bool) (int64, []error) {
 	var errors []error
 	var total int64
 	var count int64
-	rpmDao := dao.GetRpmDao(db.DB, nil)
+	rpmDao := dao.GetRpmDao(db.DB)
 	repoDao := dao.GetRepositoryDao(db.DB)
 	repos, err := repoDao.List()
 

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -72,7 +72,7 @@ func RegisterRoutes(engine *echo.Echo) {
 		RegisterRepositoryRoutes(group, &daoRepo, &introspectRequest)
 		RegisterRepositoryParameterRoutes(group, &daoRepo, &externalRepo)
 
-		daoRpm := dao.GetRpmDao(db.DB, &dao.RpmDaoOptions{})
+		daoRpm := dao.GetRpmDao(db.DB)
 		RegisterRepositoryRpmRoutes(group, &daoRpm)
 	}
 

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/event/producer"
 	"github.com/labstack/echo/v4"
-	"github.com/openlyinc/pointy"
 	"github.com/rs/zerolog/log"
 )
 
@@ -57,7 +56,6 @@ func RegisterRoutes(engine *echo.Echo) {
 		kafkaProducer     *kafka.Producer
 		introspectRequest producer.IntrospectRequest
 	)
-	pagedRpmInsertsLimit := config.Get().Options.PagedRpmInsertsLimit
 	paths := []string{fullRootPath(), majorRootPath()}
 	if kafkaProducer, err = producer.NewProducer(&config.Get().Kafka); err != nil {
 		panic(err)
@@ -74,9 +72,7 @@ func RegisterRoutes(engine *echo.Echo) {
 		RegisterRepositoryRoutes(group, &daoRepo, &introspectRequest)
 		RegisterRepositoryParameterRoutes(group, &daoRepo, &externalRepo)
 
-		daoRpm := dao.GetRpmDao(db.DB, &dao.RpmDaoOptions{
-			PagedRpmInsertsLimit: pointy.Int(pagedRpmInsertsLimit),
-		})
+		daoRpm := dao.GetRpmDao(db.DB, &dao.RpmDaoOptions{})
 		RegisterRepositoryRpmRoutes(group, &daoRpm)
 	}
 


### PR DESCRIPTION
Gorm has a built in way to batch creations, but we were not using it.  By using it, we can handle all creations, and introspect larger repos that were failing before