### PR TITLE
Fixes 1138: use env variable for count grafana panels

### DIFF
--- a/deployments/dashboards/grafana-dashboard-content-sources.configmap.yaml
+++ b/deployments/dashboards/grafana-dashboard-content-sources.configmap.yaml
@@ -34,7 +34,8 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "iteration": 1674152900066,
+      "id": 59328,
+      "iteration": 1675097446943,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -249,7 +250,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "skSy3ZB7k"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -324,7 +325,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "skSy3ZB7k"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -343,7 +344,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "skSy3ZB7k"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -418,7 +419,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "skSy3ZB7k"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -618,8 +619,7 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                       },
                       {
                         "color": "red",
@@ -989,6 +989,6 @@ data:
       "timezone": "",
       "title": "Content Sources",
       "uid": "content-sources",
-      "version": 4,
+      "version": 1,
       "weekStart": ""
     }


### PR DESCRIPTION
## Summary
The grafana panels for the repository counts were using the wrong datasource. I changed the datasource to the environment variable that holds the value of the datasource selected for the whole dashboard (a dropdown in the outer UI).
## Testing steps
none