### PR TITLE
Fixes 1624: adds config/api detailing features

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -20,6 +20,30 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/features/": {
+            "get": {
+                "description": "Get features available for the user within their Organization",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "features"
+                ],
+                "summary": "List Features within the application, whether they are enabled, and whether the requesting user can use them",
+                "operationId": "listFeatures",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.FeatureSet"
+                        }
+                    }
+                }
+            }
+        },
         "/popular_repositories/": {
             "get": {
                 "description": "Get popular repositories",
@@ -1116,6 +1140,25 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.Feature": {
+            "type": "object",
+            "properties": {
+                "accessible": {
+                    "description": "Whether the current user can access the feature",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "description": "Whether the feature is enabled on the running server",
+                    "type": "boolean"
+                }
+            }
+        },
+        "api.FeatureSet": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/api.Feature"
+            }
+        },
         "api.FetchGPGKeyResponse": {
             "type": "object",
             "properties": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,6 +1,25 @@
 {
     "components": {
         "schemas": {
+            "api.Feature": {
+                "properties": {
+                    "accessible": {
+                        "description": "Whether the current user can access the feature",
+                        "type": "boolean"
+                    },
+                    "enabled": {
+                        "description": "Whether the feature is enabled on the running server",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "api.FeatureSet": {
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/api.Feature"
+                },
+                "type": "object"
+            },
             "api.FetchGPGKeyResponse": {
                 "properties": {
                     "gpg_key": {
@@ -621,6 +640,28 @@
     },
     "openapi": "3.0.3",
     "paths": {
+        "/features/": {
+            "get": {
+                "description": "Get features available for the user within their Organization",
+                "operationId": "listFeatures",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.FeatureSet"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    }
+                },
+                "summary": "List Features within the application, whether they are enabled, and whether the requesting user can use them",
+                "tags": [
+                    "features"
+                ]
+            }
+        },
         "/popular_repositories/": {
             "get": {
                 "description": "Get popular repositories",

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -99,5 +99,11 @@ mocks:
     user_read: ["tdoe@example.com"]
     user_no_permissions: ["xdoe@example.com"]
 
+features:
+  snapshots:
+    enabled: true
+    accounts: ["snapAccount"]
+    users: ["snapUser"]
+
 # Replace kafka with postgres tasking system for introspection
 new_tasking_system: True

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -101,6 +101,10 @@ objects:
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: NEW_TASKING_SYSTEM
                 value: ${NEW_TASKING_SYSTEM}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -199,6 +203,10 @@ objects:
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: NEW_TASKING_SYSTEM
                 value: ${NEW_TASKING_SYSTEM}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -251,6 +259,10 @@ objects:
                 value: ${{LOGGING_LEVEL}}
               - name: NEW_TASKING_SYSTEM
                 value: ${NEW_TASKING_SYSTEM}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
               - name: CLIENTS_RBAC_BASE_URL
                 value: ${{CLIENTS_RBAC_BASE_URL}}
       database:
@@ -346,4 +358,7 @@ parameters:
     value: "admin"
   - name: CLIENTS_PULP_PASSWORD
     description: Password for accessing pulp over basic auth
-
+  - name: FEATURES_SNAPSHOTS_ENABLED
+    description: Whether the Snapshots feature should be turned on
+  - name: FEATURES_SNAPSHOTS_ACCOUNTS
+    description: Comma separated list of account number that can access the feature

--- a/pkg/api/features.go
+++ b/pkg/api/features.go
@@ -1,0 +1,8 @@
+package api
+
+type FeatureSet map[string]Feature
+
+type Feature struct {
+	Enabled    bool `json:"enabled"`    // Whether the feature is enabled on the running server
+	Accessible bool `json:"accessible"` // Whether the current user can access the feature
+}

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -82,6 +82,7 @@ func RegisterRoutes(engine *echo.Echo) {
 		RegisterPopularRepositoriesRoutes(group, daoReg)
 		RegisterTaskInfoRoutes(group, daoReg)
 		RegisterSnapshotRoutes(group, daoReg)
+		RegisterFeaturesRoutes(group)
 	}
 
 	data, err := json.MarshalIndent(engine.Routes(), "", "  ")

--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
+	"github.com/content-services/content-sources-backend/pkg/rbac"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/slices"
+)
+
+type FeaturesHandler struct {
+}
+
+func RegisterFeaturesRoutes(engine *echo.Group) {
+	fh := FeaturesHandler{}
+	addRoute(engine, http.MethodGet, "/features/", fh.listFeatures, rbac.RbacVerbRead)
+}
+
+// ListFeatures godoc
+// @Summary      List Features within the application, whether they are enabled, and whether the requesting user can use them
+// @ID           listFeatures
+// @Description  Get features available for the user within their Organization
+// @Tags         features
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} api.FeatureSet
+// @Router       /features/ [get]
+func (fh *FeaturesHandler) listFeatures(c echo.Context) error {
+	set := make(api.FeatureSet)
+	elem := reflect.ValueOf(config.Get().Features)
+
+	for i := 0; i < elem.NumField(); i++ {
+		name := elem.Type().Field(i).Name
+		value := elem.Field(i).Interface()
+		feature, valid := value.(config.Feature)
+		if !valid {
+			log.Logger.Error().Msgf("Could not load feature %v", feature)
+			continue
+		}
+		set[name] = api.Feature{
+			Enabled:    feature.Enabled,
+			Accessible: accessible(c.Request().Context(), feature),
+		}
+	}
+	return c.JSON(http.StatusOK, set)
+}
+
+func accessible(ctx context.Context, feature config.Feature) bool {
+	if feature.Accounts == nil && feature.Users == nil {
+		return true
+	}
+	identity := identity.Get(ctx)
+	if feature.Accounts != nil && slices.Contains(*feature.Accounts, identity.Identity.AccountNumber) {
+		return true
+	}
+	if feature.Users != nil && slices.Contains(*feature.Users, identity.Identity.User.Username) {
+		return true
+	}
+	return false
+}
+
+func CheckSnapshotAccessible(ctx context.Context) (err error) {
+	if accessible(ctx, config.Get().Features.Snapshots) {
+		return nil
+	} else {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot manage repository snapshots",
+			"Neither the user nor account is not allowed.")
+	}
+}

--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -37,7 +38,7 @@ func (fh *FeaturesHandler) listFeatures(c echo.Context) error {
 	elem := reflect.ValueOf(config.Get().Features)
 
 	for i := 0; i < elem.NumField(); i++ {
-		name := elem.Type().Field(i).Name
+		name := strings.ToLower(elem.Type().Field(i).Name)
 		value := elem.Field(i).Interface()
 		feature, valid := value.(config.Feature)
 		if !valid {

--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -72,6 +72,6 @@ func CheckSnapshotAccessible(ctx context.Context) (err error) {
 		return nil
 	} else {
 		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot manage repository snapshots",
-			"Neither the user nor account is not allowed.")
+			"Neither the user nor the account is allowed.")
 	}
 }

--- a/pkg/handler/features_test.go
+++ b/pkg/handler/features_test.go
@@ -78,21 +78,21 @@ func TestFeatures(t *testing.T) {
 		name:        "Allowed with Username",
 		id:          user,
 		allowedUser: &user.User.Username,
-		expected: api.FeatureSet{"Snapshots": {
+		expected: api.FeatureSet{"snapshots": {
 			Enabled:    true,
 			Accessible: true,
 		}}}, {
 		name:           "Allowed with Account",
 		id:             user,
 		allowedAccount: &user.AccountNumber,
-		expected: api.FeatureSet{"Snapshots": {
+		expected: api.FeatureSet{"snapshots": {
 			Enabled:    true,
 			Accessible: true,
 		}}},
 		{
 			name: "Not allowed ",
 			id:   user,
-			expected: api.FeatureSet{"Snapshots": {
+			expected: api.FeatureSet{"snapshots": {
 				Enabled:    true,
 				Accessible: false,
 			}}},

--- a/pkg/handler/features_test.go
+++ b/pkg/handler/features_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/middleware"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type FeaturesSuite struct {
+	suite.Suite
+	oldFeatureSet config.FeatureSet
+}
+
+func TestFeaturesSuite(t *testing.T) {
+	suite.Run(t, new(FeaturesSuite))
+}
+func (s *FeaturesSuite) SetupTest() {
+	// Backup previous config
+	s.oldFeatureSet = config.Get().Features
+}
+func (s *FeaturesSuite) TearDownTest() {
+	// Restore previous config
+	config.Get().Features = s.oldFeatureSet
+}
+
+func serveFeaturesRouter(req *http.Request) (int, []byte, error) {
+	router := echo.New()
+	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
+	pathPrefix := router.Group(fullRootPath())
+
+	RegisterFeaturesRoutes(pathPrefix)
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	response := rr.Result()
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	return response.StatusCode, body, err
+}
+
+type FeatureTestCase struct {
+	name           string
+	id             identity.Identity
+	allowedAccount *string
+	allowedUser    *string
+	expected       api.FeatureSet
+}
+
+func TestFeatures(t *testing.T) {
+	config.Get().Features.Snapshots.Enabled = true
+	path := fmt.Sprintf("%s/features/", fullRootPath())
+	req, _ := http.NewRequest("GET", path, nil)
+	user := identity.Identity{
+		Type:          "User",
+		AccountNumber: "acct",
+		OrgID:         "12345",
+		Internal: identity.Internal{
+			OrgID: "12345",
+		},
+		User: identity.User{Username: "foo"}}
+
+	testCases := []FeatureTestCase{{
+		name:        "Allowed with Username",
+		id:          user,
+		allowedUser: &user.User.Username,
+		expected: api.FeatureSet{"Snapshots": {
+			Enabled:    true,
+			Accessible: true,
+		}}}, {
+		name:           "Allowed with Account",
+		id:             user,
+		allowedAccount: &user.AccountNumber,
+		expected: api.FeatureSet{"Snapshots": {
+			Enabled:    true,
+			Accessible: true,
+		}}},
+		{
+			name: "Not allowed ",
+			id:   user,
+			expected: api.FeatureSet{"Snapshots": {
+				Enabled:    true,
+				Accessible: false,
+			}}},
+	}
+
+	for _, testcase := range testCases {
+		config.Get().Features.Snapshots.Users = &[]string{}
+		config.Get().Features.Snapshots.Accounts = &[]string{}
+
+		if testcase.allowedUser != nil {
+			config.Get().Features.Snapshots.Users = &[]string{*testcase.allowedUser}
+		}
+		if testcase.allowedAccount != nil {
+			config.Get().Features.Snapshots.Accounts = &[]string{*testcase.allowedAccount}
+		}
+
+		newReq := wrapReqWithIdentity(t, req, testcase.id)
+		code, body, err := serveFeaturesRouter(newReq)
+		assert.Nil(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		var featureResponse api.FeatureSet
+		err = json.Unmarshal(body, &featureResponse)
+		assert.NoError(t, err, "Could not marshal response for testcase %v", testcase.name)
+		assert.Equal(t, testcase.expected, featureResponse, "Expected response for %v does not match", testcase.name)
+	}
+}
+
+func wrapReqWithIdentity(t *testing.T, req *http.Request, id identity.Identity) *http.Request {
+	json, err := json.Marshal(identity.XRHID{Identity: id})
+	assert.NoError(t, err)
+	base64Str := base64.StdEncoding.EncodeToString([]byte(string(json)))
+
+	req.Header.Set("X-Rh-Identity", base64Str)
+	return req
+}

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -17,19 +17,7 @@ func TestConfigureEcho(t *testing.T) {
 		"/ping": {
 			"GET": "github.com/content-services/content-sources-backend/pkg/handler.ping",
 		},
-		"/ping/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.ping",
-		},
-		"/api/content-sources/v1/ping/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.ping",
-		},
-		"/api/content-sources/v1.0/ping/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.ping",
-		},
 		"/api/content-sources/v1/openapi.json": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.openapi",
-		},
-		"/api/content-sources/v1.0/openapi.json": {
 			"GET": "github.com/content-services/content-sources-backend/pkg/handler.openapi",
 		},
 		"/api/content-sources/v1/repositories/": {
@@ -40,97 +28,23 @@ func TestConfigureEcho(t *testing.T) {
 			"GET":  "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).listRepositories-fm",
 			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).createRepository-fm",
 		},
-		"/api/content-sources/v1/popular_repositories/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*PopularRepositoriesHandler).listPopularRepositories-fm",
-		},
-		"/api/content-sources/v1.0/popular_repositories/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*PopularRepositoriesHandler).listPopularRepositories-fm",
-		},
-		"/api/content-sources/v1/repository_parameters/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).listParameters-fm",
-		},
-		"/api/content-sources/v1.0/repository_parameters/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).listParameters-fm",
-		},
-		"/api/content-sources/v1/repositories/:uuid/rpms": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryRpmHandler).listRepositoriesRpm-fm",
-		},
-		"/api/content-sources/v1.0/repositories/:uuid/rpms": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryRpmHandler).listRepositoriesRpm-fm",
-		},
-		"/api/content-sources/v1/rpms/names": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryRpmHandler).searchRpmByName-fm",
-		},
-		"/api/content-sources/v1.0/rpms/names": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryRpmHandler).searchRpmByName-fm",
-		},
-		"/api/content-sources/v1/repositories/:uuid": {
-			"PATCH":  "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).partialUpdate-fm",
-			"PUT":    "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).fullUpdate-fm",
-			"GET":    "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).fetch-fm",
-			"DELETE": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).deleteRepository-fm",
-		},
-		"/api/content-sources/v1.0/repositories/:uuid/introspect/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).introspect-fm",
-		},
-		"/api/content-sources/v1/repositories/:uuid/introspect/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).introspect-fm",
-		},
-		"/api/content-sources/v1.0/repositories/:uuid": {
-			"PATCH":  "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).partialUpdate-fm",
-			"PUT":    "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).fullUpdate-fm",
-			"GET":    "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).fetch-fm",
-			"DELETE": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).deleteRepository-fm",
-		},
-		"/api/content-sources/v1/repository_parameters/external_gpg_key/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).fetchGpgKey-fm",
-		},
-		"/api/content-sources/v1.0/repository_parameters/external_gpg_key/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).fetchGpgKey-fm",
-		},
-		"/api/content-sources/v1/repositories/bulk_create/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).bulkCreateRepositories-fm",
-		},
-		"/api/content-sources/v1.0/repositories/bulk_create/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryHandler).bulkCreateRepositories-fm",
-		},
-		"/api/content-sources/v1/repository_parameters/validate/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).validate-fm",
-		},
-		"/api/content-sources/v1.0/repository_parameters/validate/": {
-			"POST": "github.com/content-services/content-sources-backend/pkg/handler.(*RepositoryParameterHandler).validate-fm",
-		},
-		"/api/content-sources/v1/tasks/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*TaskInfoHandler).listTasks-fm",
-		},
-		"/api/content-sources/v1.0/tasks/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*TaskInfoHandler).listTasks-fm",
-		},
-		"/api/content-sources/v1/tasks/:uuid": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*TaskInfoHandler).fetch-fm",
-		},
-		"/api/content-sources/v1.0/tasks/:uuid": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*TaskInfoHandler).fetch-fm",
-		},
-		"/api/content-sources/v1/repositories/:uuid/snapshots/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*SnapshotHandler).listSnapshots-fm",
-		},
-		"/api/content-sources/v1.0/repositories/:uuid/snapshots/": {
-			"GET": "github.com/content-services/content-sources-backend/pkg/handler.(*SnapshotHandler).listSnapshots-fm",
-		},
 	}
 
 	e := ConfigureEcho(true)
 	require.NotNil(t, e)
 
-	// Match Routes in expected
-	for _, route := range e.Routes() {
-		t.Logf("Method=%s Path=%s Name=%s", route.Method, route.Path, route.Name)
-		methods, okPath := testCases[route.Path]
-		require.True(t, okPath)
-		name, okMethod := methods[route.Method]
-		require.True(t, okMethod)
-		assert.Equal(t, name, route.Name)
+	for path, endpoints := range testCases {
+		for method, fnc := range endpoints {
+			found := false
+
+			for _, route := range e.Routes() {
+				if route.Path == path && method == route.Method {
+					found = true
+					assert.Equal(t, fnc, route.Name)
+				}
+			}
+			assert.True(t, found, "Could not find route for %v: %v", method, path)
+		}
 	}
 }
 

--- a/scripts/header.sh
+++ b/scripts/header.sh
@@ -2,7 +2,7 @@
 
 ORG_ID="$1"
 USER_NAME="$2"
-
+ACCOUNT_ID="$3"
 
 
 function print_out_usage {
@@ -20,13 +20,21 @@ function error {
 
 [ "${ORG_ID}" != "" ] || error "ORG_ID is required and cannot be empty"
 
+if [ "${ACCOUNT_ID}" == "" ]; then
+  ACCOUNT_ID=$ORG_ID
+fi
+
+if [ "${USER_NAME}" == "" ]; then
+  USER_NAME="snapUser"
+fi
+
 case "$( uname -s )" in
 "Darwin" )
-  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"username\":\"${USER_NAME}\"},\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -b 0)"
+  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"username\":\"${USER_NAME}\"},\"account_number\":\"${ACCOUNT_ID}\",\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -b 0)"
 ;;
 
 "Linux" | *)
-  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"username\":\"${USER_NAME}\"},\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -w0)"
+  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"username\":\"${USER_NAME}\"},\"account_number\":\"${ACCOUNT_ID}\",\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -w0)"
 ;;
 esac
 


### PR DESCRIPTION
## Summary
Adds a setting to determine if snapshotting is enabled
Adds a per account and per user setting to determine if the user can snapshot repositories
Adds an api to return if the feature is 1) enabled 2) accessible to the current user
Updated the header.sh to provide the ability to pass in an account id optionally 

## Testing steps

copy new config options from the example config file
```/bin/bash
# should show as accessible
 curl localhost:8000/api/content-sources/v1.0/features/  -H "`./scripts/header.sh 1 snapUser`" 
# should show not as accessible
 curl localhost:8000/api/content-sources/v1.0/features/  -H "`./scripts/header.sh 1 noAccess`" 
# should show as accessible
 curl localhost:8000/api/content-sources/v1.0/features/  -H "`./scripts/header.sh 1 noAccess snapAccount`" 
# should show not as accessible
 curl localhost:8000/api/content-sources/v1.0/features/  -H "`./scripts/header.sh 1 noAccess NoAccess`" 
```

