### PR TITLE
Fixes 1865: fix repository list filters

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -175,11 +175,11 @@ func (r repositoryConfigDaoImpl) List(
 	}
 
 	if filterData.AvailableForArch != "" {
-		filteredDB = filteredDB.Where("arch = ? OR arch = ''", filterData.AvailableForArch)
+		filteredDB = filteredDB.Where("arch = ? OR arch = '' OR arch = 'any'", filterData.AvailableForArch)
 	}
 	if filterData.AvailableForVersion != "" {
 		filteredDB = filteredDB.
-			Where("? = any (versions) OR array_length(versions, 1) IS NULL", filterData.AvailableForVersion)
+			Where("? = any (versions) OR 'any' = any (versions) OR array_length(versions, 1) IS NULL", filterData.AvailableForVersion)
 	}
 
 	if filterData.Search != "" {


### PR DESCRIPTION
## Summary

Takes into account 'any' in AvailableForArch/AvailableForVersion filters.

## Testing steps

1.  create a repository with arch 'x86_64'
2. create a 2nd repository with arch any
3.  curl  /api/content-sources/v1/repositories/?available_for_arch=x86_64

you should get both repositories.
Repeat a similar test for distribution_version and available_for_version
