### PR TITLE
Fixes 1759: add 9.2 repos

### DIFF
--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -54,6 +54,12 @@
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.1/x86_64/baseos/os"
     },
     {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.2/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.2/x86_64/baseos/os"
+    },
+    {
         "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
     },
     {


### PR DESCRIPTION
## Summary
Image builder will support rhel 9.2 soon.  We need to add repos to support them.

## Testing steps
can't test now, as these repos aren't live