### PR TITLE
Fixes 1882: only refresh running tasks

### DIFF
--- a/pkg/tasks/worker/worker_pool_test.go
+++ b/pkg/tasks/worker/worker_pool_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 )
@@ -18,11 +16,6 @@ type WorkerSuite struct {
 
 func TestWorkerSuite(t *testing.T) {
 	suite.Run(t, &WorkerSuite{})
-}
-
-func (s *WorkerSuite) SetupTest() {
-	config.Get().Tasking.WorkerCount = 3
-	config.Get().Tasking.Heartbeat = time.Millisecond * 12
 }
 
 func getObjectsForTest(t *testing.T) (TaskWorkerPool, *queue.MockQueue) {
@@ -36,7 +29,6 @@ func (s *WorkerSuite) TestStartStopWorkers() {
 	workerPool, mockQueue := getObjectsForTest(s.T())
 
 	mockQueue.On("Dequeue", context.Background(), []string(nil)).Times(3).Return(nil, nil)
-	mockQueue.On("RefreshHeartbeat", uuid.Nil).Times(3)
 
 	workerPool.StartWorkers(context.Background())
 	time.Sleep(time.Millisecond * 5)


### PR DESCRIPTION
## Summary
We've been seeing an error message that suggests there is a scenario where a worker will attempt to refresh the heartbeat of the previous (but no longer in-progress) task. This makes it so now only the running task's heartbeat will be refreshed.

## Testing steps
1. Use the tasking system by creating/introspecting/deleting repositories. Everything should be working as normal.
2. Try exiting the server with Ctrl+C at different points while tasks are running (or finished). You should not see any warnings or errors.