### PR TITLE
Refs 1203: Rename kafka metrics

### DIFF
--- a/pkg/event/consumer.go
+++ b/pkg/event/consumer.go
@@ -125,18 +125,18 @@ func NewConsumerEventLoop(ctx context.Context, consumer *kafka.Consumer, handler
 func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, handler Eventable, metrics m.Metrics) error {
 	var err error
 	if schemas == nil || msg == nil || handler == nil {
-		metrics.RecordKafkaMessageResult(false)
+		metrics.RecordMessageResult(false)
 		return fmt.Errorf("schemas, msg or handler is nil")
 	}
-	metrics.RecordKafkaLatency(msg.Timestamp)
+	metrics.RecordMessageLatency(msg.Timestamp)
 	if msg.TopicPartition.Topic == nil {
-		metrics.RecordKafkaMessageResult(false)
+		metrics.RecordMessageResult(false)
 		return fmt.Errorf("Topic cannot be nil")
 	}
 
 	internalTopic := TopicTranslationConfig.GetInternal(*msg.TopicPartition.Topic)
 	if internalTopic == "" {
-		metrics.RecordKafkaMessageResult(false)
+		metrics.RecordMessageResult(false)
 		return fmt.Errorf("Topic maping not found for: %s", *msg.TopicPartition.Topic)
 	}
 	log.Info().
@@ -147,15 +147,15 @@ func processConsumedMessage(schemas schema.TopicSchemas, msg *kafka.Message, han
 	logEventMessageInfo(msg, "Consuming message")
 
 	if err = schemas.ValidateMessage(msg); err != nil {
-		metrics.RecordKafkaMessageResult(false)
+		metrics.RecordMessageResult(false)
 		return err
 	}
 
 	// Dispatch message
 	if err = handler.OnMessage(msg); err != nil {
-		metrics.RecordKafkaMessageResult(false)
+		metrics.RecordMessageResult(false)
 		return err
 	}
-	metrics.RecordKafkaMessageResult(true)
+	metrics.RecordMessageResult(true)
 	return nil
 }

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -17,8 +17,8 @@ const (
 	PublicRepositories36HourIntrospectionTotal     = "public_repositories_36_hour_introspection_total"
 	PublicRepositoriesWithFailedIntrospectionTotal = "public_repositories_with_failed_introspection_total"
 	CustomRepositories36HourIntrospectionTotal     = "custom_repositories_36_hour_introspection_total"
-	KafkaMessageLatency                            = "kafka_message_latency"
-	KafkaMessageResultTotal                        = "kafka_message_result_total"
+	MessageLatency                                 = "message_latency"
+	MessageResultTotal                             = "message_result_total"
 	OrgTotal                                       = "org_total"
 )
 
@@ -31,8 +31,8 @@ type Metrics struct {
 	PublicRepositories36HourIntrospectionTotal     prometheus.GaugeVec
 	PublicRepositoriesWithFailedIntrospectionTotal prometheus.Gauge
 	CustomRepositories36HourIntrospectionTotal     prometheus.GaugeVec
-	KafkaMessageResultTotal                        prometheus.CounterVec
-	KafkaMessageLatency                            prometheus.Histogram
+	MessageResultTotal                             prometheus.CounterVec
+	MessageLatency                                 prometheus.Histogram
 	OrgTotal                                       prometheus.Gauge
 	reg                                            *prometheus.Registry
 }
@@ -52,16 +52,16 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"status", "method", "path"}),
 
-		KafkaMessageLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		MessageLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Namespace: NameSpace,
-			Name:      KafkaMessageLatency,
-			Help:      "Time to pickup kafka messages",
+			Name:      MessageLatency,
+			Help:      "Time to pickup task messages",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		KafkaMessageResultTotal: *promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		MessageResultTotal: *promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   NameSpace,
-			Name:        KafkaMessageResultTotal,
-			Help:        "Result of kafka messages",
+			Name:        MessageResultTotal,
+			Help:        "Result of task messages",
 			ConstLabels: nil,
 		}, []string{"state"}),
 		RepositoriesTotal: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
@@ -101,18 +101,18 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 	return metrics
 }
 
-func (m *Metrics) RecordKafkaMessageResult(success bool) {
+func (m *Metrics) RecordMessageResult(success bool) {
 	status := "failed"
 	if success {
 		status = "success"
 	}
 	if m != nil {
-		m.KafkaMessageResultTotal.With(prometheus.Labels{"state": status}).Inc()
+		m.MessageResultTotal.With(prometheus.Labels{"state": status}).Inc()
 	}
 }
-func (m *Metrics) RecordKafkaLatency(msgTime time.Time) {
+func (m *Metrics) RecordMessageLatency(msgTime time.Time) {
 	diff := time.Since(msgTime)
-	m.KafkaMessageLatency.Observe(diff.Seconds())
+	m.MessageLatency.Observe(diff.Seconds())
 }
 
 func (m Metrics) Registry() *prometheus.Registry {


### PR DESCRIPTION
So that we can reuse them when we switch to a newer tasking system

