### PR TITLE
Refs 1770: add cert expiry metric

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,6 +20,10 @@ func TestConfigureCertificateFile(t *testing.T) {
 	cert, err := ConfigureCertificate()
 	assert.Nil(t, err)
 	assert.NotNil(t, cert)
+
+	days, err := DaysTillExpiration(cert)
+	assert.NoError(t, err)
+	assert.True(t, days > 0)
 }
 
 func TestConfigureCertificateEnv(t *testing.T) {

--- a/pkg/instrumentation/custom/collector.go
+++ b/pkg/instrumentation/custom/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/instrumentation"
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,6 +42,7 @@ func (c *Collector) iterate() {
 	c.metrics.RepositoryConfigsTotal.Set(float64(c.dao.RepositoryConfigsCount()))
 	c.metrics.RepositoryConfigsTotal.Set(float64(c.dao.RepositoryConfigsCount()))
 	c.metrics.OrgTotal.Set(float64(c.dao.OrganizationTotal()))
+	c.metrics.RHCertExpiryDays.Set(float64(config.Get().Certs.DaysTillExpiration))
 
 	public := c.dao.RepositoriesIntrospectionCount(36, true)
 	c.metrics.PublicRepositories36HourIntrospectionTotal.With(prometheus.Labels{"status": "introspected"}).Set(float64(public.Introspected))

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -20,6 +20,7 @@ const (
 	MessageLatency                                 = "message_latency"
 	MessageResultTotal                             = "message_result_total"
 	OrgTotal                                       = "org_total"
+	RHCertExpiryDays                               = "rh_cert_expiry_days"
 )
 
 type Metrics struct {
@@ -34,6 +35,7 @@ type Metrics struct {
 	MessageResultTotal                             prometheus.CounterVec
 	MessageLatency                                 prometheus.Histogram
 	OrgTotal                                       prometheus.Gauge
+	RHCertExpiryDays                               prometheus.Gauge
 	reg                                            *prometheus.Registry
 }
 
@@ -94,6 +96,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Namespace: NameSpace,
 			Name:      OrgTotal,
 			Help:      "Number of organizations with at least one repository.",
+		}),
+		RHCertExpiryDays: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      RHCertExpiryDays,
+			Help:      "Number of days until the Red Hat client certificate expires",
 		}),
 	}
 


### PR DESCRIPTION

## Summary
this adds a new metric "content_sources_rh_cert_expiry_days", that signifies the number of days until the current RH cert expires

## Testing steps
Ensure you have a cdn cert configured in your config.yaml, run the server, then run:
```
curl localhost:9000/metrics | grep expi
```

you'll see something like:

```
# HELP content_sources_rh_cert_expiry_days Number of days until the Red Hat client certificate expires
# TYPE content_sources_rh_cert_expiry_days gauge
content_sources_rh_cert_expiry_days 23
```