### PR TITLE
Refs 322: Add clowdjobinvocation template for stage testing

### DIFF
--- a/deployments/testing.yaml
+++ b/deployments/testing.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: content-sources-stage-test
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: content-sources-stage-test-${IMAGE_TAG}-${UID}
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+  spec:
+    appName: content-sources
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'smoke'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
This will be deployed by app-interface after stage deployment, and should execute the iqe-content-sources container