### PR TITLE
Update e2e test template to pull testing image every time

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -15,6 +15,7 @@ objects:
     backoffLimit: 0
     template:
       spec:
+        imagePullPolicy: Always
         imagePullSecrets:
         - name: quay-cloudservices-pull
         restartPolicy: Never


### PR DESCRIPTION
## Summary
This PR updates the e2e test template to use an `imagePullPolicy` of `Always` for the testing container image. This is required because we always use the same `hms-integration` image tag to point to the latest build, and by default tags other than `latest` are not re-pulled.

## Testing steps
