### PR TITLE
Refs 322: Fix appName in testing clowdjobinvocation param

### DIFF
--- a/deployments/testing.yaml
+++ b/deployments/testing.yaml
@@ -12,7 +12,7 @@ objects:
       "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
       "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
   spec:
-    appName: content-sources
+    appName: content-sources-backend
     testing:
       iqe:
         debug: false


### PR DESCRIPTION
```
message: Some Jobs are still incomplete
reason: ClowdApp.cloud.redhat.com "content-sources" not found
status: 'False'
type: JobInvocationComplete
```

Resolving the above failure when this CJI tries to start