### PR TITLE
Fixes 1965: configurable download policies in pulp

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -89,6 +89,7 @@ clients:
     username: admin
     password: password
     storage_type: local #object or local
+    download_policy: on_demand #on_demand or immediate
     custom_repo_objects:
       url: http://minio:9000
       access_key: test

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -87,6 +87,8 @@ objects:
                     optional: true
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
               - name: CLIENTS_PULP_USERNAME
                 value: ${{CLIENTS_PULP_USERNAME}}
               - name: CLIENTS_PULP_PASSWORD
@@ -193,6 +195,8 @@ objects:
                     optional: true
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
               - name: CLIENTS_PULP_USERNAME
                 value: ${{CLIENTS_PULP_USERNAME}}
               - name: CLIENTS_PULP_PASSWORD
@@ -255,6 +259,8 @@ objects:
                     optional: true
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
               - name: CLIENTS_PULP_USERNAME
                 value: ${{CLIENTS_PULP_USERNAME}}
               - name: CLIENTS_PULP_PASSWORD
@@ -372,6 +378,8 @@ parameters:
     value: "admin"
   - name: CLIENTS_PULP_PASSWORD
     description: Password for accessing pulp over basic auth
+  - name: CLIENTS_PULP_DOWNLOAD_POLICY
+    description: the download policy to use in the environment (immediate or on_demand)
   - name: FEATURES_SNAPSHOTS_ENABLED
     description: Whether the Snapshots feature should be turned on
   - name: FEATURES_SNAPSHOTS_ACCOUNTS

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,6 +80,7 @@ type Pulp struct {
 	Password          string
 	StorageType       string       `mapstructure:"storage_type"` // s3 or local
 	CustomRepoObjects *ObjectStore `mapstructure:"custom_repo_objects"`
+	DownloadPolicy    string       `mapstructure:"download_policy"` // on_demand or immediate
 }
 
 const CustomRepoClowderBucketName = "content-sources-s3-custom-repos"
@@ -212,6 +213,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.rbac_base_url", "http://rbac-service:8000/api/rbac/v1")
 	v.SetDefault("clients.rbac_timeout", 30)
 	v.SetDefault("clients.pulp.server", "")
+	v.SetDefault("clients.pulp.download_policy", "immediate")
 	v.SetDefault("clients.pulp.username", "")
 	v.SetDefault("clients.pulp.password", "")
 	v.SetDefault("sentry.dsn", "")


### PR DESCRIPTION
## Summary

Allows setting the download policy via an environment variable.  Currently only on_demand and immediate are supported.

## Testing steps

for local dev testing run:
```
CLIENTS_PULP_DOWNLOAD_POLICY=immediate  make run
```

create a repo with snapshotting turned on, then check pulp (use password 'password'):
```
$ psql -h localhost -p 5432  pulp pulp 

pulp=# select policy from core_remote;
```

There's not really any way to test this from a users perspective. right now