### PR TITLE
Refs 1468: fix compose up and pulp

### DIFF
--- a/mk/pulp.mk
+++ b/mk/pulp.mk
@@ -7,7 +7,7 @@ PULP_COMPOSE_COMMAND=$(PULP_COMPOSE_OPTIONS) $(DOCKER)-compose --project-name=$(
 PULP_COMPOSE_DOWN_COMMAND=$(PULP_COMPOSE_OPTIONS) $(DOCKER)-compose --project-name=$(COMPOSE_PROJECT_NAME) -f $(PULP_COMPOSE_FILES) down
 else
 PULP_COMPOSE_COMMAND=echo "Skipping pulp deploy, set DEPLOY_PULP=true to deploy"
-PULP_COMPOSE_DOWN_COMMAND=true
+PULP_COMPOSE_DOWN_COMMAND="true"
 endif
 
 compose_files/pulp/pulp-oci-images:


### PR DESCRIPTION
## Summary
the previous change enabled pulp during compose commands by default improperly, this fixes it


## Testing steps
```make compose-clean compose-up```

check if pulp is enabled: `podman ps`