### PR TITLE
Refs 1871: Deployments: Introspect rhel-8.8 in ephemeral

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -49,7 +49,7 @@ objects:
                   - /external-repos
                   - introspect
                   - https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os
-                  - https://cdn.redhat.com/content/dist/rhel8/8.7/x86_64/baseos/os
+                  - https://cdn.redhat.com/content/dist/rhel8/8.8/x86_64/baseos/os
             image: ${IMAGE}:${IMAGE_TAG}
             livenessProbe:
               failureThreshold: 3


### PR DESCRIPTION
We started building rhel-8.8 images and so we now need to also update the repository introspection in ephemeral environments.

Related to https://github.com/content-services/content-sources-backend/pull/301

## Summary

## Testing steps
