### PR TITLE
Refs 1203: adjust message latency bucket sizes

### DIFF
--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -56,7 +56,8 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Namespace: NameSpace,
 			Name:      MessageLatency,
 			Help:      "Time to pickup task messages",
-			Buckets:   prometheus.DefBuckets,
+			//                        1m  5m   30m   1h    2h    3h     5h     10h
+			Buckets: []float64{.5, 1, 60, 300, 1800, 3600, 7200, 10800, 18000, 36000},
 		}),
 		MessageResultTotal: *promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace:   NameSpace,


### PR DESCRIPTION
## Summary
The bucket sizes weren't conducive to writing alerts or really even defining the SLO, this increases them greatly.

## Testing steps
None needed?  check the metrics after creating a repo maybe?
