### PR TITLE
Refs 1947: parametrize CJI fields for IQE

### DIFF
--- a/deployments/testing.yaml
+++ b/deployments/testing.yaml
@@ -16,10 +16,8 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: stage_post_deploy
-        filter: ''
-        marker: 'smoke and api'
-        plugins: content_sources
+        dynaconfEnvName: ${IQE_ENV}
+        marker: ${IQE_MARKER}
 parameters:
 - name: IMAGE_TAG
   value: ''
@@ -28,3 +26,7 @@ parameters:
   description: "Unique CJI name suffix"
   generate: expression
   from: "[a-z0-9]{6}"
+- name: IQE_MARKER
+  value: 'smoke and api'
+- name: IQE_ENV
+  value: 'stage_post_deploy'


### PR DESCRIPTION
## Summary
Allow for running the CJI with parameters set via SAAS


## Testing steps
`bonfire deploy-iqe-cji <args> --template-file <path-to-file-in-branch>`

Resulting CJI had parameters values set correctly via defaults. Resulting pod had correct env config and pytest args.