### PR TITLE
Fixes 2112: RPM fetch 404

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -28,7 +28,7 @@ func (r rpmDaoImpl) isOwnedRepository(orgID string, repositoryConfigUUID string)
 	var repoConfigs []models.RepositoryConfiguration
 	var count int64
 	if err := r.db.
-		Where("org_id = ? and uuid = ?", orgID, repositoryConfigUUID).
+		Where("org_id = ? and text(uuid) = ?", orgID, repositoryConfigUUID).
 		Find(&repoConfigs).
 		Count(&count).
 		Error; err != nil {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -59,7 +59,7 @@ func (r rpmDaoImpl) List(orgID string, repositoryConfigUUID string, limit int, o
 			totalRpms,
 			&ce.DaoError{
 				NotFound: true,
-				Message:  fmt.Sprintf("repositoryConfigUUID = %s is not owned", repositoryConfigUUID),
+				Message:  "Could not find repository with UUID " + repositoryConfigUUID,
 			}
 	}
 

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/yummy/pkg/yum"
 	"github.com/openlyinc/pointy"
@@ -56,7 +57,10 @@ func (r rpmDaoImpl) List(orgID string, repositoryConfigUUID string, limit int, o
 		}
 		return api.RepositoryRpmCollectionResponse{},
 			totalRpms,
-			fmt.Errorf("repositoryConfigUUID = %s is not owned", repositoryConfigUUID)
+			&ce.DaoError{
+				NotFound: true,
+				Message:  fmt.Sprintf("repositoryConfigUUID = %s is not owned", repositoryConfigUUID),
+			}
 	}
 
 	repositoryConfig := models.RepositoryConfiguration{}

--- a/pkg/handler/repository_rpms.go
+++ b/pkg/handler/repository_rpms.go
@@ -101,7 +101,7 @@ func (rh *RepositoryRpmHandler) listRepositoriesRpm(c echo.Context) error {
 	// Request record from database
 	apiResponse, total, err := rh.Dao.Rpm.List(orgId, rpmInput.UUID, page.Limit, page.Offset, rpmInput.Search, rpmInput.SortBy)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error listing RPMs", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing RPMs", err.Error())
 	}
 
 	return c.JSON(200, setCollectionResponseMetadata(&apiResponse, c, total))


### PR DESCRIPTION
## Summary

Changes RPM list endpoint to return a status 404 instead of 500 when the repository uuid is not found. 

~~GORM throws an error when an invalid uuid is passed in (i.e. invalid syntax) which is returned as a status 500. The 404 only occurs when a valid, but nonexistent uuid is passed.~~

The endpoint will return a 404 if an invalid uuid is passed in. I changed the `isOwnedRepository` method to compare the uuid as `text`, which is consistent with other endpoints.

## Testing steps

```
curl localhost:8000/api/content-sources/v1.0/repositories/{some nonexistent repository config uuid}/rpms  -H "`./scripts/header.sh 1 user`"
```