### PR TITLE
Fixes 1149: make rpm name search api case insenstive

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -190,7 +190,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest) ([]api.Se
 		Joins("inner join repositories on repositories.uuid = repositories_rpms.repository_uuid").
 		Joins("left join repository_configurations on repository_configurations.repository_uuid = repositories.uuid").
 		Where(orGroupPublicOrPrivate).
-		Where("rpms.name LIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
+		Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
 		Where(r.db.Where("repositories.url in ?", urls).
 			Or("repository_configurations.uuid in ?", uuids)).
 		Order("rpms.name ASC").


### PR DESCRIPTION
## Summary
IB is requesting that rpm name search be case insensitive 
## Testing steps

Run these requests:
```
### Create a single repository
POST http://{{host}}/api/content-sources/v1.0/repositories/
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiQXNzb2NpYXRlIiwiYWNjb3VudF9udW1iZXIiOiIxIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K

{
  "name": "needed2",
  "url": "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/",
  "distribution_versions": [
    "8"
  ],
  "distribution_arch": "x86_64"
}


### Rpm search
POST  http://{{host}}/api/content-sources/v1.0/rpms/names
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiQXNzb2NpYXRlIiwiYWNjb3VudF9udW1iZXIiOiIxIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K

{
  "urls": [
    "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/"
  ],
  "search": "Walrus"
}
```

you should get results for 'walrus'