### PR TITLE
Refs 283: only select api pods for backend service

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -169,7 +169,7 @@ objects:
           protocol: TCP
           targetPort: 8000
       selector:
-        app: content-sources-backend
+        pod: content-sources-backend-service
       sessionAffinity: None
       type: ClusterIP
     status:


### PR DESCRIPTION
instead of selecting all pods