### PR TITLE
Fixes 1118: cleanup url before bulkcreate

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -119,7 +119,8 @@ func (r repositoryConfigDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.R
 		}
 		ApiFieldsToModel(newRepositories[i], &newRepoConfigs[i], &newRepos[i])
 
-		if err := tx.Where("url = ?", newRepos[i].URL).FirstOrCreate(&newRepos[i]).Error; err != nil {
+		cleanedUrl := models.CleanupURL(newRepos[i].URL)
+		if err := tx.Where("url = ?", cleanedUrl).FirstOrCreate(&newRepos[i]).Error; err != nil {
 			dbErr = DBErrorToApi(err)
 			errors[i] = dbErr
 			tx.RollbackTo("beforecreate")


### PR DESCRIPTION
## Summary
During BulkCreate, the repository URL was not being cleaned up (trailing slashes add/removed) before searching for an existing repository. This would cause an error when creating a repository without a trailing slash, if the repository already existed (with a trailing slash) because `FirstOrCreate` would not find the repository.

## Testing steps
1. Create a repository https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
2. delete the repository
3. Create the repository again, but without a trailing slash: https://jlsherrill.fedorapeople.org/fake-repos/needed-errata

Without changes, this would say that it cannot create repository that already exists.
