### PR TITLE
Fixes 1412: remove url validation on event reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Content Sources is an application for storing information about external content
 
 1. podman & podman-compose installed or docker & docker-compose installed (and docker running)
    - This is used to start a set of containers that are dependencies for content-sources-backend
-2. yaml2json tool installed (`pip install yaml2json`).
+2. yaml2json tool installed (`pip install json2yaml`).
 
 ### Create your configuration
 

--- a/pkg/event/handler/introspect.go
+++ b/pkg/event/handler/introspect.go
@@ -42,7 +42,7 @@ func (h *IntrospectHandler) OnMessage(msg *kafka.Message) error {
 	// https://github.com/go-playground/validator
 	// FIXME Wrong usage of validator library
 	validate := validator.New()
-	if err := validate.Var(payload.Url, "required,url"); err != nil {
+	if err := validate.Var(payload.Url, "required"); err != nil {
 		return err
 	}
 

--- a/pkg/event/schema/introspectRequest.message.json
+++ b/pkg/event/schema/introspectRequest.message.json
@@ -16,8 +16,7 @@
         "url": {
             "description": "The base URL for the repository to be introspected",
             "type": "string",
-            "format": "uri",
-            "minLength": 10
+            "minLength": 1
         }
     },
     "required": [

--- a/pkg/event/schema/introspectRequest.message.yaml
+++ b/pkg/event/schema/introspectRequest.message.yaml
@@ -19,8 +19,7 @@ properties:
   url:
     description: The base URL for the repository to be introspected
     type: string
-    format: uri
-    minLength: 10
+    minLength: 1
     # TODO Pattern is not implemented for the code generator leveraged
     #      pattern field is according to the ECMA-262 regular expression dialect
     #      (https://262.ecma-international.org/13.0/#sec-regexp-regular-expression-objects)

--- a/pkg/event/schema/schemas_test.go
+++ b/pkg/event/schema/schemas_test.go
@@ -334,7 +334,7 @@ func TestValidateMessage(t *testing.T) {
 					}`),
 				},
 			},
-			Expected: fmt.Errorf("error validating schema: min length of 10 characters required: : /url = , invalid uri: uri missing scheme prefix: /url = "),
+			Expected: fmt.Errorf("error validating schema: min length of 1 characters required: : /url = "),
 		},
 		// Validate bytes return true
 		{


### PR DESCRIPTION
## Summary
Previously bad urls were treated as a 'kafka' error, and not an introspection error.  This led to bad stats when trying to look at metrics.

## Testing steps
run the following query:

```.rest
### Create a single repository
POST http://{{host}}/api/content-sources/v1.0/repositories/
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiQXNzb2NpYXRlIiwiYWNjb3VudF9udW1iZXIiOiIxIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K

{
  "name": "azure clizz2",
  "url": "/fo1",
  "distribution_versions": [
    "8"
  ],
  "distribution_arch": "x86_64"
},

```

then check metrics:
```
curl localhost:9000/metrics | grep kafka_message_result_total
```

you should see

```
content_sources_kafka_message_result_total{state="success"} 1
```

which is correct, the failure was in introspection, not in message parsing/handling 

