### PR TITLE
Fixes 1948: Add introspection/edit/delete notifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
-	github.com/vektra/mockery v1.1.2 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 )
@@ -138,7 +137,6 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1038,8 +1038,8 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.3/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.10 h1:MLn+5bFRlWMGoSRmJour3CL1w/qL96mvipqpwQW/Sfk=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -1398,8 +1398,6 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
-github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -1922,7 +1920,6 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -387,7 +387,7 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 
 func SetupNotifications() {
 	if len(LoadedConfig.Kafka.Bootstrap.Servers) == 0 {
-		log.Warn().Msg("clowder.KafkaServers and configured brokers was empty")
+		log.Warn().Msg("SetupNotifications: clowder.KafkaServers and configured broker was empty")
 	}
 
 	kafkaServers := strings.Split(LoadedConfig.Kafka.Bootstrap.Servers, ",")
@@ -397,12 +397,10 @@ func SetupNotifications() {
 	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 
 	if strings.Contains(LoadedConfig.Kafka.Sasl.Protocol, "SSL") {
-		log.Warn().Msgf("Configuring SSL authentication: %s", LoadedConfig.Kafka.Sasl.Protocol)
 		saramaConfig.Net.TLS.Enable = true
 	}
 
 	if LoadedConfig.Kafka.Capath != "" {
-		log.Warn().Msgf("kafkaCaPath is: %s", LoadedConfig.Kafka.Capath)
 		tlsConfig, err := tlsutils.NewTLSConfig(LoadedConfig.Kafka.Capath)
 		if err != nil {
 			log.Error().Err(err).Msgf("SetupNotifications failed: Unable to load TLS config for %s cert", LoadedConfig.Kafka.Capath)
@@ -412,7 +410,6 @@ func SetupNotifications() {
 	}
 
 	if strings.HasPrefix(LoadedConfig.Kafka.Sasl.Protocol, "SASL_") {
-		log.Warn().Msgf("Configuring SASL authentication: %s", LoadedConfig.Kafka.Sasl.Protocol)
 		saramaConfig.Net.SASL.Enable = true
 		saramaConfig.Net.SASL.User = LoadedConfig.Kafka.Sasl.Username
 		saramaConfig.Net.SASL.Password = LoadedConfig.Kafka.Sasl.Password
@@ -424,7 +421,6 @@ func SetupNotifications() {
 
 	if mappedTopicName == "" {
 		mappedTopicName = "platform.notifications.ingress"
-		log.Warn().Msg("Couldn't find notification mapping, using standard topic.")
 	}
 
 	protocol, err := kafka_sarama.NewSender(kafkaServers, saramaConfig, mappedTopicName)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -41,6 +41,7 @@ type RepositoryConfigDao interface {
 	SavePublicRepos(urls []string) error
 	ValidateParameters(orgId string, params api.RepositoryValidationRequest, excludedUUIDS []string) (api.RepositoryValidationResponse, error)
 	FetchByRepoUuid(orgID string, repoUuid string) (api.RepositoryResponse, error)
+	InternalOnly_ListRepoConfigsByUUID(uuid string) []api.RepositoryResponse
 }
 
 //go:generate mockery --name RpmDao --filename rpms_mock.go --inpackage

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -41,7 +41,7 @@ type RepositoryConfigDao interface {
 	SavePublicRepos(urls []string) error
 	ValidateParameters(orgId string, params api.RepositoryValidationRequest, excludedUUIDS []string) (api.RepositoryValidationResponse, error)
 	FetchByRepoUuid(orgID string, repoUuid string) (api.RepositoryResponse, error)
-	InternalOnly_ListRepoConfigsByUUID(uuid string) []api.RepositoryResponse
+	InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse
 }
 
 //go:generate mockery --name RpmDao --filename rpms_mock.go --inpackage

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -87,7 +87,6 @@ func (r repositoryConfigDaoImpl) Create(newRepoReq api.RepositoryRequest) (api.R
 	created.URL = newRepo.URL
 	created.Status = newRepo.Status
 
-	//Send update notification
 	notifications.SendNotification(
 		newRepoConfig.OrgID,
 		notifications.RepositoryCreated,
@@ -110,7 +109,6 @@ func (r repositoryConfigDaoImpl) BulkCreate(newRepositories []api.RepositoryRequ
 		return err
 	})
 
-	// Send notifications
 	mappedValues := []repositories.Repositories{}
 	for i := 0; i < len(responses); i++ {
 		mappedValues = append(mappedValues, notifications.MapRepositoryResponse(responses[i]))
@@ -247,7 +245,7 @@ func (r repositoryConfigDaoImpl) List(
 	return api.RepositoryCollectionResponse{Data: repos}, totalRepos, nil
 }
 
-func (r repositoryConfigDaoImpl) InternalOnly_ListRepoConfigsByUUID(uuid string) []api.RepositoryResponse {
+func (r repositoryConfigDaoImpl) InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse {
 	repoConfigs := make([]models.RepositoryConfiguration, 0)
 	filteredDB := r.db.Where("repositories.uuid = ?", uuid).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
@@ -340,7 +338,7 @@ func (r repositoryConfigDaoImpl) Update(orgID string, uuid string, repoParams ap
 
 	repositoryResponse := api.RepositoryResponse{}
 	ModelToApiFields(repoConfig, &repositoryResponse)
-	//Send update notification
+
 	notifications.SendNotification(
 		orgID,
 		notifications.RepositoryUpdated,
@@ -379,7 +377,7 @@ func (r repositoryConfigDaoImpl) Delete(orgID string, uuid string) error {
 
 	repositoryResponse := api.RepositoryResponse{}
 	ModelToApiFields(repoConfig, &repositoryResponse)
-	//Send delete notification
+
 	notifications.SendNotification(
 		orgID,
 		notifications.RepositoryDeleted,

--- a/pkg/dao/repository_configs_mock.go
+++ b/pkg/dao/repository_configs_mock.go
@@ -40,6 +40,12 @@ func (_m *MockRepositoryConfigDao) BulkCreate(newRepositories []api.RepositoryRe
 	return r0, r1
 }
 
+// InternalOnly_ListRepoConfigsByUUID provides a mock function with given fields: uuid
+func (_m *MockRepositoryConfigDao) InternalOnly_ListRepoConfigsByUUID(uuid string) []api.RepositoryResponse {
+	var r0 []api.RepositoryResponse
+	return r0
+}
+
 // Create provides a mock function with given fields: newRepo
 func (_m *MockRepositoryConfigDao) Create(newRepo api.RepositoryRequest) (api.RepositoryResponse, error) {
 	ret := _m.Called(newRepo)

--- a/pkg/dao/repository_configs_mock.go
+++ b/pkg/dao/repository_configs_mock.go
@@ -40,8 +40,8 @@ func (_m *MockRepositoryConfigDao) BulkCreate(newRepositories []api.RepositoryRe
 	return r0, r1
 }
 
-// InternalOnly_ListRepoConfigsByUUID provides a mock function with given fields: uuid
-func (_m *MockRepositoryConfigDao) InternalOnly_ListRepoConfigsByUUID(uuid string) []api.RepositoryResponse {
+// InternalOnly_FetchRepoConfigsForRepoUUID provides a mock function with given fields: uuid
+func (_m *MockRepositoryConfigDao) InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse {
 	var r0 []api.RepositoryResponse
 	return r0
 }

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -628,7 +628,7 @@ func (suite *RepositoryConfigSuite) TestFetchNotFound() {
 	assert.True(t, daoError.NotFound)
 }
 
-func (suite *RepositoryConfigSuite) TestInternalOnly_ListRepoConfigsByUUID() {
+func (suite *RepositoryConfigSuite) TestInternalOnly_FetchRepoConfigsForRepoUUID() {
 	t := suite.T()
 	numberOfRepos := 10 // Tested with up to 10,000 results
 
@@ -648,7 +648,7 @@ func (suite *RepositoryConfigSuite) TestInternalOnly_ListRepoConfigsByUUID() {
 		assert.Nil(t, err)
 	}
 
-	results := GetRepositoryConfigDao(suite.tx).InternalOnly_ListRepoConfigsByUUID(repoConfig.RepositoryUUID)
+	results := GetRepositoryConfigDao(suite.tx).InternalOnly_FetchRepoConfigsForRepoUUID(repoConfig.RepositoryUUID)
 
 	// Confirm all 10 repoConfigs are returned
 	assert.Equal(t, numberOfRepos, len(results))

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/RedHatInsights/event-schemas-go/apps/repositories/v1"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/notifications"
 	"github.com/content-services/yummy/pkg/yum"
 	"github.com/openlyinc/pointy"
 	"github.com/rs/zerolog/log"
@@ -128,11 +131,13 @@ func reposForIntrospection(urls *[]string, force bool) ([]dao.Repository, []erro
 // and separately all other fatal errors
 func IntrospectAll(urls *[]string, force bool) (int64, []error, []error) {
 	var (
-		total               int64
-		count               int64
-		err                 error
-		dao                 = dao.GetDaoRegistry(db.DB)
-		introspectionErrors []error
+		total                  int64
+		count                  int64
+		err                    error
+		dao                    = dao.GetDaoRegistry(db.DB)
+		introspectionErrors    []error
+		introspectFailedUuids  []string
+		introspectSuccessUuids []string
 	)
 	repos, errors := reposForIntrospection(urls, force)
 	for i := 0; i < len(repos); i++ {
@@ -155,6 +160,11 @@ func IntrospectAll(urls *[]string, force bool) (int64, []error, []error) {
 		if err != nil {
 			errors = append(errors, err)
 		}
+		if err == nil {
+			introspectSuccessUuids = append(introspectSuccessUuids, repos[i].UUID)
+		} else {
+			introspectFailedUuids = append(introspectFailedUuids, repos[i].UUID)
+		}
 	}
 	err = dao.Repository.OrphanCleanup()
 	if err != nil {
@@ -164,7 +174,65 @@ func IntrospectAll(urls *[]string, force bool) (int64, []error, []error) {
 	if err != nil {
 		errors = append(errors, err)
 	}
+
+	// Logic to handle notifications
+	sendIntrospectionNotifications(introspectSuccessUuids, introspectFailedUuids, dao)
+
 	return total, introspectionErrors, errors
+}
+
+func sendIntrospectionNotifications(successUuids []string, failedUuids []string, dao *dao.DaoRegistry) {
+	count := 0
+	wg := sync.WaitGroup{}
+
+	if len(successUuids) != 0 {
+		for i := 0; i < len(successUuids); i++ {
+			uuid := successUuids[i]
+			repos := dao.RepositoryConfig.InternalOnly_ListRepoConfigsByUUID(uuid)
+			for j := 0; j < len(repos); j++ {
+				wg.Add(1)
+				count = count + 1
+				go func(index int) {
+					notifications.SendNotification(
+						repos[index].OrgID,
+						notifications.RepositoryIntrospected,
+						[]repositories.Repositories{notifications.MapRepositoryResponse(repos[index])},
+					)
+					wg.Done()
+				}(j)
+				if count > 100 { // This limits the thread count
+					count = 0
+					wg.Wait()
+				}
+			}
+		}
+		// Reset count
+		count = 0
+		wg.Wait()
+	}
+
+	for i := 0; i < len(failedUuids); i++ {
+		uuid := failedUuids[i]
+		repos := dao.RepositoryConfig.InternalOnly_ListRepoConfigsByUUID(uuid)
+		for j := 0; j < len(repos); j++ {
+			wg.Add(1)
+			count = count + 1
+			go func(index int) {
+				notifications.SendNotification(
+					repos[index].OrgID,
+					notifications.RepositoryIntrospectionFailure,
+					[]repositories.Repositories{notifications.MapRepositoryResponse(repos[index])},
+				)
+				wg.Done()
+			}(j)
+			if count > 100 { // This limits the thread count
+				count = 0
+				wg.Wait()
+			}
+		}
+	}
+
+	wg.Wait()
 }
 
 func needsIntrospect(repo *dao.Repository) (bool, string) {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -188,7 +188,7 @@ func sendIntrospectionNotifications(successUuids []string, failedUuids []string,
 	if len(successUuids) != 0 {
 		for i := 0; i < len(successUuids); i++ {
 			uuid := successUuids[i]
-			repos := dao.RepositoryConfig.InternalOnly_ListRepoConfigsByUUID(uuid)
+			repos := dao.RepositoryConfig.InternalOnly_FetchRepoConfigsForRepoUUID(uuid)
 			for j := 0; j < len(repos); j++ {
 				wg.Add(1)
 				count = count + 1
@@ -213,7 +213,7 @@ func sendIntrospectionNotifications(successUuids []string, failedUuids []string,
 
 	for i := 0; i < len(failedUuids); i++ {
 		uuid := failedUuids[i]
-		repos := dao.RepositoryConfig.InternalOnly_ListRepoConfigsByUUID(uuid)
+		repos := dao.RepositoryConfig.InternalOnly_FetchRepoConfigsForRepoUUID(uuid)
 		for j := 0; j < len(repos); j++ {
 			wg.Add(1)
 			count = count + 1

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/RedHatInsights/event-schemas-go/apps/repositories/v1"
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
@@ -13,7 +12,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/event/adapter"
 	"github.com/content-services/content-sources-backend/pkg/event/message"
 	"github.com/content-services/content-sources-backend/pkg/event/producer"
-	"github.com/content-services/content-sources-backend/pkg/notifications"
 	"github.com/content-services/content-sources-backend/pkg/rbac"
 	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/client"
@@ -208,14 +206,6 @@ func (rh *RepositoryHandler) bulkCreateRepositories(c echo.Context) error {
 	if len(errs) > 0 {
 		return ce.NewErrorResponseFromError("Error creating repository", errs...)
 	}
-
-	// Send notifications
-	mappedValues := []repositories.Repositories{}
-	for i := 0; i < len(responses); i++ {
-		mappedValues = append(mappedValues, notifications.MapRepositoryResponse(responses[i]))
-	}
-
-	notifications.SendNotification(orgID, notifications.RepositoryCreated, mappedValues)
 
 	// Produce an event for each repository
 	for _, repo := range responses {

--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -12,9 +12,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func SendNotification(orgId string, eventName EventName, repos []repositories.Repositories) {
+// SendNotification - Sends a notification
+func SendNotification(orgID string, eventName EventName, repos []repositories.Repositories) {
 	if config.Get().NotificationsClient != nil {
-		log.Warn().Msgf("Notification started: %v", config.Get().NotificationsClient)
 		eventNameStr := eventName.String()
 		newUUID, _ := uuid.NewRandom()
 		e := cloudevents.NewEvent()
@@ -23,7 +23,7 @@ func SendNotification(orgId string, eventName EventName, repos []repositories.Re
 		e.SetType("com.redhat.console.repositories." + eventNameStr)
 		e.SetSubject("urn:redhat:subject:console:rhel:" + eventNameStr)
 		e.SetTime(time.Now())
-		e.SetExtension("redhatorgid", orgId)
+		e.SetExtension("redhatorgid", orgID)
 		e.SetExtension("redhatconsolebundle", "rhel")
 		e.SetDataSchema("https://console.redhat.com/api/schemas/apps/repositories/v1/repository-events.json")
 
@@ -40,8 +40,6 @@ func SendNotification(orgId string, eventName EventName, repos []repositories.Re
 		if result := config.Get().NotificationsClient.Send(ctx, e); cloudevents.IsUndelivered(result) {
 			log.Error().Msgf("Notification message failed to send: %v", result)
 			return
-		} else {
-			log.Warn().Msgf("Notification message accepted: %t", cloudevents.IsACK(result))
 		}
 		ctx.Done()
 	} else {
@@ -49,6 +47,7 @@ func SendNotification(orgId string, eventName EventName, repos []repositories.Re
 	}
 }
 
+// MapRepositoryResponse - Maps RepositoryResponse to Repositories struct
 func MapRepositoryResponse(importedRepo api.RepositoryResponse) repositories.Repositories {
 	packageCount := int64(importedRepo.PackageCount)
 	failedIntrospectionsCount := int64(importedRepo.FailedIntrospectionsCount)
@@ -71,6 +70,7 @@ func MapRepositoryResponse(importedRepo api.RepositoryResponse) repositories.Rep
 	}
 }
 
+// SetEmptyToNil - Sets a string to null if == ""
 func SetEmptyToNil(value string) *string {
 	if value == "" {
 		return nil


### PR DESCRIPTION
## Summary



## Testing steps

1) configure your config for kafka if not already:
```
kafka:
  auto:
    offset:
      reset: latest
    commit:
      interval:
        ms: 5000
  bootstrap:
    servers: localhost:9092
  group:
    id: content-sources
  message:
    send:
      max:
        retries: 15
  request:
    timeout:
      ms: 30000
    required:
      acks: -1
  retry:
    backoff:
      ms: 100
  timeout: 10000
  topics:
    - platform.content-sources.introspect
    - platform.notifications.ingress
```
2) run server `make run`
3) run listener ` KAFKA_TOPIC=platform.notifications.ingress make  kafka-topic-consume`
4) create a bulk repo, edit it, delete it, and see the associated notifications
