### PR TITLE
Refs 299: set default log stream

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,7 @@ func setDefaults(v *viper.Viper) {
 
 	v.SetDefault("cloudwatch.region", "")
 	v.SetDefault("cloudwatch.group", "")
-	v.SetDefault("cloudwatch.stream", "")
+	v.SetDefault("cloudwatch.stream", "default")
 	v.SetDefault("cloudwatch.session", "")
 	v.SetDefault("cloudwatch.secret", "")
 	v.SetDefault("cloudwatch.key", "")

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -25,7 +25,6 @@ func ConfigureLogging() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 	if conf.Cloudwatch.Key != "" {
-		log.Error().Msgf("Cloudwatch config: %s, %s", conf.Cloudwatch.Group, conf.Cloudwatch.Stream)
 		cloudWatchLogger, err := newCloudWatchLogger(conf.Cloudwatch)
 		if err != nil {
 			log.Fatal().Err(err).Msg("ERROR setting up cloudwatch")


### PR DESCRIPTION
to reproduce the error we were seeing in stage, run with: `CLOUDWATCH_STREAM=""`  on main branch.

With this change, if you run with `CLOUDWATCH_STREAM=""`  it will default to a 'default' stream.  Otherwise it will use the specified stream.  This could allow us to customize the stream with env variables in our clowdapp config