### PR TITLE
Fixes 1846: log request ID

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -63,7 +64,7 @@ func main() {
 			}
 		}
 
-		count, introErrors, errors := external_repos.IntrospectAll(&urls, forceIntrospect)
+		count, introErrors, errors := external_repos.IntrospectAll(context.Background(), &urls, forceIntrospect)
 		for i := 0; i < len(introErrors); i++ {
 			log.Warn().Msgf("Introspection Error: %v", introErrors[i].Error())
 		}
@@ -78,7 +79,7 @@ func main() {
 				log.Error().Err(err).Msg("error queueing introspection tasks")
 			}
 		} else {
-			count, introErrors, errors := external_repos.IntrospectAll(nil, forceIntrospect)
+			count, introErrors, errors := external_repos.IntrospectAll(context.Background(), nil, forceIntrospect)
 			for i := 0; i < len(introErrors); i++ {
 				log.Warn().Msgf("Introspection Error: %v", introErrors[i].Error())
 			}

--- a/db/migrations/20230706145024_add_request_id_to_tasks.down.sql
+++ b/db/migrations/20230706145024_add_request_id_to_tasks.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+alter table tasks drop column request_id;
+
+COMMIT;

--- a/db/migrations/20230706145024_add_request_id_to_tasks.up.sql
+++ b/db/migrations/20230706145024_add_request_id_to_tasks.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+alter table tasks add column request_id varchar;
+
+COMMIT;

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -17,6 +17,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const HeaderRequestId = "x-rh-insights-request-id" // the header that contains the request ID
+const RequestIdLoggingKey = "request_id"           // the key that represents the request ID when logged
+
 func ConfigureLogging() {
 	var writers []io.Writer
 

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
@@ -29,7 +30,7 @@ func GetDaoRegistry(db *gorm.DB) *DaoRegistry {
 		Metrics:    metricsDaoImpl{db: db},
 		Snapshot:   snapshotDaoImpl{db: db},
 		TaskInfo:   taskInfoDaoImpl{db: db},
-		AdminTask:  adminTaskInfoDaoImpl{db: db, pulpClient: pulp_client.GetPulpClient()},
+		AdminTask:  adminTaskInfoDaoImpl{db: db, pulpClient: pulp_client.GetPulpClient(context.Background())},
 	}
 	return &reg
 }

--- a/pkg/event/handler/introspect.go
+++ b/pkg/event/handler/introspect.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
@@ -46,7 +47,7 @@ func (h *IntrospectHandler) OnMessage(msg *kafka.Message) error {
 		return err
 	}
 
-	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(payload.Url, true)
+	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(context.Background(), payload.Url, true)
 	for i := 0; i < len(nonFatalErrs); i++ {
 		log.Warn().Err(nonFatalErrs[i]).Msgf("Error %v introspecting repository %v", i, payload.Url)
 	}

--- a/pkg/external_repos/introspect_test.go
+++ b/pkg/external_repos/introspect_test.go
@@ -2,6 +2,7 @@ package external_repos
 
 //nolint:gci
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -103,6 +104,7 @@ func TestIntrospect(t *testing.T) {
 	mockDao.Rpm.On("InsertForRepository", repoUpdate.UUID, mock.Anything).Return(int64(14), nil)
 
 	count, err, updated := Introspect(
+		context.Background(),
 		&dao.Repository{
 			UUID:         repoUUID,
 			URL:          server.URL + "/content",
@@ -116,6 +118,7 @@ func TestIntrospect(t *testing.T) {
 
 	// Without any changes to the repo, there should be no package updates
 	count, err, updated = Introspect(
+		context.Background(),
 		&dao.Repository{
 			UUID:           repoUUID,
 			URL:            server.URL + "/content",
@@ -130,6 +133,7 @@ func TestIntrospect(t *testing.T) {
 
 	// If the repository has failed more than FailedIntrospectionsLimit number of times in a row, it should not introspect
 	_, err, updated = Introspect(
+		context.Background(),
 		&dao.Repository{
 			UUID:                      repoUUID,
 			URL:                       server.URL + "/content",

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -106,7 +107,7 @@ var PulpConnected bool
 
 func ping(c echo.Context) error {
 	if config.LoadedConfig.Clients.Pulp.Server != "" && !PulpConnected {
-		_, err := pulp_client.GetPulpClient().GetRpmRemoteList()
+		_, err := pulp_client.GetPulpClient(context.Background()).GetRpmRemoteList()
 		if err != nil {
 			return c.JSON(502, echo.Map{
 				"message": err.Error(),

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -521,7 +521,7 @@ func (rh *RepositoryHandler) enqueueSnapshotEvent(c echo.Context, repositoryUUID
 			Payload:        payloads.SnapshotPayload{},
 			OrgId:          orgID,
 			RepositoryUUID: repositoryUUID,
-			RequestID:      c.Request().Header.Get(config.HeaderRequestId),
+			RequestID:      c.Response().Header().Get(config.HeaderRequestId),
 		}
 		taskID, err := rh.TaskClient.Enqueue(task)
 		if err != nil {
@@ -539,7 +539,7 @@ func (rh *RepositoryHandler) enqueueSnapshotDeleteEvent(c echo.Context, orgID st
 			Payload:        payload,
 			OrgId:          orgID,
 			RepositoryUUID: repo.RepositoryUUID,
-			RequestID:      c.Request().Header.Get(config.HeaderRequestId),
+			RequestID:      c.Response().Header().Get(config.HeaderRequestId),
 		}
 		taskID, err := rh.TaskClient.Enqueue(task)
 		if err != nil {
@@ -558,7 +558,7 @@ func (rh *RepositoryHandler) enqueueIntrospectEvent(c echo.Context, response api
 			Payload:        payloads.IntrospectPayload{Url: response.URL, Force: true},
 			OrgId:          orgID,
 			RepositoryUUID: response.RepositoryUUID,
-			RequestID:      c.Request().Header.Get(config.HeaderRequestId),
+			RequestID:      c.Response().Header().Get(config.HeaderRequestId),
 		}
 		taskID, err := rh.TaskClient.Enqueue(task)
 		if err != nil {

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -23,6 +23,10 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_midd
 				if identityHeader != "" {
 					c.Response().Header().Set("X-Rh-Identity", identityHeader)
 				}
+				requestIdHeader := c.Request().Header.Get(config.HeaderRequestId)
+				if requestIdHeader != "" {
+					c.Response().Header().Set(config.HeaderRequestId, requestIdHeader)
+				}
 				err = next(c)
 			})).ServeHTTP(c.Response(), c.Request())
 			return

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -23,10 +23,6 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_midd
 				if identityHeader != "" {
 					c.Response().Header().Set("X-Rh-Identity", identityHeader)
 				}
-				requestIdHeader := c.Request().Header.Get(config.HeaderRequestId)
-				if requestIdHeader != "" {
-					c.Response().Header().Set(config.HeaderRequestId, requestIdHeader)
-				}
 				err = next(c)
 			})).ServeHTTP(c.Response(), c.Request())
 			return

--- a/pkg/models/task_info.go
+++ b/pkg/models/task_info.go
@@ -22,6 +22,7 @@ type TaskInfo struct {
 	Finished       *time.Time `gorm:"column:finished_at"`
 	Error          *string
 	Status         string
+	RequestID      string
 }
 
 func (*TaskInfo) TableName() string {

--- a/pkg/pulp_client/client.go
+++ b/pkg/pulp_client/client.go
@@ -14,8 +14,8 @@ type pulpDaoImpl struct {
 	ctx    context.Context
 }
 
-func GetPulpClient() PulpClient {
-	ctx := context.WithValue(context.Background(), zest.ContextServerIndex, 0)
+func GetPulpClient(ctx context.Context) PulpClient {
+	ctx2 := context.WithValue(ctx, zest.ContextServerIndex, 0)
 
 	timeout := 60 * time.Second
 	transport := &http.Transport{ResponseHeaderTimeout: timeout}
@@ -28,7 +28,7 @@ func GetPulpClient() PulpClient {
 	}}
 	client := zest.NewAPIClient(pulpConfig)
 
-	auth := context.WithValue(ctx, zest.ContextBasicAuth, zest.BasicAuth{
+	auth := context.WithValue(ctx2, zest.ContextBasicAuth, zest.BasicAuth{
 		UserName: config.Get().Clients.Pulp.Username,
 		Password: config.Get().Clients.Pulp.Password,
 	})

--- a/pkg/rbac/client_wrapper.go
+++ b/pkg/rbac/client_wrapper.go
@@ -28,7 +28,7 @@ import (
 	"github.com/RedHatInsights/rbac-client-go"
 	"github.com/content-services/content-sources-backend/pkg/cache"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 const application = "content-sources"
@@ -67,12 +67,13 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 	var acl rbac.AccessList
 	var err error
 	var cacheHit = false
+	logger := zerolog.Ctx(ctx)
 
 	if r.cache != nil {
 		acl, err = r.cache.GetAccessList(ctx)
 		cacheHit = err == nil
 		if err != cache.NotFound && err != nil {
-			log.Logger.Err(err).Msg("cache error")
+			logger.Error().Err(err).Msg("cache error")
 		}
 	}
 	if !cacheHit {
@@ -87,7 +88,7 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 		}
 		err := r.cache.SetAccessList(ctx, acl)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to cache Access List")
+			logger.Error().Err(err).Msg("Failed to cache Access List")
 		}
 	}
 

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -25,7 +25,7 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		lecho.WithLevel(echo_log.INFO),
 	)
 	e.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
-		TargetHeader: "x-rh-insights-request-id",
+		TargetHeader: config.HeaderRequestId,
 	}))
 	e.Use(lecho.Middleware(lecho.Config{
 		Logger:          echoLogger,

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -28,9 +28,10 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		TargetHeader: "x-rh-insights-request-id",
 	}))
 	e.Use(lecho.Middleware(lecho.Config{
-		Logger:       echoLogger,
-		RequestIDKey: "x-rh-insights-request-id",
-		Skipper:      config.SkipLogging,
+		Logger:          echoLogger,
+		RequestIDHeader: config.HeaderRequestId,
+		RequestIDKey:    config.RequestIdLoggingKey,
+		Skipper:         config.SkipLogging,
 	}))
 	e.Use(middleware.EnforceJSONContentType)
 

--- a/pkg/tasks/client/client.go
+++ b/pkg/tasks/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	"github.com/google/uuid"
 )
@@ -21,5 +22,11 @@ func NewTaskClient(q queue.Queue) TaskClient {
 }
 
 func (c *Client) Enqueue(task queue.Task) (uuid.UUID, error) {
-	return c.queue.Enqueue(&task)
+	id, err := c.queue.Enqueue(&task)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	logger := tasks.LogForTask(id.String(), task.Typename, task.RequestID)
+	logger.Info().Msg("[Enqueued Task]")
+	return id, nil
 }

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -32,9 +32,13 @@ func DeleteSnapshotHandler(ctx context.Context, task *models.TaskInfo, _ *queue.
 		return fmt.Errorf("payload incorrect type for " + config.DeleteRepositorySnapshotsTask)
 	}
 
+	logger := LogForTask(task.Id.String(), task.Typename, task.RequestID)
+	ctxWithLogger := logger.WithContext(context.Background())
+	pulpClient := pulp_client.GetPulpClient(ctxWithLogger)
+
 	ds := DeleteRepositorySnapshots{
 		daoReg:     dao.GetDaoRegistry(db.DB),
-		pulpClient: pulp_client.GetPulpClient(),
+		pulpClient: pulpClient,
 		payload:    &opts,
 		task:       task,
 		ctx:        ctx,

--- a/pkg/tasks/introspect.go
+++ b/pkg/tasks/introspect.go
@@ -10,12 +10,16 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	"github.com/go-playground/validator/v10"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 // TODO possibly remove context arg
 func IntrospectHandler(ctx context.Context, task *models.TaskInfo, _ *queue.Queue) error {
 	var p payloads.IntrospectPayload
+
+	logger := LogForTask(task.Id.String(), task.Typename, task.RequestID)
+
 	if err := json.Unmarshal(task.Payload, &p); err != nil {
 		return fmt.Errorf("payload incorrect type for IntrospectHandler")
 	}
@@ -26,15 +30,24 @@ func IntrospectHandler(ctx context.Context, task *models.TaskInfo, _ *queue.Queu
 		return err
 	}
 
-	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(p.Url, p.Force)
+	newRpms, nonFatalErrs, errs := external_repos.IntrospectUrl(logger.WithContext(context.Background()), p.Url, p.Force)
 	for i := 0; i < len(nonFatalErrs); i++ {
-		log.Warn().Err(nonFatalErrs[i]).Msgf("Error %v introspecting repository %v", i, p.Url)
+		logger.Warn().Err(nonFatalErrs[i]).Msgf("Error %v introspecting repository %v", i, p.Url)
 	}
 
 	// Introspection failure isn't considered a message failure, as the message has been handled
 	for i := 0; i < len(errs); i++ {
-		log.Error().Err(errs[i]).Msgf("Error %v introspecting repository %v", i, p.Url)
+		logger.Error().Err(errs[i]).Msgf("Error %v introspecting repository %v", i, p.Url)
 	}
-	log.Debug().Msgf("IntrospectionUrl returned %d new packages", newRpms)
+	logger.Debug().Msgf("IntrospectionUrl returned %d new packages", newRpms)
 	return nil
+}
+
+func LogForTask(taskID, typename, requestID string) *zerolog.Logger {
+	logger := log.Logger.With().
+		Str("task_type", typename).
+		Str("task_id", taskID).
+		Str("request_id", requestID).
+		Logger()
+	return &logger
 }

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -17,6 +17,7 @@ type Task struct {
 	Dependencies   []uuid.UUID
 	OrgId          string
 	RepositoryUUID string
+	RequestID      string
 }
 
 //go:generate mockery  --name Queue --filename queue_mock.go --inpackage
@@ -39,7 +40,7 @@ type Queue interface {
 	// IdFromToken returns a task's ID given its token
 	IdFromToken(token uuid.UUID) (id uuid.UUID, isRunning bool, err error)
 	// RefreshHeartbeat refresh heartbeat of task given its token
-	RefreshHeartbeat(token uuid.UUID)
+	RefreshHeartbeat(token uuid.UUID) error
 	// UpdatePayload update the payload on a task
 	UpdatePayload(task *models.TaskInfo, payload interface{}) (*models.TaskInfo, error)
 }
@@ -49,4 +50,5 @@ var (
 	ErrNotRunning      = fmt.Errorf("task is not running")
 	ErrCanceled        = fmt.Errorf("task was canceled")
 	ErrContextCanceled = fmt.Errorf("dequeue context timed out or was canceled")
+	ErrRowsNotAffected = fmt.Errorf("no rows were affected")
 )

--- a/pkg/tasks/queue/queue_mock.go
+++ b/pkg/tasks/queue/queue_mock.go
@@ -148,8 +148,17 @@ func (_m *MockQueue) IdFromToken(token uuid.UUID) (uuid.UUID, bool, error) {
 }
 
 // RefreshHeartbeat provides a mock function with given fields: token
-func (_m *MockQueue) RefreshHeartbeat(token uuid.UUID) {
-	_m.Called(token)
+func (_m *MockQueue) RefreshHeartbeat(token uuid.UUID) error {
+	ret := _m.Called(token)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uuid.UUID) error); ok {
+		r0 = rf(token)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Requeue provides a mock function with given fields: taskId

--- a/pkg/tasks/repository_snapshot_test.go
+++ b/pkg/tasks/repository_snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	zest "github.com/content-services/zest/release/v3"
 	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -112,6 +113,7 @@ func (s *SnapshotSuite) TestSnapshotFull() {
 		task:           &task,
 		queue:          &s.Queue,
 		ctx:            nil,
+		logger:         &log.Logger,
 	}
 
 	s.mockDaoRegistry.Snapshot.On("Create", &expectedSnap).Return(nil).Once()
@@ -156,6 +158,7 @@ func (s *SnapshotSuite) TestSnapshotResync() {
 		task:           &task,
 		queue:          &s.Queue,
 		ctx:            nil,
+		logger:         &log.Logger,
 	}
 	snapErr := snap.Run()
 	assert.NoError(s.T(), snapErr)
@@ -241,6 +244,7 @@ func (s *SnapshotSuite) TestSnapshotRestartAfterSync() {
 		task:           &task,
 		queue:          &s.Queue,
 		ctx:            nil,
+		logger:         &log.Logger,
 	}
 
 	s.mockDaoRegistry.Snapshot.On("Create", &expectedSnap).Return(nil).Once()

--- a/pkg/tasks/worker/worker_pool_test.go
+++ b/pkg/tasks/worker/worker_pool_test.go
@@ -27,6 +27,7 @@ func (s *WorkerSuite) TestStartStopWorkers() {
 	defer goleak.VerifyNone(s.T())
 
 	workerPool, mockQueue := getObjectsForTest(s.T())
+	s.T().Setenv("TASKING_WORKER_COUNT", "3")
 
 	mockQueue.On("Dequeue", context.Background(), []string(nil)).Times(3).Return(nil, nil)
 

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -107,7 +107,7 @@ func (s *SnapshotSuite) TestSnapshot() {
 	assert.NoError(s.T(), err)
 
 	s.snapshotAndWait(taskClient, repo, repoUuid)
-	remote, err := pulp_client.GetPulpClient().GetRpmRemoteByName(repo.UUID)
+	remote, err := pulp_client.GetPulpClient(context.Background()).GetRpmRemoteByName(repo.UUID)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), repo.URL, remote.Url)
 


### PR DESCRIPTION
## Summary
- Adds support for the request ID, `x-rh-insights-request-id`, sent in the header and propagates that request ID to logging in the API, tasking, and redis
- Also propagates TaskID/Type logging throughout tasking system and pulp. 

The goal here is to more easily track which events correspond to which request. For example, if I get an error during repository snapshot, it is nice to know which request or task triggered that failed snapshot.

TODO
- [x] I need to double check redis logging. Will add testing step for that as well.


## Testing steps
1. Make an API request, for example, one to create a repository. Add the `x-rh-insights-request-id` header.
```
POST http://localhost:8000/api/content-sources/v1.0/repositories/
x-rh-identity: zEzcvAe....
x-Rh-Insights-Request-Id: 12345
Content-Type: application/json
```
3. You should see the request ID propagated through the to the logs for the API, tasking, and introspection. Set your log level to  `debug` to make sure you see all the logs.
4. Try variations of snapshotting, introspecting, CTRL+C exiting the server while it's in the middle of a task, and make sure the logs are all showing the request ID (or task ID if applicable).
5. Provide feedback if you think something should or shouldn't be logged.
6. A quick test for RBAC/Redis logging is to hard-code an error in `client_wrapper.go` and see the error get logged.
