### PR TITLE
Fixes 2193: popular repository pagination

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -58,6 +58,26 @@ const docTemplate = `{
                 ],
                 "summary": "List Popular Repositories",
                 "operationId": "listPopularRepositories",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Offset into the list of results to return in the response",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit the number of items returned",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search term for name and url.",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -731,6 +731,32 @@
             "get": {
                 "description": "Get popular repositories",
                 "operationId": "listPopularRepositories",
+                "parameters": [
+                    {
+                        "description": "Offset into the list of results to return in the response",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Limit the number of items returned",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Search term for name and url.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "content": {

--- a/pkg/handler/popular_repositories.go
+++ b/pkg/handler/popular_repositories.go
@@ -54,19 +54,36 @@ func (rh *PopularRepositoriesHandler) listPopularRepositories(c echo.Context) er
 	}
 
 	filters := ParseFilters(c)
+	pageData := ParsePagination(c)
 
-	filteredData := filterBySearchQuery(configData, filters.Search)
+	filteredData, totalCount := filterPopularRepositories(configData, filters, pageData)
 
 	// We should likely call the db directly here to reduce this down to one query if this list get's larger.
-	for i := 0; i < len(filteredData); i++ {
-		err := rh.updateIfExists(c, &filteredData[i])
+	for i := 0; i < len(filteredData.Data); i++ {
+		err := rh.updateIfExists(c, &filteredData.Data[i])
 
 		if err != nil {
 			return ce.NewErrorResponseFromError("Could not get repository list", err)
 		}
 	}
 
-	return c.JSON(200, setCollectionResponseMetadata(&api.PopularRepositoriesCollectionResponse{Data: filteredData}, c, int64(len(filteredData))))
+	return c.JSON(200, setCollectionResponseMetadata(&filteredData, c, totalCount))
+}
+
+func filterPopularRepositories(configData []api.PopularRepositoryResponse, filters api.FilterData, pageData api.PaginationData) (api.PopularRepositoriesCollectionResponse, int64) {
+	filteredData := filterBySearchQuery(configData, filters.Search)
+
+	totalCount := len(filteredData)
+
+	if pageData.Offset < 0 || pageData.Offset >= totalCount {
+		return api.PopularRepositoriesCollectionResponse{Data: []api.PopularRepositoryResponse{}}, int64(totalCount)
+	} else if pageData.Offset+pageData.Limit > totalCount {
+		filteredData = filteredData[pageData.Offset:]
+	} else {
+		filteredData = filteredData[pageData.Offset : pageData.Offset+pageData.Limit]
+	}
+
+	return api.PopularRepositoriesCollectionResponse{Data: filteredData}, int64(totalCount)
 }
 
 func (rh *PopularRepositoriesHandler) updateIfExists(c echo.Context, repo *api.PopularRepositoryResponse) error {

--- a/pkg/handler/popular_repositories.go
+++ b/pkg/handler/popular_repositories.go
@@ -31,6 +31,9 @@ func RegisterPopularRepositoriesRoutes(engine *echo.Group, dao *dao.DaoRegistry)
 // @ID           listPopularRepositories
 // @Description  Get popular repositories
 // @Tags         popular_repositories
+// @Param        offset query int false "Offset into the list of results to return in the response"
+// @Param		     limit query int false "Limit the number of items returned"
+// @Param		     search query string false "Search term for name and url."
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.PopularRepositoriesCollectionResponse


### PR DESCRIPTION
## Summary

The popular repository table UI implements pagination and this PR adds backend support for pagination using the limit and offset URL parameters.

## Testing steps

The JSON that contains popular repositories currently has 3 entries, so it is easiest to test pagination with limits below 3.

```
curl "localhost:8000/api/content-sources/v1/popular_repositories/?offset=1&limit=1"  -H "`./scripts/header.sh 1 user`"
```

Negative or out of range offsets returns an empty array (consistent with other list APIs)
