### PR TITLE
Fixes 25: Remove selenium container from testing.yaml

### DIFF
--- a/deployments/testing.yaml
+++ b/deployments/testing.yaml
@@ -20,10 +20,6 @@ objects:
         filter: ''
         marker: 'smoke and api'
         plugins: content_sources
-        ui: 
-          enabled: true
-          selenium:
-            deploy: true
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
## Summary
The test deployment in testing.yaml only runs api tests, so the `ui` section is unnecessary and creates an unused selenium container for each deployment. This PR removes the `ui` section so that the container isn't created at all.

## Testing steps
N/A