### PR TITLE
Refs 1882: retry refresh heartbeat when no rows affected

### DIFF
--- a/pkg/tasks/queue/pgqueue_test.go
+++ b/pkg/tasks/queue/pgqueue_test.go
@@ -239,11 +239,12 @@ func (s *QueueSuite) TestIdFromToken() {
 	info, err := s.queue.Dequeue(context.Background(), []string{testTaskType})
 	require.NoError(s.T(), err)
 
-	token, err := s.queue.IdFromToken(info.Token)
+	token, isRunning, err := s.queue.IdFromToken(info.Token)
 	assert.NoError(s.T(), err)
 	assert.NotEqual(s.T(), uuid.Nil, token)
+	assert.True(s.T(), isRunning)
 
 	// Test no token found
-	_, err = s.queue.IdFromToken(uuid.New())
+	_, _, err = s.queue.IdFromToken(uuid.New())
 	assert.ErrorIs(s.T(), err, ErrNotExist)
 }

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -37,7 +37,7 @@ type Queue interface {
 	// Heartbeats returns the tokens of all tasks older than given duration
 	Heartbeats(olderThan time.Duration) []uuid.UUID
 	// IdFromToken returns a task's ID given its token
-	IdFromToken(token uuid.UUID) (id uuid.UUID, err error)
+	IdFromToken(token uuid.UUID) (id uuid.UUID, isRunning bool, err error)
 	// RefreshHeartbeat refresh heartbeat of task given its token
 	RefreshHeartbeat(token uuid.UUID)
 	// UpdatePayload update the payload on a task

--- a/pkg/tasks/queue/queue_mock.go
+++ b/pkg/tasks/queue/queue_mock.go
@@ -115,12 +115,13 @@ func (_m *MockQueue) Heartbeats(olderThan time.Duration) []uuid.UUID {
 }
 
 // IdFromToken provides a mock function with given fields: token
-func (_m *MockQueue) IdFromToken(token uuid.UUID) (uuid.UUID, error) {
+func (_m *MockQueue) IdFromToken(token uuid.UUID) (uuid.UUID, bool, error) {
 	ret := _m.Called(token)
 
 	var r0 uuid.UUID
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uuid.UUID) (uuid.UUID, error)); ok {
+	var r1 bool
+	var r2 error
+	if rf, ok := ret.Get(0).(func(uuid.UUID) (uuid.UUID, bool, error)); ok {
 		return rf(token)
 	}
 	if rf, ok := ret.Get(0).(func(uuid.UUID) uuid.UUID); ok {
@@ -131,13 +132,19 @@ func (_m *MockQueue) IdFromToken(token uuid.UUID) (uuid.UUID, error) {
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(uuid.UUID) error); ok {
+	if rf, ok := ret.Get(1).(func(uuid.UUID) bool); ok {
 		r1 = rf(token)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(bool)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(uuid.UUID) error); ok {
+		r2 = rf(token)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // RefreshHeartbeat provides a mock function with given fields: token

--- a/pkg/tasks/worker/worker_pool.go
+++ b/pkg/tasks/worker/worker_pool.go
@@ -54,14 +54,16 @@ func (w *WorkerPool) HeartbeatListener() {
 			//nolint:staticcheck
 			for range time.Tick(heartbeat) {
 				for _, token := range w.queue.Heartbeats(heartbeat) {
-					id, err := w.queue.IdFromToken(token)
+					id, isRunning, err := w.queue.IdFromToken(token)
 					if err != nil {
 						log.Logger.Warn().Err(err).Msg("error getting task id")
 					}
 
-					err = w.queue.Requeue(id)
-					if err != nil {
-						log.Logger.Warn().Err(err).Msg("error requeuing task")
+					if isRunning {
+						err = w.queue.Requeue(id)
+						if err != nil {
+							log.Logger.Warn().Err(err).Msg("error requeuing task")
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
There is still reoccurring error "No rows affected when refreshing heartbeat". This error seems to be caused by a race condition at the postgres level. The process refreshing the heartbeat and the process completing the task are two separate goroutines. If the process refreshing the heartbeat queries the task while it is finishing, it will get the old values (i.e. the status is running and not completed). But when it refreshes the heartbeat, the task status is "completed" so there is no longer a heartbeat to refresh.

These changes make it so if we've hit the error, we query the task status, and and try again to refresh the heartbeat only if the task is running.

## Testing steps
You can use this python script to help test by introspecting a repository repeatedly.
```
import requests

def sendReq():
  url = "<insert introspect endpoint here>"
  headers = { "x-rh-identity":"<insert identity here>" }
  x = requests.post(url, headers = headers)

for i in range(100):
  sendReq()
```
1. Make the heartbeat interval 100ms, which is unrealistic but will make the error more reproducible. 
2. Without the changes, this script should make the error, `"No rows affected when refreshing heartbeat"`, pop up at least a couple of times.
3. With the changes, you should no longer see the error. 
4. You can also test the tasking system by syncing, interrupting syncing, introspecting via command line, etc. Make sure no new errors were introduced.