### PR TITLE
Fixes 286: 404s not logged by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,7 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}/cmd/content-sources",
+            "args": ["api", "consumer"],
             "cwd": "${workspaceFolder}",
             "env": {
                 "CONFIG_PATH": "${workspaceFolder}/configs"

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -73,6 +73,8 @@ objects:
                   secretKeyRef:
                     name: content-sources-certs
                     key: cdn.redhat.com
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -144,6 +146,8 @@ objects:
                   secretKeyRef:
                     name: content-sources-certs
                     key: cdn.redhat.com
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -174,6 +178,8 @@ objects:
                   secretKeyRef:
                     name: content-sources-certs
                     key: cdn.redhat.com
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
       database:
         name: content-sources
         version: 13
@@ -210,3 +216,6 @@ parameters:
     value: 1Gi
   - name: MEMORY_REQUESTS
     value: 100Mi
+  - name: LOGGING_LEVEL
+    value: "info"
+

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -217,5 +217,5 @@ parameters:
   - name: MEMORY_REQUESTS
     value: 100Mi
   - name: LOGGING_LEVEL
-    value: "warn"
+    value: warn
 

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -217,5 +217,5 @@ parameters:
   - name: MEMORY_REQUESTS
     value: 100Mi
   - name: LOGGING_LEVEL
-    value: "info"
+    value: "warn"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,7 @@ func ConfigureLogging() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 	log.Logger = log.Logger.Level(level)
-	zerolog.SetGlobalLevel(level)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	zerolog.DefaultContextLogger = &log.Logger
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,8 +8,10 @@ import (
 
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/event"
+
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
+	echo_middleware "github.com/labstack/echo/v4/middleware"
+	echo_log "github.com/labstack/gommon/log"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	identity "github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/rs/zerolog"
@@ -181,7 +183,7 @@ func ConfigureLogging() {
 }
 
 // WrapMiddleware wraps `func(http.Handler) http.Handler` into `echo.MiddlewareFunc`
-func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip middleware.Skipper) echo.MiddlewareFunc {
+func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_middleware.Skipper) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
 			if skip != nil && skip(c) {
@@ -252,8 +254,9 @@ func ConfigureEcho() *echo.Echo {
 	echoLogger := lecho.From(log.Logger,
 		lecho.WithTimestamp(),
 		lecho.WithCaller(),
+		lecho.WithLevel(echo_log.INFO),
 	)
-	e.Use(middleware.RequestIDWithConfig(middleware.RequestIDConfig{
+	e.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
 		TargetHeader: "x-rh-insights-request-id",
 	}))
 	e.Use(WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipLiveness))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/event"
-
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	echo_log "github.com/labstack/gommon/log"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.name", "")
 	v.SetDefault("certs.cert_path", "")
 	v.SetDefault("options.paged_rpm_inserts_limit", DefaultPagedRpmInsertsLimit)
+	v.SetDefault("logging.level", "info")
 
 	addEventConfigDefaults(v)
 }
@@ -101,7 +102,9 @@ func Load() {
 	var err error
 	v := viper.New()
 
-	readConfigFile(v)
+	if !clowder.IsClowderEnabled() {
+		readConfigFile(v)
+	}
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 	setDefaults(v)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,7 +78,7 @@ func readConfigFile(v *viper.Viper) {
 	}
 	err := v.ReadInConfig()
 	if err != nil {
-		log.Logger.Err(err).Msg("")
+		log.Logger.Warn().Msgf("config.yaml file not loaded: %s", err.Error())
 	}
 }
 
@@ -102,9 +102,7 @@ func Load() {
 	var err error
 	v := viper.New()
 
-	if !clowder.IsClowderEnabled() {
-		readConfigFile(v)
-	}
+	readConfigFile(v)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 	setDefaults(v)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,7 +203,7 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip middlewar
 
 func SkipLiveness(c echo.Context) bool {
 	p := c.Request().URL.Path
-	if p == "/ping" {
+	if p == "/ping" || p == "/ping/" {
 		return true
 	}
 	if strings.HasPrefix(p, "/api/"+DefaultAppName+"/") &&

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -83,6 +83,7 @@ func RegisterRoutes(engine *echo.Echo) {
 
 func RegisterPing(engine *echo.Echo) {
 	engine.GET("/ping", ping)
+	engine.GET("/ping/", ping)
 }
 
 func ping(c echo.Context) error {

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -58,8 +58,6 @@ func TestPingV1IsNotAvailable(t *testing.T) {
 
 		expected := "{\"errors\":[{\"status\":404,\"detail\":\"Not Found\"}]}\n"
 		assert.Equal(t, expected, string(body))
-		// expected := "{\"message\":\"Not Found\"}\n"
-		// assert.Equal(t, expected, string(body))
 	}
 }
 

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -30,24 +30,37 @@ func serveRouter(req *http.Request) (int, []byte, error) {
 }
 
 func TestPing(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/ping", nil)
-	code, body, err := serveRouter(req)
-	assert.Nil(t, err)
-	assert.Equal(t, http.StatusOK, code)
+	paths := []string{"/ping", "/ping/"}
+	for _, path := range paths {
+		req, _ := http.NewRequest("GET", path, nil)
+		code, body, err := serveRouter(req)
+		assert.Nil(t, err)
+		assert.Equal(t, http.StatusOK, code)
 
-	expected := "{\"message\":\"pong\"}\n"
-	assert.Equal(t, expected, string(body))
+		expected := "{\"message\":\"pong\"}\n"
+		assert.Equal(t, expected, string(body))
+	}
 }
 
 func TestPingV1IsNotAvailable(t *testing.T) {
-	print(fullRootPath() + "/ping")
-	req, _ := http.NewRequest("GET", majorRootPath()+"/ping", nil)
-	code, body, err := serveRouter(req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusNotFound, code)
+	paths := []string{
+		fullRootPath() + "/ping",
+		fullRootPath() + "/ping/",
+		majorRootPath() + "/ping",
+		majorRootPath() + "/ping/",
+	}
+	for _, path := range paths {
+		t.Log(path)
+		req, _ := http.NewRequest("GET", path, nil)
+		code, body, err := serveRouter(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, code)
 
-	expected := "{\"errors\":[{\"status\":404,\"detail\":\"Not Found\"}]}\n"
-	assert.Equal(t, expected, string(body))
+		expected := "{\"errors\":[{\"status\":404,\"detail\":\"Not Found\"}]}\n"
+		assert.Equal(t, expected, string(body))
+		// expected := "{\"message\":\"Not Found\"}\n"
+		// assert.Equal(t, expected, string(body))
+	}
 }
 
 func TestOpenapi(t *testing.T) {


### PR DESCRIPTION
- Add default log level value to info.
- Add LOGGING_LEVEL parameter to the deployment level (we could increase the level in deployment time for ephemeral environment if needed).
- Fix '/ping' and '/ping/' endpoint and update the tests.

TODO:

- [x] Pending to check last time in ephemeral environment (I have to move some commits to the branch I cherry pick that help me on this, which works with bonfire 4.11.0).