### PR TITLE
Refs 1104: Add params to CJI for iqe

### DIFF
--- a/deployments/testing.yaml
+++ b/deployments/testing.yaml
@@ -19,6 +19,8 @@ objects:
         dynaconfEnvName: stage_post_deploy
         filter: ''
         marker: 'smoke and api'
+        plugins: content_sources
+        ui: true
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
Include ui param to add selenium container
explicitly specify plugin

I'm not entirely sure this will correctly include the container in the CJI pod for iqe, but this param will be needed regardless of current working order. The CJI spec at least recognizes it right now.

https://github.com/RedHatInsights/clowder/blob/f43aee65bbbe9c1303c23de7661613f2bdf66110/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go#L59


