### PR TITLE
Fixes 360: use log level from config/env

### DIFF
--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -34,7 +34,7 @@ func ConfigureLogging() {
 		log.Logger = log.Logger.Level(level)
 	}
 
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	zerolog.SetGlobalLevel(level)
 	zerolog.DefaultContextLogger = &log.Logger
 }
 


### PR DESCRIPTION
## Summary
The global log level was hard-coded as info, so the log-level set in config was not taking effect.

It looks like this bug came about from a misunderstanding on a previous pr (#152), that `SetGlobalLevel` is the default log level. I believe the bug in that PR was fixed by adding `LOGGING_LEVEL` to `deployment.yaml`, but not by hard-coding `SetGlobalLevel` to `info`.

## Testing steps
1. In your config and/or env, set the logging level to `info`.
2. `make run`, and you should see several messages logged to "info" in the terminal.
3.  Change your log level to `warn`.
4. `make run`, and you should no longer see those messages.
5. Double check my understanding of PR #152 and make sure I did not break what was fixed there. 