### PR TITLE
Fixes 2183: fix deadlock in concurrent task enqueue

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type Database struct {
 	Password   string
 	Name       string
 	CACertPath string `mapstructure:"ca_cert_path"`
+	PoolLimit  int    `mapstructure:"pool_limit"`
 }
 
 type Logging struct {
@@ -185,6 +186,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.user", "")
 	v.SetDefault("database.password", "")
 	v.SetDefault("database.name", "")
+	v.SetDefault("database.pool_limit", 20)
 	v.SetDefault("certs.cert_path", "")
 	v.SetDefault("options.paged_rpm_inserts_limit", DefaultPagedRpmInsertsLimit)
 	v.SetDefault("options.introspect_api_time_limit_sec", DefaultIntrospectApiTimeLimitSec)

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -44,10 +44,20 @@ func GetUrl() string {
 // Connect initializes global database connection, DB
 func Connect() error {
 	var err error
+
 	dbURL := GetUrl()
 	DB, err = gorm.Open(pg.Open(dbURL), &gorm.Config{Logger: gorm_zerolog.Logger{}})
+	if err != nil {
+		return err
+	}
 	DB.CreateBatchSize = config.DefaultPagedRpmInsertsLimit
-	return err
+
+	sqlDb, err := DB.DB()
+	if err != nil {
+		return err
+	}
+	sqlDb.SetMaxOpenConns(config.Get().Database.PoolLimit)
+	return nil
 }
 
 // Close closes global database connection, DB

--- a/pkg/tasks/queue/pgx_pool_wrapper.go
+++ b/pkg/tasks/queue/pgx_pool_wrapper.go
@@ -1,0 +1,101 @@
+package queue
+
+import (
+	"context"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// PgxPoolWrapper wraps a pgx Pool in a generic interface to allow for alternative implementations, such as the FakePgxPoolWrapper
+type PgxPoolWrapper struct {
+	pool *pgxpool.Pool
+}
+
+func (p *PgxPoolWrapper) Begin(ctx context.Context) (pgx.Tx, error) {
+	return p.pool.Begin(ctx)
+}
+
+func (p *PgxPoolWrapper) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+	return p.pool.Exec(ctx, sql, arguments...)
+}
+
+func (p *PgxPoolWrapper) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return p.pool.Query(ctx, sql, args...)
+}
+
+func (p *PgxPoolWrapper) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return p.pool.QueryRow(ctx, sql, args...)
+}
+
+func (p *PgxPoolWrapper) Acquire(ctx context.Context) (Connection, error) {
+	conn, err := p.pool.Acquire(ctx)
+	return &PgxConnWrapper{conn: conn}, err
+}
+
+// PgxConnWrapper wraps a pgxpool Conn in a generic interface to allow for alternative implementations, such as the FakePgxPoolWrapper
+type PgxConnWrapper struct {
+	conn *pgxpool.Conn
+}
+
+func (p *PgxConnWrapper) Begin(ctx context.Context) (pgx.Tx, error) {
+	return p.conn.Begin(ctx)
+}
+
+func (p *PgxConnWrapper) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+	return p.conn.Exec(ctx, sql, arguments...)
+}
+
+func (p *PgxConnWrapper) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return p.conn.Query(ctx, sql, args...)
+}
+
+func (p *PgxConnWrapper) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return p.conn.QueryRow(ctx, sql, args...)
+}
+
+func (p *PgxConnWrapper) Release() {
+	p.conn.Release()
+}
+
+func (p *PgxConnWrapper) Conn() *pgx.Conn {
+	return p.conn.Conn()
+}
+
+// FakePgxPoolWrapper is used for testing, to provide a pool interface implementation that doesn't actually use the pool
+// in order to wrap all work in a transaction.  This shouldn't be used in production, as it is based off a single
+// transaction
+type FakePgxPoolWrapper struct {
+	tx   *pgx.Tx
+	conn *pgxpool.Conn
+}
+
+func (p *FakePgxPoolWrapper) Release() {
+	// This isn't a real pool so ignore
+}
+
+func (p *FakePgxPoolWrapper) Begin(ctx context.Context) (pgx.Tx, error) {
+	return (*p.tx).Begin(ctx)
+}
+
+func (p *FakePgxPoolWrapper) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+	return (*p.tx).Exec(ctx, sql, arguments...)
+}
+
+func (p *FakePgxPoolWrapper) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return (*p.tx).Query(ctx, sql, args...)
+}
+
+func (p *FakePgxPoolWrapper) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return (*p.tx).QueryRow(ctx, sql, args...)
+}
+
+func (p *FakePgxPoolWrapper) Acquire(_ context.Context) (Connection, error) {
+	// Not a real pool so ignore
+	return p, nil
+}
+
+func (p *FakePgxPoolWrapper) Conn() *pgx.Conn {
+	return p.conn.Conn()
+}


### PR DESCRIPTION
## Summary

This resolves a couple of issues:
* Enqueue() was not properly releasing its acquired db pool connection, this resulted in deadlocks when more than ~20 create reqs came in at once
* Sets a limit on the postgres connections for gorm, as if you perform ~50 create reqs at the same time a postgres server with a default limit of connections will start to max out and start issuing errors
* Reworks pgqueue to use a wrapper around pgxpool.Pool, this allows for testing while giving pgqueue the ability to start/end transactions and acquire/release Pool connections


## Testing steps

Checkout this pr and 'make run'
create a new file `./cmd/test/main.go`   with the contents here: https://gist.github.com/jlsherrill/d07efa70bed152d8428c758b7332f95e

then run it:  `go run ./cmd/test/main.go`

You should only get back 201s, and all tasks should be processed without error (other than the 404)