### PR TITLE
Refs 268: change grafana folder path to Insights

### DIFF
--- a/deployments/dashboards/grafana-dashboard-content-sources.configmap.yaml
+++ b/deployments/dashboards/grafana-dashboard-content-sources.configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     grafana_dashboard: "true"
   annotations:
-    grafana-folder: /grafana-dashboard-definitions/Content-Sources
+    grafana-folder: /grafana-dashboard-definitions/Insights
 data:
   grafana.json: |-
     {


### PR DESCRIPTION
## Summary
Our grafana dashboard is not showing up in stage. Pretty sure this is why.
## Testing steps