### PR TITLE
Fixes 1364: do not require auth for openapi.json

### DIFF
--- a/pkg/handler/popular_repositories_test.go
+++ b/pkg/handler/popular_repositories_test.go
@@ -32,7 +32,7 @@ var popularRepository = api.PopularRepositoryResponse{
 func servePopularRepositoriesRouter(req *http.Request, mockDao *mocks.RepositoryConfigDao) (int, []byte, error) {
 	router := echo.New()
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
-	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	pathPrefix := router.Group(fullRootPath())
 
 	repoDao := dao.RepositoryConfigDao(mockDao)

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -77,7 +77,7 @@ func serveRepositoriesRouter(req *http.Request, mockDao *mocks.RepositoryConfigD
 	router.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
 		TargetHeader: "x-rh-insights-request-id",
 	}))
-	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
 	pathPrefix := router.Group(fullRootPath())
 

--- a/pkg/handler/repository_parameters_test.go
+++ b/pkg/handler/repository_parameters_test.go
@@ -25,7 +25,7 @@ import (
 func serveRepositoryParametersRouter(req *http.Request, mockDao *mocks.RepositoryConfigDao) (int, []byte, error) {
 	router := echo.New()
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
-	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	pathPrefix := router.Group(fullRootPath())
 
 	repoDao := dao.RepositoryConfigDao(mockDao)

--- a/pkg/handler/repository_rpms_test.go
+++ b/pkg/handler/repository_rpms_test.go
@@ -33,7 +33,7 @@ func serveRpmsRouter(req *http.Request, mockDao *mock_dao.RpmDao) (int, []byte, 
 	router.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
 		TargetHeader: "x-rh-insights-request-id",
 	}))
-	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	pathPrefix := router.Group(fullRootPath())
 
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
@@ -63,7 +63,7 @@ func (suite *RpmSuite) SetupTest() {
 	suite.echo.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
 		TargetHeader: "x-rh-insights-request-id",
 	}))
-	suite.echo.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	suite.echo.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 }
 
 func (suite *RpmSuite) TearDownTest() {

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -30,15 +30,21 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_midd
 	}
 }
 
-func SkipLiveness(c echo.Context) bool {
+func SkipAuth(c echo.Context) bool {
 	p := c.Request().URL.Path
-	if p == "/ping" || p == "/ping/" {
-		return true
+	skipped := []string{"ping", "openapi.json"}
+	for i := 0; i < len(skipped); i++ {
+		path := skipped[i]
+
+		if p == "/"+path || p == "/"+path+"/" {
+			return true
+		}
+		if strings.HasPrefix(p, "/api/"+config.DefaultAppName+"/") &&
+			len(strings.Split(p, "/")) == 5 &&
+			strings.Split(p, "/")[4] == path {
+			return true
+		}
 	}
-	if strings.HasPrefix(p, "/api/"+config.DefaultAppName+"/") &&
-		len(strings.Split(p, "/")) == 5 &&
-		strings.Split(p, "/")[4] == "ping" {
-		return true
-	}
+
 	return false
 }

--- a/pkg/middleware/enforce_identity_test.go
+++ b/pkg/middleware/enforce_identity_test.go
@@ -23,14 +23,14 @@ func TestSkipLivenessTrue(t *testing.T) {
 	}
 	e := echo.New()
 	handler.RegisterPing(e)
-	e.Use(WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipLiveness))
+	e.Use(WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipAuth))
 
 	for _, route := range listRoutes {
 		req := httptest.NewRequest(http.MethodGet, route, nil)
 		res := httptest.NewRecorder()
 		c := e.NewContext(req, res)
 
-		result := SkipLiveness(c)
+		result := SkipAuth(c)
 		assert.True(t, result)
 	}
 }
@@ -42,14 +42,14 @@ func TestSkipLivenessFalse(t *testing.T) {
 	}
 	e := echo.New()
 	handler.RegisterPing(e)
-	e.Use(WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipLiveness))
+	e.Use(WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipAuth))
 
 	for _, route := range listRoutes {
 		req := httptest.NewRequest(http.MethodGet, route, nil)
 		res := httptest.NewRecorder()
 		c := e.NewContext(req, res)
 
-		result := SkipLiveness(c)
+		result := SkipAuth(c)
 		assert.False(t, result)
 	}
 }
@@ -64,7 +64,7 @@ func TestWrapMiddlewareWithSkipper(t *testing.T) {
 		listSuccessPaths []string
 	)
 	e := echo.New()
-	m := WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipLiveness)
+	m := WrapMiddlewareWithSkipper(identity.EnforceIdentity, SkipAuth)
 
 	IdentityHeader := "X-Rh-Identity"
 	xrhidentityHeaderSuccess := `{"identity":{"type":"Associate","account_number":"2093","internal":{"org_id":"7066"}}}`

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -49,7 +49,7 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 
 	// Add additional global middlewares
 	e.Use(middleware.CreateMetricsMiddleware(metrics))
-	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipLiveness))
+	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	if config.Get().Clients.RbacEnabled {
 		rbacBaseUrl := config.Get().Clients.RbacBaseUrl
 		rbacTimeout := time.Duration(int64(config.Get().Clients.RbacTimeout) * int64(time.Second))
@@ -60,7 +60,7 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 			middleware.NewRbac(
 				middleware.Rbac{
 					BaseUrl:        config.Get().Clients.RbacBaseUrl,
-					Skipper:        middleware.SkipLiveness,
+					Skipper:        middleware.SkipAuth,
 					PermissionsMap: middleware.ServicePermissions,
 					Client:         rbacClient,
 				},


### PR DESCRIPTION
## Summary
Stop requiring auth for requests to openapi.json

## Testing steps
run server
run: ```curl localhost:8000/api/content-sources/v1/openapi.json```
