### PR TITLE
Refs 602: allow notifications to local kafka

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -24,6 +24,7 @@ kafka:
   timeout: 10000
   topics:
     - platform.content-sources.introspect
+    - platform.notifications.ingress
   # sasl:
   #   username: someusername
   #   passowrd: somepassword


### PR DESCRIPTION
## Summary
This allows local testing of notification message sending

## Testing steps

1) configure your config for kafka if not already:
```
kafka:
  auto:
    offset:
      reset: latest
    commit:
      interval:
        ms: 5000
  bootstrap:
    servers: localhost:9092
  group:
    id: content-sources
  message:
    send:
      max:
        retries: 15
  request:
    timeout:
      ms: 30000
    required:
      acks: -1
  retry:
    backoff:
      ms: 100
  timeout: 10000
  topics:
    - platform.content-sources.introspect
    - platform.notifications.ingress
```
2) run server `make run`
3) run listener ` KAFKA_TOPIC=platform.notifications.ingress make  kafka-topic-consume`
4) create a bulk repo and see the notification
