### PR TITLE
Fixes 2065: conditional Introspect & fixed update 

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -331,11 +331,6 @@ func (r repositoryConfigDaoImpl) Update(orgID string, uuid string, repoParams ap
 		repoConfig.RepositoryUUID = repo.UUID
 	}
 
-	repoConfig.Repository = models.Repository{}
-	if err := r.db.Model(&repoConfig).Updates(repoConfig.MapForUpdate()).Error; err != nil {
-		return DBErrorToApi(err)
-	}
-
 	repositoryResponse := api.RepositoryResponse{}
 	ModelToApiFields(repoConfig, &repositoryResponse)
 
@@ -344,6 +339,11 @@ func (r repositoryConfigDaoImpl) Update(orgID string, uuid string, repoParams ap
 		notifications.RepositoryUpdated,
 		[]repositories.Repositories{notifications.MapRepositoryResponse(repositoryResponse)},
 	)
+
+	repoConfig.Repository = models.Repository{}
+	if err := r.db.Model(&repoConfig).Updates(repoConfig.MapForUpdate()).Error; err != nil {
+		return DBErrorToApi(err)
+	}
 
 	return nil
 }

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -102,7 +102,7 @@ func TestIntrospect(t *testing.T) {
 	mockDao.Repository.On("Update", repoUpdate).Return(nil).Times(1)
 	mockDao.Rpm.On("InsertForRepository", repoUpdate.UUID, mock.Anything).Return(int64(14), nil)
 
-	count, err := Introspect(
+	count, err, updated := Introspect(
 		&dao.Repository{
 			UUID:         repoUUID,
 			URL:          server.URL + "/content",
@@ -111,10 +111,11 @@ func TestIntrospect(t *testing.T) {
 		mockDao.ToDaoRegistry())
 	assert.NoError(t, err)
 	assert.Equal(t, int64(14), count)
+	assert.Equal(t, true, updated)
 	assert.Equal(t, 14, expected.PackageCount)
 
 	// Without any changes to the repo, there should be no package updates
-	count, err = Introspect(
+	count, err, updated = Introspect(
 		&dao.Repository{
 			UUID:           repoUUID,
 			URL:            server.URL + "/content",
@@ -124,10 +125,11 @@ func TestIntrospect(t *testing.T) {
 		mockDao.ToDaoRegistry())
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), count)
+	assert.Equal(t, false, updated)
 	assert.Equal(t, 14, expected.PackageCount)
 
 	// If the repository has failed more than FailedIntrospectionsLimit number of times in a row, it should not introspect
-	_, err = Introspect(
+	_, err, updated = Introspect(
 		&dao.Repository{
 			UUID:                      repoUUID,
 			URL:                       server.URL + "/content",
@@ -137,6 +139,7 @@ func TestIntrospect(t *testing.T) {
 		},
 		mockDao.ToDaoRegistry())
 	assert.Error(t, err)
+	assert.Equal(t, false, updated)
 }
 
 func TestHttpClient(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes the empty struct values for the update notification that were causing it to fail to be parsed by the schems. 

This adds conditional sending of the introspect notification so that it now will only send a notification when the introspection would result in an update.


## Testing steps

1) configure your config for kafka if not already:
```
kafka:
  auto:
    offset:
      reset: latest
    commit:
      interval:
        ms: 5000
  bootstrap:
    servers: localhost:9092
  group:
    id: content-sources
  message:
    send:
      max:
        retries: 15
  request:
    timeout:
      ms: 30000
    required:
      acks: -1
  retry:
    backoff:
      ms: 100
  timeout: 10000
  topics:
    - platform.content-sources.introspect
    - platform.notifications.ingress
```
2) run server `make run`
3) run listener ` KAFKA_TOPIC=platform.notifications.ingress make  kafka-topic-consume`
4) create a bulk repo, edit it, delete it, and see the associated notifications. 
5) check the json for the "package_count": and "url": values (these were appearing as empty string "", when editing/updating a repo).




