### PR TITLE
Fixes 1470: switch nightly introspect to tasking system

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -213,7 +213,7 @@ objects:
               - mountPath: /tmp
                 name: tmpdir
       jobs:
-        - name: introspect-all
+        - name: nightly-jobs
           # https://crontab.guru/
           schedule: "0 0/8 * * *"
           concurrencyPolicy: "Forbid"
@@ -222,7 +222,7 @@ objects:
             inheritEnv: true
             command:
               - /external-repos
-              - introspect-all
+              - nightly-jobs
             env:
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -406,7 +406,7 @@ func (rh *RepositoryHandler) enqueueIntrospectEvent(c echo.Context, response api
 	var msg *message.IntrospectRequestMessage
 	var err error
 	if config.Get().NewTaskingSystem {
-		task := queue.Task{Typename: tasks.Introspect, Payload: tasks.IntrospectPayload{Url: response.URL}, OrgId: orgID, RepositoryUUID: response.RepositoryUUID}
+		task := queue.Task{Typename: tasks.Introspect, Payload: tasks.IntrospectPayload{Url: response.URL, Force: true}, OrgId: orgID, RepositoryUUID: response.RepositoryUUID}
 		_, err := rh.TaskClient.Enqueue(task)
 		if err != nil {
 			log.Error().Err(err).Msgf("error enqueuing tasks")

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -113,7 +113,7 @@ func mockTaskClientEnqueue(tcMock *client.TaskClientMock, expectedUrl string) {
 	if config.Get().NewTaskingSystem {
 		tcMock.On("Enqueue", queue.Task{
 			Typename:       tasks.Introspect,
-			Payload:        tasks.IntrospectPayload{Url: expectedUrl},
+			Payload:        tasks.IntrospectPayload{Url: expectedUrl, Force: true},
 			Dependencies:   nil,
 			OrgId:          test_handler.MockOrgId,
 			RepositoryUUID: "",

--- a/pkg/tasks/introspect.go
+++ b/pkg/tasks/introspect.go
@@ -14,7 +14,8 @@ import (
 const Introspect = "introspect"
 
 type IntrospectPayload struct {
-	Url string
+	Url   string
+	Force bool
 }
 
 // TODO possibly remove context arg
@@ -30,7 +31,7 @@ func IntrospectHandler(ctx context.Context, task *queue.TaskInfo, _ *queue.Queue
 		return err
 	}
 
-	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(p.Url, true)
+	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(p.Url, p.Force)
 	for i := 0; i < len(nonFatalErrs); i++ {
 		log.Warn().Err(nonFatalErrs[i]).Msgf("Error %v introspecting repository %v", i, p.Url)
 	}


### PR DESCRIPTION
## Summary
- Renames the `introspect-all` command to `nightly-jobs`
- If new tasking system has been enabled, adds each repository as introspect job to queue, instead of directly invoking introspect for all repositories

## Testing steps
1. Set `NEW_TASKING_SYSTEM` env var or `config.yaml` to true.
2. `go run cmd/external_repos/main.go nightly-jobs` will show `[Enqueued Task]...` for each repository.
3. Main server will need to be running for tasks to process.
4. Setting NEW_TASKING_SYSTEM to false should _not_ use the new tasking system, and instead directly invoke introspection for all repositories.