### PR TITLE
Fixes 326: Filter repositories by status

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -133,8 +133,14 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Sets the sort order of the results.",
+                        "description": "Sets the sort order of the results",
                         "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma separated list of statuses to optionally filter on",
+                        "name": "status",
                         "in": "query"
                     }
                 ],

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -645,9 +645,17 @@
                         }
                     },
                     {
-                        "description": "Sets the sort order of the results.",
+                        "description": "Sets the sort order of the results",
                         "in": "query",
                         "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Comma separated list of statuses to optionally filter on",
+                        "in": "query",
+                        "name": "status",
                         "schema": {
                             "type": "string"
                         }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,6 +21,7 @@ type FilterData struct {
 	AvailableForVersion string `query:"available_for_version" json:"available_for_version"` // Filter by compatible version (e.g. 7 would return Repositories with the version 7 or where version is not set)
 	Name                string `query:"name" json:"name"`                                   // Filter repositories by name using an exact match.
 	URL                 string `query:"url" json:"url"`                                     // Filter repositories by URL using an exact match.
+	Status              string `query:"status" json:"status"`                               // Comma separated list of statuses to optionally filter on.
 }
 
 type ResponseMetadata struct {

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -199,6 +199,11 @@ func (r repositoryConfigDaoImpl) List(
 		filteredDB = filteredDB.Where(orGroup)
 	}
 
+	if filterData.Status != "" {
+		statuses := strings.Split(filterData.Status, ",")
+		filteredDB = filteredDB.Where("status IN ?", statuses)
+	}
+
 	sortMap := map[string]string{
 		"name":                  "name",
 		"url":                   "url",

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -30,6 +30,7 @@ const DefaultArch = ""
 const DefaultVersion = ""
 const DefaultAvailableForArch = ""
 const DefaultAvailableForVersion = ""
+const DefaultStatus = ""
 const MaxLimit = 200
 const ApiVersion = "1.0"
 const ApiVersionMajor = "1"
@@ -215,6 +216,7 @@ func ParseFilters(c echo.Context) api.FilterData {
 		Version:             DefaultVersion,
 		AvailableForArch:    DefaultAvailableForArch,
 		AvailableForVersion: DefaultAvailableForVersion,
+		Status:              DefaultStatus,
 	}
 	err := echo.QueryParamsBinder(c).
 		String("search", &filterData.Search).
@@ -224,6 +226,7 @@ func ParseFilters(c echo.Context) api.FilterData {
 		String("available_for_version", &filterData.AvailableForVersion).
 		String("name", &filterData.Name).
 		String("url", &filterData.URL).
+		String("status", &filterData.Status).
 		BindError()
 
 	if err != nil {

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -89,10 +89,10 @@ func serveRepositoriesRouter(req *http.Request, mockDao *mocks.RepositoryConfigD
 	}
 
 	rh := RepositoryHandler{
-		RepositoryDao:             mockDao,
+		RepositoryConfigDao:       mockDao,
 		IntrospectRequestProducer: prod,
 	}
-	RegisterRepositoryRoutes(pathPrefix, &rh.RepositoryDao, &rh.IntrospectRequestProducer)
+	RegisterRepositoryRoutes(pathPrefix, &rh.RepositoryConfigDao, &rh.IntrospectRequestProducer)
 
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)

--- a/pkg/seeds/seeds_test.go
+++ b/pkg/seeds/seeds_test.go
@@ -29,7 +29,7 @@ func (s *SeedSuite) TestSeedRepository() {
 	var err error
 	tx := s.tx
 
-	err = SeedRepository(tx, 505)
+	err = SeedRepository(tx, 505, SeedOptions{})
 	assert.Nil(t, err, "Error seeding Repositories")
 }
 


### PR DESCRIPTION
Adds filtering repository list by status e.g. `/api/content-sources/v1/repositories/?status=Pending,Valid`

To test, create repositories with different introspection statuses and try filtering.