### PR TITLE
Fixes 2083: log when a task fails to complete

### DIFF
--- a/pkg/tasks/worker/worker.go
+++ b/pkg/tasks/worker/worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -153,10 +154,14 @@ func (w *worker) process(ctx context.Context, taskInfo *models.TaskInfo) {
 	defer recoverOnPanic(*logger)
 
 	if handler, ok := w.handlers[taskInfo.Typename]; ok {
+		var finishStr string
 		err := handler(ctx, taskInfo, &w.queue)
 		if err != nil {
+			finishStr = fmt.Sprintf("task failed with error: %v", err)
+			logger.Warn().Msgf("error during task processing: %v", err)
 			w.metrics.RecordMessageResult(false)
 		} else {
+			finishStr = "task completed"
 			w.metrics.RecordMessageResult(true)
 		}
 
@@ -164,7 +169,7 @@ func (w *worker) process(ctx context.Context, taskInfo *models.TaskInfo) {
 		if err != nil {
 			logger.Error().Msgf("error finishing task: %v", err)
 		}
-		logger.Info().Msg("[Finished Task]")
+		logger.Info().Msgf("[Finished Task] %v", finishStr)
 		w.runningTask.clear()
 	} else {
 		logger.Warn().Msg("handler not found for task type")


### PR DESCRIPTION
## Summary
PR #333 should merge first. This PR is built on that PR.

To make it clearer that the task failed, this changes logging to log the error of the failed task.

This PR in combination with this [commit to zest](https://github.com/content-services/zest/commit/ee55f31f4234ca312ca13fc860b8cd0ca923b2cb) should fully address the JIRA issue. The change to zest will not be used until we update our app to a newer version of zest. 

## Testing steps
1. Create a repo with bad url (i.e. `http://example.com`), with snapshot enabled. 
2. You should see the error `json: cannot unmarshal string into Go struct field TaskResponse.error of type map[string]interface {}"` for the sync task specifically. 
3. To test the change to zest, update your go.mod to use the latest zest version. There will be some syntax errors in the pulp_client package that you will have to manually fix to use the latest version. The functions that end in `Api` have to be changed to `API`. 
4. Now you should see a different error for the sync task.
