### PR TITLE
Refs 531: Add pulp integration and example script

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -46,6 +46,17 @@ func main() {
 			log.Panic().Err(err).Msg("Failed to save repositories")
 		}
 		log.Debug().Msg("Successfully loaded external repositories.")
+	} else if args[1] == "pulp-create" {
+		if len(args) < 3 {
+			log.Error().Msg("Usage:  ./external_repos pulp-create URL")
+			os.Exit(1)
+		}
+		url := args[2]
+		errors := external_repos.CreatePulpRepoFromURL(url)
+		for i := 0; i < len(errors); i++ {
+			log.Panic().Err(errors[i]).Msg("Failed to create pulp reference")
+		}
+		log.Debug().Msgf("Repository with URL %s successfully created in pulp", url)
 	} else if args[1] == "introspect" {
 		if len(args) < 3 {
 			log.Error().Msg("Usage:  ./external_repos introspect URL [--force]")

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.3
+	github.com/content-services/zest/release/v3 v3.23.0
 	github.com/lzap/cloudwatchwriter2 v1.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,8 @@ github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/content-services/yummy v1.0.4 h1:WnOUvJzw/gKEFR1brUI2G/rsvw1oTM0myILJuu7RNWo=
 github.com/content-services/yummy v1.0.4/go.mod h1:diGfri6r8uFw0u7sXOrkXwiDcitfzl5wYV4hioS91qw=
+github.com/content-services/zest/release/v3 v3.23.0 h1:2nKRTf92cqOQWeH5b6vME3WAeDSDfFNHJ3q2xPBMix0=
+github.com/content-services/zest/release/v3 v3.23.0/go.mod h1:5ShCAAZeekb14xTUmCalgGCj02k8iGJU4oyp0n9Rg0w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/external_repos/pulp.go
+++ b/pkg/external_repos/pulp.go
@@ -1,0 +1,122 @@
+package external_repos
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/pulp_client"
+)
+
+// CreatePulpRepoFromURL
+func CreatePulpRepoFromURL(url string) []error {
+	var errs []error
+	repoDao := dao.GetRepositoryDao(db.DB)
+	repo, err := repoDao.FetchForUrl(url)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n\nDidn't find URL reference in repoDao: %v\n\n", repo.URL)
+		return []error{err}
+	}
+
+	pulpClient := pulp_client.GetPulpClient()
+
+	err = PulpCreate(&repo, pulpClient)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("Error creating pulp reference for %s: %s", repo.URL, err.Error()))
+	}
+
+	return errs
+}
+
+func PulpCreate(repo *dao.Repository, pulpClient pulp_client.PulpClient) error {
+	fmt.Printf("\n\nRunning Pulp Create for: %s \n", repo.URL)
+	var remoteHref string
+	var repoHref string
+	var taskHref string
+
+	//Create remote
+	createResp, firstErr := pulpClient.CreateRpmRemote(repo.UUID, repo.URL)
+
+	if firstErr != nil {
+		//Err, check if the remote exists, use it if so.
+		resp, secondErr := pulpClient.GetRpmRemoteByName(repo.UUID)
+		if secondErr != nil {
+			return firstErr
+		}
+		remoteHref = *resp.PulpHref
+	} else {
+		remoteHref = *createResp.PulpHref
+	}
+
+	// Create Repository
+	remoteResp, createErr := pulpClient.CreateRpmRepository(repo.UUID, repo.URL, &remoteHref)
+
+	if createErr != nil {
+		//Err, Presume repository exists, use it if so.
+		resp, err := pulpClient.GetRpmRemoteByName(repo.UUID)
+		if err != nil {
+			return createErr
+		}
+		repoHref = *resp.PulpHref
+	} else {
+		repoHref = *remoteResp.PulpHref
+	}
+
+	taskHref, err := pulpClient.SyncRpmRepository(repoHref, nil)
+
+	if err != nil {
+		return err
+	}
+
+	syncInProgress := true
+	syncCount := 1
+	for syncInProgress {
+		task, err := pulpClient.GetTask(taskHref)
+
+		if err != nil {
+			return err
+		}
+
+		taskState := *task.State
+		prettyResponse, _ := json.MarshalIndent(task, "", "    ")
+
+		switch {
+		case taskState == "completed":
+			print("\n================== DONE! ==================\n")
+			fmt.Printf("\nRepository Creation Success\n\nTask State is: %s \n\n", taskState)
+			syncInProgress = false
+		case taskState == "waiting":
+			print("\n================== Waiting ==================\n")
+		case taskState == "running":
+			print("\n================== Running ==================\n")
+		case taskState == "skipped":
+			print("\n================== Skipped ==================\n")
+			fmt.Fprintf(os.Stdout, "Response from Repository Creation Skipped %v\nTask State is: %s \n\n", string(prettyResponse), taskState)
+			syncInProgress = false
+		case taskState == "canceled":
+			print("\n================== Canceled ==================\n")
+			fmt.Fprintf(os.Stdout, "Response from Repository Creation Canceled %v\nTask State is: %s \n\n", string(prettyResponse), taskState)
+			syncInProgress = false
+		case taskState == "failed":
+			print("\n================== Failed ==================\n")
+			fmt.Fprintf(os.Stdout, "Response from Repository Creation Failed %v\nTask State is: %s \n\n", string(prettyResponse), taskState)
+			print(task.Error)
+			syncInProgress = false
+		default:
+			print("\nState returned something else:", taskState, "\n")
+			syncInProgress = false
+		}
+
+		if taskState != "completed" {
+			fmt.Printf("\nPollingTime: %v seconds\n", syncCount)
+			syncCount++
+			time.Sleep(1000)
+		}
+	}
+
+	return nil
+}

--- a/pkg/pulp_client/client.go
+++ b/pkg/pulp_client/client.go
@@ -1,0 +1,30 @@
+package pulp_client
+
+import (
+	"context"
+
+	zest "github.com/content-services/zest/release/v3"
+)
+
+type pulpDaoImpl struct {
+	client *zest.APIClient
+	ctx    context.Context
+}
+
+func GetPulpClient() PulpClient {
+	ctx := context.WithValue(context.Background(), zest.ContextServerIndex, 0)
+	pulpConfig := zest.NewConfiguration()
+
+	client := zest.NewAPIClient(pulpConfig)
+
+	auth := context.WithValue(ctx, zest.ContextBasicAuth, zest.BasicAuth{
+		UserName: "admin",
+		Password: "password",
+	})
+
+	// Return DAO instance
+	return pulpDaoImpl{
+		client: client,
+		ctx:    auth,
+	}
+}

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -1,0 +1,19 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+type PulpClient interface {
+	//Remotes
+	CreateRpmRemote(name string, url string) (*zest.RpmRpmRemoteResponse, error)
+	UpdateRpmRemoteUrl(pulpHref string, url string) (string, error)
+	GetRpmRemoteByName(name string) (zest.RpmRpmRemoteResponse, error)
+	GetRpmRemoteList() ([]zest.RpmRpmRemoteResponse, error)
+	DeleteRpmRemote(pulpHref string) (string, error)
+	//Tasks
+	GetTask(taskHref string) (zest.TaskResponse, error)
+	//Rpm
+	CreateRpmRepository(uuid string, url string, rpmRemotePulpRef *string) (zest.RpmRpmRepositoryResponse, error)
+	GetRpmRepositoryByName(name string) (zest.RpmRpmRepositoryResponse, error)
+	GetRpmRepositoryByRemote(pulpHref string) (zest.RpmRpmRepositoryResponse, error)
+	SyncRpmRepository(rpmRpmRepositoryHref string, remoteHref *string) (string, error)
+}

--- a/pkg/pulp_client/mocks/pulp_script_test.go
+++ b/pkg/pulp_client/mocks/pulp_script_test.go
@@ -1,0 +1,30 @@
+package pulp_client
+
+import (
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/external_repos"
+	zest "github.com/content-services/zest/release/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateRpmRemote(t *testing.T) {
+	mockPulpClient := &MockPulpClient{}
+
+	repoUUID := uuid.NewString()
+	url := "http://someRandom.url/thing"
+	expectedRemoteResponse := zest.RpmRpmRemoteResponse{}
+	expectedRemoteResponse.SetPulpHref("remotePulpHref")
+	expectedRepositoryResponse := zest.RpmRpmRepositoryResponse{}
+	expectedRepositoryResponse.SetPulpHref("rpmPulpHref")
+	mockPulpClient.On("CreateRpmRemote", repoUUID, url).Return(expectedRemoteResponse, nil)
+	mockPulpClient.On("CreateRpmRepository", repoUUID, url, "remotePulpHref").Return(expectedRepositoryResponse, nil)
+	mockPulpClient.On("SyncRpmRepository", "rpmPulpHref").Return("taskPulpHref", nil)
+	mockPulpClient.On("GetTask", "taskPulpHref").Return("completed", nil)
+
+	repository := &dao.Repository{UUID: repoUUID, URL: url}
+	err := external_repos.PulpCreate(repository, mockPulpClient)
+	assert.NoError(t, err)
+}

--- a/pkg/pulp_client/mocks/rpm_remote_mock.go
+++ b/pkg/pulp_client/mocks/rpm_remote_mock.go
@@ -1,0 +1,46 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+func (r *MockPulpClient) CreateRpmRemote(name string, url string) (*zest.RpmRpmRemoteResponse, error) {
+	args := r.Called(name, url)
+
+	if v, ok := args.Get(0).(*zest.RpmRpmRemoteResponse); ok {
+		return v, nil
+	}
+	response := zest.RpmRpmRemoteResponse{Name: name, Url: url}
+	response.SetPulpHref("remotePulpHref")
+	return &response, args.Error(1)
+}
+
+func (r *MockPulpClient) UpdateRpmRemoteUrl(pulpHref string, url string) (string, error) {
+	args := r.Called(pulpHref, url)
+	if v, ok := args.Get(0).(string); ok {
+		return v, nil
+	}
+	return "", nil
+}
+
+func (r *MockPulpClient) GetRpmRemoteByName(name string) (zest.RpmRpmRemoteResponse, error) {
+	args := r.Called(name)
+	if v, ok := args.Get(0).(zest.RpmRpmRemoteResponse); ok {
+		return v, nil
+	}
+	return zest.RpmRpmRemoteResponse{}, nil
+}
+
+func (r *MockPulpClient) GetRpmRemoteList() ([]zest.RpmRpmRemoteResponse, error) {
+	args := r.Called()
+	if v, ok := args.Get(0).([]zest.RpmRpmRemoteResponse); ok {
+		return v, nil
+	}
+	return []zest.RpmRpmRemoteResponse{}, nil
+}
+
+func (r *MockPulpClient) DeleteRpmRemote(pulpHref string) (string, error) {
+	args := r.Called(pulpHref)
+	if v, ok := args.Get(0).(string); ok {
+		return v, nil
+	}
+	return "", nil
+}

--- a/pkg/pulp_client/mocks/rpm_repositories_mock.go
+++ b/pkg/pulp_client/mocks/rpm_repositories_mock.go
@@ -1,0 +1,42 @@
+package pulp_client
+
+import (
+	zest "github.com/content-services/zest/release/v3"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockPulpClient struct {
+	mock.Mock
+}
+
+func (r *MockPulpClient) CreateRpmRepository(uuid string, url string, rpmRemotePulpRef *string) (zest.RpmRpmRepositoryResponse, error) {
+	args := r.Called(uuid, url, *rpmRemotePulpRef)
+	if v, ok := args.Get(0).(zest.RpmRpmRepositoryResponse); ok {
+		return v, nil
+	}
+	return zest.RpmRpmRepositoryResponse{}, nil
+}
+
+func (r *MockPulpClient) GetRpmRepositoryByName(name string) (zest.RpmRpmRepositoryResponse, error) {
+	args := r.Called(name)
+	if v, ok := args.Get(0).(zest.RpmRpmRepositoryResponse); ok {
+		return v, nil
+	}
+	return zest.RpmRpmRepositoryResponse{}, nil
+}
+
+func (r *MockPulpClient) GetRpmRepositoryByRemote(pulpHref string) (zest.RpmRpmRepositoryResponse, error) {
+	args := r.Called(pulpHref)
+	if v, ok := args.Get(0).(zest.RpmRpmRepositoryResponse); ok {
+		return v, nil
+	}
+	return zest.RpmRpmRepositoryResponse{}, nil
+}
+
+func (r *MockPulpClient) SyncRpmRepository(rpmRpmRepositoryHref string, remoteHref *string) (string, error) {
+	args := r.Called(rpmRpmRepositoryHref)
+	if v, ok := args.Get(0).(string); ok {
+		return v, nil
+	}
+	return "taskPulpHref", nil
+}

--- a/pkg/pulp_client/mocks/task_mock.go
+++ b/pkg/pulp_client/mocks/task_mock.go
@@ -1,0 +1,13 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+func (r *MockPulpClient) GetTask(taskHref string) (zest.TaskResponse, error) {
+	args := r.Called(taskHref)
+	if v, ok := args.Get(0).(zest.TaskResponse); ok {
+		return v, nil
+	}
+	response := zest.TaskResponse{}
+	response.SetState("completed")
+	return response, nil
+}

--- a/pkg/pulp_client/rpm_remote.go
+++ b/pkg/pulp_client/rpm_remote.go
@@ -1,0 +1,66 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+// Creates a remote
+func (r pulpDaoImpl) CreateRpmRemote(name string, url string) (*zest.RpmRpmRemoteResponse, error) {
+	rpmRpmRemote := *zest.NewRpmRpmRemote(name, url)
+	rpmRpmRemote.SetPolicy(zest.POLICY762ENUM_ON_DEMAND)
+	remoteResp, _, err := r.client.RemotesRpmApi.RemotesRpmRpmCreate(r.ctx).
+		RpmRpmRemote(rpmRpmRemote).Execute()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return remoteResp, nil
+}
+
+// Starts an update task on an existing remote
+func (r pulpDaoImpl) UpdateRpmRemoteUrl(pulpHref string, url string) (string, error) {
+	patchRpmRemote := zest.PatchedrpmRpmRemote{}
+	patchRpmRemote.SetUrl(url)
+	updateResp, _, err := r.client.RemotesRpmApi.RemotesRpmRpmPartialUpdate(r.ctx, pulpHref).
+		PatchedrpmRpmRemote(patchRpmRemote).Execute()
+
+	if err != nil {
+		return "", err
+	}
+
+	return updateResp.Task, nil
+}
+
+// Finds a remote by name, returning the associated RpmRpmRemoteResponse (containing the PulpHref)
+func (r pulpDaoImpl) GetRpmRemoteByName(name string) (zest.RpmRpmRemoteResponse, error) {
+	readResp, _, err := r.client.RemotesRpmApi.RemotesRpmRpmList(r.ctx).Name(name).Execute()
+
+	if err != nil {
+		return zest.RpmRpmRemoteResponse{}, err
+	}
+
+	results := readResp.GetResults()
+	return results[0], nil
+}
+
+// Returns a list of RpmRpmRemotes
+func (r pulpDaoImpl) GetRpmRemoteList() ([]zest.RpmRpmRemoteResponse, error) {
+	readResp, _, err := r.client.RemotesRpmApi.RemotesRpmRpmList(r.ctx).Execute()
+
+	if err != nil {
+		return []zest.RpmRpmRemoteResponse{}, err
+	}
+
+	results := readResp.GetResults()
+	return results, nil
+}
+
+// Starts a Delete task on an existing remote
+func (r pulpDaoImpl) DeleteRpmRemote(pulpHref string) (string, error) {
+	deleteResp, _, err := r.client.RemotesRpmApi.RemotesRpmRpmDelete(r.ctx, pulpHref).Execute()
+
+	if err != nil {
+		return "", err
+	}
+
+	return deleteResp.Task, nil
+}

--- a/pkg/pulp_client/rpm_repositories.go
+++ b/pkg/pulp_client/rpm_repositories.go
@@ -1,0 +1,61 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+// Creates a repository, rpmRemotePulpRef is optional
+func (r pulpDaoImpl) CreateRpmRepository(uuid string, url string, rpmRemotePulpRef *string) (zest.RpmRpmRepositoryResponse, error) {
+	rpmRpmRepository := *zest.NewRpmRpmRepository(uuid)
+	if rpmRemotePulpRef != nil {
+		rpmRpmRepository.SetRemote(*rpmRemotePulpRef)
+	}
+	resp, _, err := r.client.RepositoriesRpmApi.RepositoriesRpmRpmCreate(r.ctx).
+		RpmRpmRepository(rpmRpmRepository).Execute()
+
+	if err != nil {
+		return zest.RpmRpmRepositoryResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Finds a repository given a name
+func (r pulpDaoImpl) GetRpmRepositoryByName(name string) (zest.RpmRpmRepositoryResponse, error) {
+	resp, _, err := r.client.RepositoriesRpmApi.RepositoriesRpmRpmList(r.ctx).Name(name).Execute()
+
+	if err != nil {
+		return zest.RpmRpmRepositoryResponse{}, err
+	}
+
+	results := resp.GetResults()
+	return results[0], nil
+}
+
+// Finds a repository given a remoteHref
+func (r pulpDaoImpl) GetRpmRepositoryByRemote(pulpHref string) (zest.RpmRpmRepositoryResponse, error) {
+	resp, _, err := r.client.RepositoriesRpmApi.RepositoriesRpmRpmList(r.ctx).Remote(pulpHref).Execute()
+
+	if err != nil {
+		return zest.RpmRpmRepositoryResponse{}, err
+	}
+
+	results := resp.GetResults()
+	return results[0], nil
+}
+
+// Starts a sync task, returns a taskHref, remoteHref is optional.
+func (r pulpDaoImpl) SyncRpmRepository(rpmRpmRepositoryHref string, remoteHref *string) (string, error) {
+	rpmRepositoryHref := *zest.NewRpmRepositorySyncURL()
+	if remoteHref != nil {
+		rpmRepositoryHref.SetRemote(*remoteHref)
+	}
+	rpmRepositoryHref.SetSyncPolicy(*zest.SYNCPOLICYENUM_MIRROR_CONTENT_ONLY.Ptr())
+
+	resp, _, err := r.client.RepositoriesRpmApi.RepositoriesRpmRpmSync(r.ctx, rpmRpmRepositoryHref).
+		RpmRepositorySyncURL(rpmRepositoryHref).Execute()
+
+	if err != nil {
+		return "", err
+	}
+
+	return resp.Task, nil
+}

--- a/pkg/pulp_client/task.go
+++ b/pkg/pulp_client/task.go
@@ -1,0 +1,14 @@
+package pulp_client
+
+import zest "github.com/content-services/zest/release/v3"
+
+// Creates a remote
+func (r pulpDaoImpl) GetTask(taskHref string) (zest.TaskResponse, error) {
+	task, _, err := r.client.TasksApi.TasksRead(r.ctx, taskHref).Execute()
+
+	if err != nil {
+		return zest.TaskResponse{}, err
+	}
+
+	return *task, nil
+}


### PR DESCRIPTION
## Summary

This adds a demonstration script for integrating with our new Pulp Binding. 
Documentation around this integration can be referenced [here](https://docs.google.com/document/d/1PBzYDDBwnNYRPPTNHKVnbKFOLZYjyLqXzPCLDk2-Zos/edit#).

## Testing steps

Run the following:

- make compose-clean   
- DEPLOY_PULP=true make compose-up
- make run 

Then use the API or the UI to add a few repositories to sync with pulp below. 

Then run the following command in your console: 
   
- go run cmd/external-repos/main.go pulp-create ||Enter URL of added repo||
