### PR TITLE
Fixes 2058: Empty url on introspect notification

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -250,7 +250,7 @@ func (r repositoryConfigDaoImpl) InternalOnly_FetchRepoConfigsForRepoUUID(uuid s
 	filteredDB := r.db.Where("repositories.uuid = ?", uuid).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
 
-	filteredDB.Find(&repoConfigs).Preload("Repository")
+	filteredDB.Preload("Repository").Find(&repoConfigs)
 
 	if filteredDB.Error != nil {
 		log.Error().Msgf("Unable to ListRepos: %v", uuid)

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -652,6 +652,9 @@ func (suite *RepositoryConfigSuite) TestInternalOnly_FetchRepoConfigsForRepoUUID
 
 	// Confirm all 10 repoConfigs are returned
 	assert.Equal(t, numberOfRepos, len(results))
+	// Ensure that the url and Name are successfully returned (both required) for notifications
+	assert.NotEmpty(t, results[0].URL)
+	assert.NotEmpty(t, results[0].Name)
 }
 
 func (suite *RepositoryConfigSuite) TestList() {


### PR DESCRIPTION
## Summary
Fixed a bug that would return an empty URL for the introspect notification, causing the schema to blow up. 
This was a simple DB call order mistake.
