### PR TITLE
Change integration test template to not restart containers on failure

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -16,7 +16,7 @@ objects:
       spec:
         imagePullSecrets:
         - name: quay-cloudservices-pull
-        restartPolicy: OnFailure
+        restartPolicy: Never
         volumes:
         - name: sel-shm
           emptyDir:


### PR DESCRIPTION
## Summary
This PR updates the integration-testing template to never restart the testing or selenium containers.

## Testing steps
