### PR TITLE
Fixes 2224: admin task fetch 404

### DIFF
--- a/pkg/dao/admin_tasks.go
+++ b/pkg/dao/admin_tasks.go
@@ -30,7 +30,7 @@ func GetAdminTaskDao(db *gorm.DB, pulpClient pulp_client.PulpClient) AdminTaskDa
 
 func (a adminTaskInfoDaoImpl) Fetch(id string) (api.AdminTaskInfoResponse, error) {
 	taskInfo := models.TaskInfo{}
-	query := a.db.Where("id = ?", id).Joins("LEFT JOIN repository_configurations ON (tasks.repository_uuid = repository_configurations.repository_uuid AND tasks.org_id = repository_configurations.org_id)")
+	query := a.db.Where("text(id) = ?", id).Joins("LEFT JOIN repository_configurations ON (tasks.repository_uuid = repository_configurations.repository_uuid AND tasks.org_id = repository_configurations.org_id)")
 	result := query.First(&taskInfo)
 	var account_id sql.NullString
 	query.Select("account_id").First(&account_id)

--- a/pkg/dao/admin_tasks_test.go
+++ b/pkg/dao/admin_tasks_test.go
@@ -77,6 +77,19 @@ func (suite *AdminTaskSuite) TestFetchNotFound() {
 	assert.True(t, daoError.NotFound)
 }
 
+func (suite *AdminTaskSuite) TestFetchInvalidUUID() {
+	suite.createTask()
+	t := suite.T()
+	invalidUUID := "bad task id"
+
+	_, err := suite.dao.Fetch(invalidUUID)
+	assert.NotNil(t, err)
+	daoError, ok := err.(*ce.DaoError)
+	assert.True(t, ok)
+	assert.True(t, daoError.NotFound)
+	assert.Equal(t, "Could not find task with UUID "+invalidUUID, daoError.Message)
+}
+
 // Occurs if repository/repository configuration associated with task is deleted
 func (suite *AdminTaskSuite) TestFetchMissingAccountId() {
 	t := suite.T()


### PR DESCRIPTION
## Summary

Improves the "not found" error message when fetching an admin task using a uuid with invalid syntax.

Previously, when making a GET request to `/admin/tasks/:uuid` with a uuid that had invalid syntax, e.g. "invalid-uuid", the error message would be `(ERROR: invalid input syntax for type uuid: "invalid-uuid" (SQLSTATE 22P02))`

The PR changes the error message to `Could not find task with UUID invalid-uuid` which is consistent with other fetch APIs

## Testing steps

```curl localhost:8000/api/content-sources/v1.0/admin/tasks/bad-uuid  -H "`./scripts/header.sh 1 adminUser`"```
The "admin_tasks" config feature must be enabled. Either both "admin_tasks.accounts" and "admin_tasks.users" must  be nil to allow any user to access it, or "adminUser" must be added to "admin_tasks.users" to access the endpoint.

This can also be tested through the frontend in [this PR](https://github.com/content-services/content-sources-frontend/pull/128) by navigating to `/beta/insights/content/admin-tasks/bad-uuid` You should be redirected to `/beta/insights/content/admin-tasks` and the error will pop up as a notification.