### PR TITLE
Fixes 1924: move notifications loading to startup

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -71,6 +71,8 @@ func main() {
 	if argsContain(args, "mock_rbac") {
 		mockRbac(ctx, &wg)
 	}
+	config.SetupNotifications()
+
 	wg.Wait()
 }
 


### PR DESCRIPTION
## Summary
Notifications Client loading spawns a go routine which seemed to cause an issue with worker shutdown in tests.

## Testing steps
Tests pass, notifications still are sent.