### PR TITLE
Fixes 548: delete orphaned repos

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -28,6 +28,7 @@ type RepositoryDao interface {
 	List() ([]Repository, error)
 	Update(repo RepositoryUpdate) error
 	FetchRepositoryRPMCount(repoUUID string) (int, error)
+	OrphanCleanup() error
 }
 
 type ExternalResourceDao interface {

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -110,7 +110,6 @@ func (r repositoryDaoImpl) OrphanCleanup() error {
 
 	// Delete orphans
 	tx := r.db.
-		Unscoped().
 		Where("repositories.uuid in (?)", query).
 		Delete(&models.Repository{})
 	if tx.Error != nil {

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
@@ -95,6 +96,28 @@ func (p repositoryDaoImpl) Update(repoIn RepositoryUpdate) error {
 		return result.Error
 	}
 
+	return nil
+}
+
+func (r repositoryDaoImpl) OrphanCleanup() error {
+	// lookup orphans
+	query := r.db.Model(&models.Repository{}).
+		Joins("left join repository_configurations on repositories.uuid = repository_configurations.repository_uuid").
+		Where("repository_configurations.uuid is NULL").
+		Where("repositories.public is false").
+		Where("repositories.created_at < (LOCALTIMESTAMP - INTERVAL '1 week' ) ").
+		Select("repositories.uuid")
+
+	// Delete orphans
+	tx := r.db.
+		Unscoped().
+		Where("repositories.uuid in (?)", query).
+		Delete(&models.Repository{})
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	log.Debug().Msgf("Cleaned up %v orphaned repositories", tx.RowsAffected)
 	return nil
 }
 

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -360,7 +360,6 @@ func (r rpmDaoImpl) OrphanCleanup() error {
 
 	// Remove dangling rpms
 	if err := r.db.
-		Unscoped().
 		Where("rpms.uuid in (?)", danglingRpmUuids).
 		Delete(&models.Rpm{}).
 		Error; err != nil {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -153,6 +153,10 @@ func IntrospectAll(force bool) (int64, []error) {
 			errors = append(errors, err)
 		}
 	}
+	err = repoDao.OrphanCleanup()
+	if err != nil {
+		errors = append(errors, err)
+	}
 	err = rpmDao.OrphanCleanup()
 	if err != nil {
 		errors = append(errors, err)

--- a/pkg/external_repos/introspect_mocks_test.go
+++ b/pkg/external_repos/introspect_mocks_test.go
@@ -24,6 +24,10 @@ func (m MockRpmDao) Search(orgID string, request api.SearchRpmRequest) ([]api.Se
 	return []api.SearchRpmResponse{}, nil
 }
 
+func (m MockRpmDao) OrphanCleanup() error {
+	return nil
+}
+
 type MockRepositoryDao struct {
 	mock.Mock
 }
@@ -46,6 +50,6 @@ func (m *MockRepositoryDao) Update(repo dao.RepositoryUpdate) error {
 	return args.Error(0)
 }
 
-func (m MockRpmDao) OrphanCleanup() error {
+func (m *MockRepositoryDao) OrphanCleanup() error {
 	return nil
 }

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -49,6 +49,7 @@ func RegisterRepositoryRoutes(engine *echo.Group, rDao *dao.RepositoryConfigDao,
 func GetIdentity(c echo.Context) (identity.XRHID, error) {
 	// This block is a bit defensive as the read of the XRHID structure from the
 	// context does not check if the value is a nil and
+
 	if value := c.Request().Context().Value(identity.Key); value == nil {
 		return identity.XRHID{}, fmt.Errorf("cannot find identity into the request context")
 	}


### PR DESCRIPTION
## Summary

as part of introspect-all.  This deletes any non-public repositories that were created more than a week ago and do not have any repo_configs defined


## Testing steps
Create a repo:
```
curl -X POST http://localhost:8000/api/content-sources/v1/repositories/bulk_create/  -d '[{"name":"foobarz", "url":"https://jlsherrill.fedorapeople.org/fake-repos/needed-errataz"}]'  -H "`./scripts/header.sh 3 1`"   -H "Content-Type: application/json"   
```
update the created_at time:
```
make db-cli-connect
```
```
# update repositories  set created_at = LOCALTIMESTAMP - INTERVAL '1 week' where url = 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errataz/';
UPDATE 1
```

Delete the repo (using UUID from create output):
```
curl -X DELETE http://localhost:8000/api/content-sources/v1/repositories/f3430e8e-38b1-4563-84c1-4b93c3e63585  -H "`./scripts/header.sh 3 1`"   -H "Content-Type: application/json"
```

introspect-all
```
go run cmd/external-repos/main.go introspect-all
```

notice:

```
{"level":"debug","time":"2023-01-31T16:30:43-05:00","message":"Cleaned up 1 orphaned repositories"}
```


and in the db, it should be gone:
```
select url from repositories;
```