### PR TITLE
Fixes 1564: Update migration to prevent status ui bug

### DIFF
--- a/db/migrations/20230215133838_RenameEpelUrls.up.sql
+++ b/db/migrations/20230215133838_RenameEpelUrls.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-INSERT into repositories (uuid, url) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/') ON CONFLICT DO NOTHING;
+INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
 --- Update repo_configs and set the repo_uuid to the new url's repository, only if the repository_config is part of an org that does not also have the new url already
 UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/')
     where repository_configurations.uuid in (
@@ -12,7 +12,7 @@ UPDATE repository_configurations set repository_uuid = (select uuid from reposit
                                             inner join  repositories r2 on r2.uuid = rc2.repository_uuid
                                             where r2.url = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'));
 
-INSERT into repositories (uuid, url) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/') ON CONFLICT DO NOTHING;
+INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
 
 UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/')
 where repository_configurations.uuid in (
@@ -25,7 +25,7 @@ where repository_configurations.uuid in (
                               where r2.url = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/'));
 
 
-INSERT into repositories (uuid, url) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/7/x86_64/') ON CONFLICT DO NOTHING;
+INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/7/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
 UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/7/x86_64/')
 where repository_configurations.uuid in (
     select rc.uuid from repository_configurations rc


### PR DESCRIPTION
## Summary
This fixes an issue where in dev/ephemeral environments adding a "Popular Repository" would cause the API to return a Status of "" (empty string). 
This prevented the UI from updating the repository list the frontend looks at a repository's "Status" to determine whether or not to poll the API.

## Testing steps
Add a popular repository that needs to introspect.
One you haven't added before, or clean out your database.

After adding quickly switch to the repository list view you should see a blank status.

Result after fixing: 
It should say Pending, or any state, if introspection has finished.