### PR TITLE
Refs 1203: add additional metrics

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -79,7 +79,7 @@ func kafkaConsumer(ctx context.Context, wg *sync.WaitGroup, metrics *m.Metrics) 
 	go func() {
 		defer wg.Done()
 		handler := eventHandler.NewIntrospectHandler(db.DB)
-		event.Start(ctx, &config.Get().Kafka, handler)
+		event.Start(ctx, &config.Get().Kafka, handler, metrics)
 		log.Logger.Info().Msgf("kafkaConsumer stopped")
 	}()
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -42,4 +42,5 @@ type MetricsDao interface {
 	RepositoryConfigsCount() int
 	RepositoriesIntrospectionCount(hours int, public bool) IntrospectionCount
 	PublicRepositoriesFailedIntrospectionCount() int
+	OrganizationTotal() int64
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -40,8 +40,6 @@ type ExternalResourceDao interface {
 type MetricsDao interface {
 	RepositoriesCount() int
 	RepositoryConfigsCount() int
-	PublicRepositoriesNotIntrospectedLas24HoursCount() int
+	RepositoriesIntrospectionCount(hours int, public bool) IntrospectionCount
 	PublicRepositoriesFailedIntrospectionCount() int
-	NonPublicRepositoriesNonIntrospectedLast24HoursCount() int
-	// Top50Repositories() []map[string]interface{}
 }

--- a/pkg/dao/metrics.go
+++ b/pkg/dao/metrics.go
@@ -1,10 +1,18 @@
 package dao
 
 import (
+	"fmt"
+
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
+
+type IntrospectionCount struct {
+	Introspected int64
+	Missed       int64
+}
 
 type metricsDaoImpl struct {
 	db *gorm.DB
@@ -37,21 +45,36 @@ func (d metricsDaoImpl) RepositoryConfigsCount() int {
 	return int(output)
 }
 
-func (d metricsDaoImpl) PublicRepositoriesNotIntrospectedLas24HoursCount() int {
+func (d metricsDaoImpl) RepositoriesIntrospectionCount(hours int, public bool) IntrospectionCount {
 	// select COUNT(*)
 	//   from repositories
 	//  where public
-	//    and status in ('Invalid','Unavailable')
 	//    and (last_introspection_time < NOW() - INTERVAL '24 hours' or last_introspection_time is NULL);
-	var output int64 = -1
-	d.db.
-		Model(&models.Repository{}).
-		Where("public").
-		Where("status in (?, ?)", config.StatusInvalid, config.StatusUnavailable).
-		Where(d.db.Where("last_introspection_time is NULL").
-			Or("last_introspection_time < NOW() - INTERVAL '24 hours'")).
-		Count(&output)
-	return int(output)
+	output := IntrospectionCount{
+		Introspected: -1,
+		Missed:       -1,
+	}
+	interval := fmt.Sprintf("%v hours", hours)
+	publicClause := "not public"
+	if public {
+		publicClause = "public"
+	}
+
+	tx := d.db.Model(&models.Repository{}).
+		Where(publicClause).Where(d.db.Where("last_introspection_time is NULL and status != ?", config.StatusPending).
+		Or("last_introspection_time < NOW() - cast(? as INTERVAL)", interval)).
+		Count(&output.Missed)
+	if tx.Error != nil {
+		log.Logger.Err(tx.Error).Msg("error")
+	}
+
+	tx = d.db.Model(&models.Repository{}).
+		Where(publicClause).Where("last_introspection_time >= NOW() - cast(? as INTERVAL)", interval).
+		Count(&output.Introspected)
+	if tx.Error != nil {
+		log.Logger.Err(tx.Error).Msg("Error")
+	}
+	return output
 }
 
 func (d metricsDaoImpl) PublicRepositoriesFailedIntrospectionCount() int {
@@ -64,23 +87,6 @@ func (d metricsDaoImpl) PublicRepositoriesFailedIntrospectionCount() int {
 		Model(&models.Repository{}).
 		Where("public").
 		Where("status in (?, ?)", config.StatusInvalid, config.StatusUnavailable).
-		Count(&output)
-	return int(output)
-}
-
-func (d metricsDaoImpl) NonPublicRepositoriesNonIntrospectedLast24HoursCount() int {
-	// select COUNT(*)
-	//   from repositories
-	//  where not public
-	//    and status in ('Invalid','Unavailable')
-	//    and (last_introspection_time < NOW() - INTERVAL '24 hours' or last_introspection_time is NULL);
-	var output int64 = -1
-	d.db.
-		Model(&models.Repository{}).
-		Where("not public").
-		Where("status in (?, ?)", config.StatusInvalid, config.StatusUnavailable).
-		Where(d.db.Where("last_introspection_time is NULL").
-			Or("last_introspection_time < NOW() - INTERVAL '24 hours'")).
 		Count(&output)
 	return int(output)
 }

--- a/pkg/dao/metrics.go
+++ b/pkg/dao/metrics.go
@@ -45,6 +45,17 @@ func (d metricsDaoImpl) RepositoryConfigsCount() int {
 	return int(output)
 }
 
+func (d metricsDaoImpl) OrganizationTotal() int64 {
+	var output int64 = -1
+	tx := d.db.
+		Model(&models.RepositoryConfiguration{}).Group("org_id").
+		Count(&output)
+	if tx.Error != nil {
+		log.Error().Err(tx.Error).Msg("Cannot calculate OrganizationTotal")
+	}
+	return output
+}
+
 func (d metricsDaoImpl) RepositoriesIntrospectionCount(hours int, public bool) IntrospectionCount {
 	// select COUNT(*)
 	//   from repositories

--- a/pkg/dao/metrics_test.go
+++ b/pkg/dao/metrics_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/lib/pq"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
@@ -63,6 +64,19 @@ func (s *MetricsSuite) TestGetMetricsDao() {
 
 	dao = GetMetricsDao(s.tx)
 	assert.NotNil(t, dao)
+}
+
+func (s *MetricsSuite) TestOrganizationCount() {
+	t := s.T()
+	dao := s.dao
+	var result int64
+
+	err := seeds.SeedRepositoryConfigurations(s.db, 1, seeds.SeedOptions{})
+	assert.Nil(t, err)
+
+	// The initial state should be 0
+	result = dao.OrganizationTotal()
+	assert.True(t, result > 0)
 }
 
 func (s *MetricsSuite) TestRepositoriesCount() {

--- a/pkg/event/consumer.go
+++ b/pkg/event/consumer.go
@@ -125,18 +125,18 @@ func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler
 func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, handler Eventable, metrics m.Metrics) error {
 	var err error
 	if schemas == nil || msg == nil || handler == nil {
-		metrics.RecordKafkaMessageStatus(false)
+		metrics.RecordKafkaMessageResult(false)
 		return fmt.Errorf("schemas, msg or handler is nil")
 	}
 	metrics.RecordKafkaLatency(msg.Timestamp)
 	if msg.TopicPartition.Topic == nil {
-		metrics.RecordKafkaMessageStatus(false)
+		metrics.RecordKafkaMessageResult(false)
 		return fmt.Errorf("Topic cannot be nil")
 	}
 
 	internalTopic := TopicTranslationConfig.GetInternal(*msg.TopicPartition.Topic)
 	if internalTopic == "" {
-		metrics.RecordKafkaMessageStatus(false)
+		metrics.RecordKafkaMessageResult(false)
 		return fmt.Errorf("Topic maping not found for: %s", *msg.TopicPartition.Topic)
 	}
 	log.Info().
@@ -147,15 +147,15 @@ func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, han
 	logEventMessageInfo(msg, "Consuming message")
 
 	if err = schemas.ValidateMessage(msg); err != nil {
-		metrics.RecordKafkaMessageStatus(false)
+		metrics.RecordKafkaMessageResult(false)
 		return err
 	}
 
 	// Dispatch message
 	if err = handler.OnMessage(msg); err != nil {
-		metrics.RecordKafkaMessageStatus(false)
+		metrics.RecordKafkaMessageResult(false)
 		return err
 	}
-	metrics.RecordKafkaMessageStatus(true)
+	metrics.RecordKafkaMessageResult(true)
 	return nil
 }

--- a/pkg/event/consumer.go
+++ b/pkg/event/consumer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/content-services/content-sources-backend/pkg/event/schema"
+	m "github.com/content-services/content-sources-backend/pkg/instrumentation"
 	"github.com/rs/zerolog/log"
 )
 
@@ -69,7 +70,7 @@ func NewConsumer(config *KafkaConfig) (*kafka.Consumer, error) {
 //
 // Return a function that represent the event loop or a panic if a failure
 // happens.
-func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler Eventable) func() {
+func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler Eventable, metrics *m.Metrics) func() {
 	var (
 		err     error
 		msg     *kafka.Message
@@ -80,6 +81,9 @@ func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler
 	}
 	if handler == nil {
 		panic(fmt.Errorf("handler cannot be nil"))
+	}
+	if metrics == nil {
+		panic(fmt.Errorf("metrics cannot be nil"))
 	}
 	if schemas, err = schema.LoadSchemas(); err != nil {
 		panic(err)
@@ -110,7 +114,7 @@ func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler
 				break
 			}
 
-			if err = processConsumedMessage(schemas, msg, handler); err != nil {
+			if err = processConsumedMessage(schemas, msg, handler, *metrics); err != nil {
 				logEventMessageError(msg, err)
 				continue
 			}
@@ -118,18 +122,21 @@ func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler
 	}
 }
 
-func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, handler Eventable) error {
+func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, handler Eventable, metrics m.Metrics) error {
 	var err error
-
 	if schemas == nil || msg == nil || handler == nil {
+		metrics.RecordKafkaMessageStatus(false)
 		return fmt.Errorf("schemas, msg or handler is nil")
 	}
+	metrics.RecordKafkaLatency(msg.Timestamp)
 	if msg.TopicPartition.Topic == nil {
+		metrics.RecordKafkaMessageStatus(false)
 		return fmt.Errorf("Topic cannot be nil")
 	}
 
 	internalTopic := TopicTranslationConfig.GetInternal(*msg.TopicPartition.Topic)
 	if internalTopic == "" {
+		metrics.RecordKafkaMessageStatus(false)
 		return fmt.Errorf("Topic maping not found for: %s", *msg.TopicPartition.Topic)
 	}
 	log.Info().
@@ -140,12 +147,15 @@ func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, han
 	logEventMessageInfo(msg, "Consuming message")
 
 	if err = schemas.ValidateMessage(msg); err != nil {
+		metrics.RecordKafkaMessageStatus(false)
 		return err
 	}
 
 	// Dispatch message
 	if err = handler.OnMessage(msg); err != nil {
+		metrics.RecordKafkaMessageStatus(false)
 		return err
 	}
+	metrics.RecordKafkaMessageStatus(true)
 	return nil
 }

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	m "github.com/content-services/content-sources-backend/pkg/instrumentation"
 	"github.com/rs/zerolog/log"
 )
 
@@ -14,7 +15,7 @@ import (
 // messages.
 // config a reference to an initialized KafkaConfig. It cannot be nil.
 // handler is the event handler which receive the read messages.
-func Start(ctx context.Context, config *KafkaConfig, handler Eventable) {
+func Start(ctx context.Context, config *KafkaConfig, handler Eventable, m *m.Metrics) {
 	var (
 		err      error
 		consumer *kafka.Consumer
@@ -26,6 +27,6 @@ func Start(ctx context.Context, config *KafkaConfig, handler Eventable) {
 	}
 	defer consumer.Close()
 
-	start := NewConsumerEventLoop(ctx, consumer, handler)
+	start := NewConsumerEventLoop(ctx, consumer, handler, m)
 	start()
 }

--- a/pkg/event/handler/introspect.go
+++ b/pkg/event/handler/introspect.go
@@ -48,9 +48,11 @@ func (h *IntrospectHandler) OnMessage(msg *kafka.Message) error {
 
 	newRpms, errs := external_repos.IntrospectUrl(payload.Url, true)
 	if len(errs) > 0 {
-		return errs[0]
+		// Introspection failure isn't considered a message failure, as the message has been handled
+		for i := 0; i < len(errs); i++ {
+			log.Error().Err(errs[i]).Msgf("Error %v introspecting repository %v", i, payload.Url)
+		}
 	}
 	log.Debug().Msgf("IntrospectionUrl returned %d new packages", newRpms)
-
 	return nil
 }

--- a/pkg/instrumentation/custom/collector.go
+++ b/pkg/instrumentation/custom/collector.go
@@ -39,6 +39,8 @@ func NewCollector(context context.Context, metrics *instrumentation.Metrics, db 
 func (c *Collector) iterate() {
 	c.metrics.RepositoriesTotal.Set(float64(c.dao.RepositoriesCount()))
 	c.metrics.RepositoryConfigsTotal.Set(float64(c.dao.RepositoryConfigsCount()))
+	c.metrics.RepositoryConfigsTotal.Set(float64(c.dao.RepositoryConfigsCount()))
+	c.metrics.OrgTotal.Set(float64(c.dao.OrganizationTotal()))
 
 	public := c.dao.RepositoriesIntrospectionCount(36, true)
 	c.metrics.PublicRepositories36HourIntrospectionTotal.With(prometheus.Labels{"status": "introspected"}).Set(float64(public.Introspected))

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -1,6 +1,8 @@
 package instrumentation
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -8,25 +10,28 @@ import (
 
 // TODO Update metric names according to: https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 const (
-	NameSpace                                            = "content_sources"
-	HttpStatusHistogram                                  = "http_status_histogram"
-	RepositoriesTotal                                    = "repositories_total"
-	RepositoryConfigsTotal                               = "repository_configs_total"
-	PublicRepositoriesNotIntrospectedLast24HoursTotal    = "public_repositories_not_introspected_last_24_hours_total"
-	PublicRepositoriesWithFailedIntrospectionTotal       = "public_repositories_with_failed_introspection_total"
-	NonPublicRepositoriesNotIntrospectedLast24HoursTotal = "non_public_repositories_not_introspected_last_24_hours_total"
-	Top50Repositories                                    = "top_50_repositories"
+	NameSpace                                      = "content_sources"
+	HttpStatusHistogram                            = "http_status_histogram"
+	RepositoriesTotal                              = "repositories_total"
+	RepositoryConfigsTotal                         = "repository_configs_total"
+	PublicRepositories36HourIntrospectionTotal     = "public_repositories_36_hour_introspection_total"
+	PublicRepositoriesWithFailedIntrospectionTotal = "public_repositories_with_failed_introspection_total"
+	CustomRepositories36HourIntrospectionTotal     = "custom_repositories_36_hour_introspection_total"
+	KafkaMessageLatency                            = "kafka_message_latency"
+	KafkaMessageStatus                             = "kafka_message_status"
 )
 
 type Metrics struct {
 	HttpStatusHistogram prometheus.HistogramVec
 
 	// Custom metrics
-	RepositoriesTotal                                    prometheus.Gauge
-	RepositoryConfigsTotal                               prometheus.Gauge
-	PublicRepositoriesNotIntrospectedLast24HoursTotal    prometheus.Gauge
-	PublicRepositoriesWithFailedIntrospectionTotal       prometheus.Gauge
-	NonPublicRepositoriesNotIntrospectedLast24HoursTotal prometheus.Gauge
+	RepositoriesTotal                              prometheus.Gauge
+	RepositoryConfigsTotal                         prometheus.Gauge
+	PublicRepositories36HourIntrospectionTotal     prometheus.GaugeVec
+	PublicRepositoriesWithFailedIntrospectionTotal prometheus.Gauge
+	CustomRepositories36HourIntrospectionTotal     prometheus.GaugeVec
+	KafkaMessageStatus                             prometheus.CounterVec
+	KafkaMessageLatency                            prometheus.Histogram
 
 	reg *prometheus.Registry
 }
@@ -46,6 +51,18 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"status", "method", "path"}),
 
+		KafkaMessageLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: NameSpace,
+			Name:      KafkaMessageLatency,
+			Help:      "Time to pickup kafka messages",
+			Buckets:   prometheus.DefBuckets,
+		}),
+		KafkaMessageStatus: *promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace:   NameSpace,
+			Name:        KafkaMessageStatus,
+			Help:        "Result of kafka messages",
+			ConstLabels: nil,
+		}, []string{"state"}),
 		RepositoriesTotal: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      RepositoriesTotal,
@@ -56,26 +73,40 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      RepositoryConfigsTotal,
 			Help:      "Number of repository configurations",
 		}),
-		PublicRepositoriesNotIntrospectedLast24HoursTotal: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		PublicRepositories36HourIntrospectionTotal: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: NameSpace,
-			Name:      PublicRepositoriesNotIntrospectedLast24HoursTotal,
+			Name:      PublicRepositories36HourIntrospectionTotal,
 			Help:      "Number of public repositories not introspected into the last 24 hours",
-		}),
+		}, []string{"status"}),
 		PublicRepositoriesWithFailedIntrospectionTotal: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      PublicRepositoriesWithFailedIntrospectionTotal,
 			Help:      "Number of repositories with failed introspection",
 		}),
-		NonPublicRepositoriesNotIntrospectedLast24HoursTotal: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		CustomRepositories36HourIntrospectionTotal: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: NameSpace,
-			Name:      NonPublicRepositoriesNotIntrospectedLast24HoursTotal,
+			Name:      CustomRepositories36HourIntrospectionTotal,
 			Help:      "Number of non public repositories not introspected in the last 24 hours",
-		}),
+		}, []string{"status"}),
 	}
 
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 
 	return metrics
+}
+
+func (m *Metrics) RecordKafkaMessageStatus(success bool) {
+	status := "failed"
+	if success {
+		status = "success"
+	}
+	if m != nil {
+		m.KafkaMessageStatus.With(prometheus.Labels{"state": status}).Inc()
+	}
+}
+func (m *Metrics) RecordKafkaLatency(msgTime time.Time) {
+	diff := time.Since(msgTime)
+	m.KafkaMessageLatency.Observe(diff.Seconds())
 }
 
 func (m Metrics) Registry() *prometheus.Registry {


### PR DESCRIPTION
Adds the following metrics:

* kafka message latency
* kafka message success (with error or without error)
* 36 hour intropsection status (intropsected or not)
  * this reworks a lot of the existing 24 hours metric gathering
