### PR TITLE
Fixes 602: Revert previous commit (Glitchtip)

### DIFF
--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -31,7 +31,7 @@ func SendNotification(orgId string, eventName EventName, repos []repositories.Re
 		saramaConfig.Version = sarama.V2_0_0_0
 		saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 
-		protocol, err := kafka_sarama.NewProtocol(kafkaServers, saramaConfig, "platform.notifications.ingress", "some.dummy.ingress")
+		protocol, err := kafka_sarama.NewSender(kafkaServers, saramaConfig, "platform.notifications.ingress")
 		if err != nil {
 			log.Error().Err(err).Msg("failed to create kafka_sarama protocol")
 			return


### PR DESCRIPTION
## Summary

Previous commit caused an error to do with an unfound dummy kafka ingress. 
This reverts that and prevents the error, it will likely not fix the failing notifications.

## Testing steps
