### PR TITLE
Fixes 1568: lower log level on introspect errors

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -60,9 +60,12 @@ func main() {
 			}
 		}
 
-		count, errors := external_repos.IntrospectAll(&urls, forceIntrospect)
+		count, introErrors, errors := external_repos.IntrospectAll(&urls, forceIntrospect)
+		for i := 0; i < len(introErrors); i++ {
+			log.Warn().Msgf("Introspection Error: %v", introErrors[i].Error())
+		}
 		for i := 0; i < len(errors); i++ {
-			log.Panic().Err(errors[i]).Msg("Failed to introspect repository")
+			log.Panic().Err(errors[i]).Msg("Failed to introspect repository due to fatal errors")
 		}
 		log.Debug().Msgf("Inserted %d packages", count)
 	} else if args[1] == "introspect-all" {
@@ -75,9 +78,12 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		count, errors := external_repos.IntrospectAll(nil, forceIntrospect)
+		count, introErrors, errors := external_repos.IntrospectAll(nil, forceIntrospect)
+		for i := 0; i < len(introErrors); i++ {
+			log.Warn().Msgf("Introspection Error: %v", introErrors[i].Error())
+		}
 		for i := 0; i < len(errors); i++ {
-			log.Err(errors[i]).Msg("Introspection Error")
+			log.Error().Err(errors[i]).Msg("Fatal Introspection Error")
 		}
 
 		log.Debug().Msgf("Inserted %d packages", count)

--- a/pkg/event/handler/introspect.go
+++ b/pkg/event/handler/introspect.go
@@ -46,12 +46,14 @@ func (h *IntrospectHandler) OnMessage(msg *kafka.Message) error {
 		return err
 	}
 
-	newRpms, errs := external_repos.IntrospectUrl(payload.Url, true)
-	if len(errs) > 0 {
-		// Introspection failure isn't considered a message failure, as the message has been handled
-		for i := 0; i < len(errs); i++ {
-			log.Error().Err(errs[i]).Msgf("Error %v introspecting repository %v", i, payload.Url)
-		}
+	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(payload.Url, true)
+	for i := 0; i < len(nonFatalErrs); i++ {
+		log.Warn().Err(nonFatalErrs[i]).Msgf("Error %v introspecting repository %v", i, payload.Url)
+	}
+
+	// Introspection failure isn't considered a message failure, as the message has been handled
+	for i := 0; i < len(errs); i++ {
+		log.Error().Err(errs[i]).Msgf("Error %v introspecting repository %v", i, payload.Url)
 	}
 	log.Debug().Msgf("IntrospectionUrl returned %d new packages", newRpms)
 	return nil

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -25,8 +25,9 @@ const (
 )
 
 // IntrospectUrl Fetch the metadata of a url and insert RPM data
-// Returns the number of new RPMs inserted system-wide and any error encountered
-func IntrospectUrl(url string, force bool) (int64, []error) {
+// Returns the number of new RPMs inserted system-wide, any introspection errors,
+// and any fatal errors
+func IntrospectUrl(url string, force bool) (int64, []error, []error) {
 	urls := []string{url}
 	return IntrospectAll(&urls, force)
 }
@@ -116,14 +117,16 @@ func reposForIntrospection(urls *[]string) ([]dao.Repository, []error) {
 }
 
 // IntrospectAll introspects all repositories
-// Returns the number of new RPMs inserted system-wide and all errors encountered
-func IntrospectAll(urls *[]string, force bool) (int64, []error) {
+// Returns the number of new RPMs inserted system-wide, all non-fatal introspection errors,
+// and separately all other fatal errors
+func IntrospectAll(urls *[]string, force bool) (int64, []error, []error) {
 	var (
-		total   int64
-		count   int64
-		err     error
-		rpmDao  = dao.GetRpmDao(db.DB)
-		repoDao = dao.GetRepositoryDao(db.DB)
+		total               int64
+		count               int64
+		err                 error
+		rpmDao              = dao.GetRpmDao(db.DB)
+		repoDao             = dao.GetRepositoryDao(db.DB)
+		introspectionErrors []error
 	)
 	repos, errors := reposForIntrospection(urls)
 	for i := 0; i < len(repos); i++ {
@@ -140,7 +143,7 @@ func IntrospectAll(urls *[]string, force bool) (int64, []error) {
 		total += count
 
 		if err != nil {
-			errors = append(errors, fmt.Errorf("Error introspecting %s: %s", repos[i].URL, err.Error()))
+			introspectionErrors = append(introspectionErrors, fmt.Errorf("Error introspecting %s: %s", repos[i].URL, err.Error()))
 		}
 		err = UpdateIntrospectionStatusMetadata(repos[i], repoDao, count, err)
 		if err != nil {
@@ -155,7 +158,7 @@ func IntrospectAll(urls *[]string, force bool) (int64, []error) {
 	if err != nil {
 		errors = append(errors, err)
 	}
-	return total, errors
+	return total, introspectionErrors, errors
 }
 
 func needsIntrospect(repo *dao.Repository) (bool, string) {


### PR DESCRIPTION
## Summary
This separates introspection errors from internal errors to better report them separately

## Testing steps

run the server locally, and run the following request:

```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/" \
    -H "Content-Type: application/json" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiQXNzb2NpYXRlIiwiYWNjb3VudF9udW1iZXIiOiIxIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K" \
    -d "{
          \"name\": \"needed3\",
          \"url\": \"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata3/\",
          \"distribution_versions\": [
            \"8\"
          ],
          \"distribution_arch\": \"x86_64\"
        }"
```

Then monitor the server logs:

```
11:22AM INF Forcing introspection for 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata3/'
11:22AM WRN Error 0 introspecting repository https://jlsherrill.fedorapeople.org/fake-repos/needed-errata3/ error="Error introspecting https://jlsherrill.fedorapeople.org/fake-repos/needed-errata3/: Cannot fetch https://jlsherrill.fedorapeople.org/fake-repos/needed-errata3/repodata/repomd.xml: 404"
```

you should see a WARN message, and not a FAIL message.

Also try running: 

```
go run cmd/external-repos/main.go introspect-all --force
```

you should see:

```
{"level":"warn","time":"2023-04-05T11:47:02-04:00","message":"Introspection Error: Error introspecting https://jlsherrill.fedorapeople.org/fake-repos/needed-errata2/: Cannot fetch https://jlsherrill.fedorapeople.org/fake-repos/needed-errata2/repodata/repomd.xml: 404"}

```
which is now warn
