### PR TITLE
Fixes 1358: set rbac timeout properly

### DIFF
--- a/pkg/client/rbac.go
+++ b/pkg/client/rbac.go
@@ -54,10 +54,10 @@ type Rbac interface {
 
 type RbacConfig struct {
 	client  rbac.Client
-	timeout time.Duration
+	timeout int
 }
 
-func NewRbac(baseUrl string, timeout time.Duration) Rbac {
+func NewRbac(baseUrl string, timeout int) Rbac {
 	if baseUrl == "" {
 		return nil
 	}
@@ -76,7 +76,7 @@ func NewRbac(baseUrl string, timeout time.Duration) Rbac {
 // resource is the content-sources resource which is being requested.
 // verb is the action we are quering, in our case, read or write
 func (r *RbacConfig) Allowed(xrhid string, resource string, verb RbacVerb) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(r.timeout)*time.Second)
 	defer cancel()
 
 	acl, err := r.client.GetAccess(ctx, xrhid, "")

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -1,8 +1,6 @@
 package router
 
 import (
-	"time"
-
 	"github.com/content-services/content-sources-backend/pkg/client"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/handler"
@@ -52,10 +50,9 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
 	if config.Get().Clients.RbacEnabled {
 		rbacBaseUrl := config.Get().Clients.RbacBaseUrl
-		rbacTimeout := time.Duration(int64(config.Get().Clients.RbacTimeout) * int64(time.Second))
-		rbacClient := client.NewRbac(rbacBaseUrl, rbacTimeout)
+		rbacClient := client.NewRbac(rbacBaseUrl, config.Get().Clients.RbacTimeout)
 		log.Info().Msgf("rbacBaseUrl=%s", rbacBaseUrl)
-		log.Info().Msgf("rbacTimeout=%d secs", rbacTimeout/time.Second)
+		log.Info().Msgf("rbacTimeout=%d secs", config.Get().Clients.RbacTimeout)
 		e.Use(
 			middleware.NewRbac(
 				middleware.Rbac{


### PR DESCRIPTION
## Summary

I'm about 75% sure this is the problem in stage, as the config value wasn't properly being converted to 
seconds in the main usage (but was as part of metrics).

## Testing steps
Tests pass
Works against mock rbac service