### PR TITLE
Fixes 1644: Enforce JSON Content Type

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -238,6 +238,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -305,6 +311,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
@@ -430,6 +442,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -535,6 +553,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
@@ -754,6 +778,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -819,6 +849,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -878,6 +914,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -805,6 +805,16 @@
                         },
                         "description": "Not Found"
                     },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -892,6 +902,16 @@
                             }
                         },
                         "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
                     },
                     "500": {
                         "content": {
@@ -1112,6 +1132,16 @@
                         },
                         "description": "Not Found"
                     },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -1194,6 +1224,16 @@
                             }
                         },
                         "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
                     },
                     "500": {
                         "content": {
@@ -1471,6 +1511,16 @@
                         },
                         "description": "Not Found"
                     },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -1551,6 +1601,16 @@
                         },
                         "description": "Not Found"
                     },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
                     "500": {
                         "content": {
                             "application/json": {
@@ -1627,6 +1687,16 @@
                             }
                         },
                         "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
                     },
                     "500": {
                         "content": {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -131,6 +131,7 @@ func (rh *RepositoryHandler) listRepositories(c echo.Context) error {
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/ [post]
 func (rh *RepositoryHandler) createRepository(c echo.Context) error {
@@ -171,6 +172,7 @@ func (rh *RepositoryHandler) createRepository(c echo.Context) error {
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/bulk_create/ [post]
 func (rh *RepositoryHandler) bulkCreateRepositories(c echo.Context) error {
@@ -252,6 +254,7 @@ func (rh *RepositoryHandler) fetch(c echo.Context) error {
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/{uuid} [put]
 func (rh *RepositoryHandler) fullUpdate(c echo.Context) error {
@@ -271,6 +274,7 @@ func (rh *RepositoryHandler) fullUpdate(c echo.Context) error {
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/{uuid} [patch]
 func (rh *RepositoryHandler) partialUpdate(c echo.Context) error {

--- a/pkg/handler/repository_parameters.go
+++ b/pkg/handler/repository_parameters.go
@@ -38,6 +38,7 @@ func RegisterRepositoryParameterRoutes(engine *echo.Group, dao *dao.DaoRegistry)
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repository_parameters/external_gpg_key [post]
 func (rh *RepositoryParameterHandler) fetchGpgKey(c echo.Context) error {
@@ -90,6 +91,7 @@ func (rh *RepositoryParameterHandler) listParameters(c echo.Context) error {
 // @Failure         400 {object} ce.ErrorResponse
 // @Failure      	401 {object} ce.ErrorResponse
 // @Failure         404 {object} ce.ErrorResponse
+// @Failure      	415 {object} ce.ErrorResponse
 // @Failure         500 {object} ce.ErrorResponse
 // @Router			/repository_parameters/validate/ [post]
 func (rph *RepositoryParameterHandler) validate(c echo.Context) error {

--- a/pkg/handler/repository_rpms.go
+++ b/pkg/handler/repository_rpms.go
@@ -34,6 +34,7 @@ func RegisterRepositoryRpmRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /rpms/names [post]
 func (rh *RepositoryRpmHandler) searchRpmByName(c echo.Context) error {

--- a/pkg/middleware/enforce_json.go
+++ b/pkg/middleware/enforce_json.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"mime"
+	"net/http"
+
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
+	"github.com/labstack/echo/v4"
+)
+
+const JSONMimeType = "application/json"
+
+func enforceJSONContentTypeSkipper(c echo.Context) bool {
+	return c.Request().Body == http.NoBody
+}
+
+func EnforceJSONContentType(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if enforceJSONContentTypeSkipper(c) {
+			return next(c)
+		}
+		mediatype, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
+		if err != nil {
+			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
+		}
+		if mediatype != JSONMimeType {
+			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
+		}
+		return next(c)
+	}
+}

--- a/pkg/middleware/enforce_json_test.go
+++ b/pkg/middleware/enforce_json_test.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func serveRouter(method string, contentType string, path string, includeBody bool) (int, []byte, error) {
+	router := echo.New()
+	router.Use(EnforceJSONContentType)
+	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
+
+	router.Add(method, path, func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"Status": "OK"})
+	})
+
+	var req *http.Request
+	if includeBody {
+		req = httptest.NewRequest(method, path, strings.NewReader("body"))
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	response := rr.Result()
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	return response.StatusCode, body, err
+}
+
+func TestEnforceJSONSkipper(t *testing.T) {
+	router := echo.New()
+	path := "/"
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader("body"))
+	ctx := router.NewContext(req, nil)
+	assert.False(t, enforceJSONContentTypeSkipper(ctx))
+
+	// Skips check if no body
+	noBodyReq := httptest.NewRequest(http.MethodGet, path, nil)
+	noBodyCtx := router.NewContext(noBodyReq, nil)
+	assert.True(t, enforceJSONContentTypeSkipper(noBodyCtx))
+}
+
+func TestJSONContentType(t *testing.T) {
+	path := "/"
+	status, _, err := serveRouter(http.MethodPatch, "application/json", path, true)
+	assert.Equal(t, http.StatusOK, status)
+	assert.NoError(t, err)
+
+	withParameterStatus, _, withParameterErr := serveRouter(http.MethodPut, "application/json; parameter=value", path, true)
+	assert.Equal(t, http.StatusOK, withParameterStatus)
+	assert.NoError(t, withParameterErr)
+}
+
+func TestInvalidContentType(t *testing.T) {
+	testCases := []struct {
+		method       string
+		contentType  string
+		errorMessage string
+	}{
+		{http.MethodPost, "text/html", "Incorrect content type"},
+		{http.MethodPatch, "not a valid content type", "Error parsing content type"},
+		{http.MethodPut, "", "Error parsing content type"},
+	}
+
+	for _, testCase := range testCases {
+		status, body, err := serveRouter(testCase.method, testCase.contentType, "/", true)
+		assert.Equal(t, http.StatusUnsupportedMediaType, status)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), testCase.errorMessage)
+	}
+}
+
+func TestSkippedRoutes(t *testing.T) {
+	status, _, err := serveRouter(http.MethodPost, "", "/", false)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -32,6 +32,7 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		RequestIDKey: "x-rh-insights-request-id",
 		Skipper:      config.SkipLogging,
 	}))
+	e.Use(middleware.EnforceJSONContentType)
 
 	// Add routes
 	handler.RegisterPing(e)


### PR DESCRIPTION
## Summary

Adds middleware `EnforceJSONContentType` that returns an error with status code 415 "Unsupported Media Type" if the Content-Type header is missing, invalid, or not `application/json`. If the Content-Type has optional parameters (e.g. `application/json; parameter=value`), it is still accepted.

The middleware is added at root level and applied to any request that has a body

It affects the following endpoints: 

1. /rpms/names [post] - searchRpmByName
2. /repository_parameters/external_gpg_key/ [post] - fetchGpgKey
3. /repository_parameters/validate/ [post] - validate
4. /repositories [post] - createRepository
5. /repositories/bulk_create/ [post] - bulkCreateRepositories
6. /repositories/{uuid} [put] - fullUpdate
7. /repositories/{uuid} [patch] - partialUpdate

/repositories/{uuid}/introspect/ [post] accepts an optional JSON body, so the middleware is only applied when the body is passed in.

## Testing steps

Make a curl request to any of the 7 endpoints without setting the Content-Type header or with a Content-Type header that isn't `application/json`

 `curl -H "$( ./scripts/header.sh 9999 1111 )" "http://localhost:8000/api/content-sources/v1.0/rpms/names" -X POST -d '{ "urls": [ "https://omaciel.fedorapeople.org/fakerepo01/", "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/" ],   "search": "3" } '`

Curl seems to set the content type to `application/x-www-form-urlencoded` by default so if no content type is specified, the error title returned will be "Incorrect content type" 

To get "Error parsing content type" make a request with an empty Content-Type or a value that doesn't follow the MIME type format

 `curl -H "$( ./scripts/header.sh 9999 1111 )" "http://localhost:8000/api/content-sources/v1.0/rpms/names" -X POST -d '{ "urls": [ "https://omaciel.fedorapeople.org/fakerepo01/", "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/" ],   "search": "3" } ' -H "Content-Type:"`

 `curl -H "$( ./scripts/header.sh 9999 1111 )" "http://localhost:8000/api/content-sources/v1.0/rpms/names" -X POST -d '{ "urls": [ "https://omaciel.fedorapeople.org/fakerepo01/", "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/" ],   "search": "3" } ' -H "Content-Type: not a valid type"`