### PR TITLE
Fixes 289: Package count accuracy fix

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -27,6 +27,7 @@ type RepositoryDao interface {
 	FetchForUrl(url string) (Repository, error)
 	List() ([]Repository, error)
 	Update(repo RepositoryUpdate) error
+	FetchRepositoryRPMCount(repoUUID string) (int, error)
 }
 
 type ExternalResourceDao interface {

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -43,6 +43,16 @@ type repositoryDaoImpl struct {
 	db *gorm.DB
 }
 
+func (p repositoryDaoImpl) FetchRepositoryRPMCount(repoUUID string) (int, error) {
+	var dbRepos []models.RepositoryRpm
+	var count int64 = 0
+	result := p.db.Model(&dbRepos).Where("repository_uuid = ?", repoUUID).Count(&count)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return int(count), nil
+}
+
 func (p repositoryDaoImpl) FetchForUrl(url string) (Repository, error) {
 	repo := models.Repository{}
 	internalRepo := Repository{}

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -214,4 +215,18 @@ func (s *RepositorySuite) TestUpdateRepository() {
 	assert.Equal(t, expected.LastIntrospectionError, repo.LastIntrospectionError)
 	assert.Equal(t, *expected.PackageCount, repo.PackageCount)
 	assert.Equal(t, *expected.Status, repo.Status)
+}
+
+func (s *RepositorySuite) TestFetchRpmCount() {
+	tx := s.tx
+	t := s.T()
+	var err error
+	expected := 20
+	err = seeds.SeedRpms(tx, s.repo, expected)
+	assert.Nil(t, err, "Error seeding Rpms")
+
+	dao := GetRepositoryDao(tx)
+	count, err := dao.FetchRepositoryRPMCount(s.repo.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, count)
 }

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -105,8 +105,13 @@ func Introspect(repo *dao.Repository, repoDao dao.RepositoryDao, rpm dao.RpmDao)
 		return 0, err
 	}
 
+	var foundCount int
+	if foundCount, err = repoDao.FetchRepositoryRPMCount(repo.UUID); err != nil {
+		return 0, err
+	}
+
 	repo.RepomdChecksum = checksumStr
-	repo.PackageCount = len(packages)
+	repo.PackageCount = foundCount
 	if err = repoDao.Update(RepoToRepoUpdate(*repo)); err != nil {
 		return 0, err
 	}

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -28,6 +28,11 @@ type MockRepositoryDao struct {
 	mock.Mock
 }
 
+func (m *MockRepositoryDao) FetchRepositoryRPMCount(repoUUID string) (int, error) {
+	args := m.Called(repoUUID)
+	return args.Int(0), args.Error(1)
+}
+
 func (m *MockRepositoryDao) List() ([]dao.Repository, error) {
 	return []dao.Repository{}, nil
 }

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -105,6 +105,7 @@ func TestIntrospect(t *testing.T) {
 		RepomdChecksum: templateRepoMdXmlSum,
 		PackageCount:   13,
 	}
+	mockRepoDao.On("FetchRepositoryRPMCount", repoUUID).Return(13, nil)
 	repoUpdate := RepoToRepoUpdate(expected)
 
 	mockRepoDao.On("Update", repoUpdate).Return(nil).Times(1)

--- a/pkg/handler/repository_rpms_test.go
+++ b/pkg/handler/repository_rpms_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -49,7 +48,7 @@ func serveRpmsRouter(req *http.Request, mockDao *mock_dao.RpmDao) (int, []byte, 
 	response := rr.Result()
 	defer response.Body.Close()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	return response.StatusCode, body, err
 }
 


### PR DESCRIPTION
This fixes an issue seen when two packages were identical but have different names.

In such a case the total count would be incorrect, as the checksum data used for package uniqueness would prevent duplication of the package, but the original package count would still be used after this process was completed. 

This fix makes an actual count of the associated items in the database after the introspection is finished to accurately return the correct number for storage. 

- [x]  Needs tests