### PR TITLE
Fixes 1507: use deprecated security proto config

### DIFF
--- a/pkg/config/event.go
+++ b/pkg/config/event.go
@@ -47,6 +47,9 @@ func addEventConfigDefaults(options *viper.Viper) {
 				options.Set("kafka.sasl.username", *broker.Sasl.Username)
 				options.Set("kafka.sasl.password", *broker.Sasl.Password)
 				options.Set("kafka.sasl.mechanism", *broker.Sasl.SaslMechanism)
+				if broker.Sasl.SecurityProtocol != nil { // nolint:staticcheck
+					options.Set("kafka.sasl.protocol", *broker.Sasl.SecurityProtocol) // nolint:staticcheck
+				}
 				if broker.SecurityProtocol != nil {
 					options.Set("kafka.sasl.protocol", *broker.SecurityProtocol)
 				}


### PR DESCRIPTION
## Summary
https://github.com/content-services/content-sources-backend/commit/3f26de3b5798caf97e2c20e7d4c7bf48d7562cf6 

moved us away from using a now deprecated clowder setting, but it turns out the non-deprecated setting isn't actually populated.  This now checks and tries to use either if they are populated.

## Testing steps
Deploy to stage.