### PR TITLE
Fixes 2273: handle bad uuids on validate api

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -247,7 +247,7 @@ func (r repositoryConfigDaoImpl) List(
 
 func (r repositoryConfigDaoImpl) InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse {
 	repoConfigs := make([]models.RepositoryConfiguration, 0)
-	filteredDB := r.db.Where("repositories.uuid = ?", uuid).
+	filteredDB := r.db.Where("text(repositories.uuid) = ?", uuid).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
 
 	filteredDB.Preload("Repository").Find(&repoConfigs)
@@ -597,7 +597,7 @@ func (r repositoryConfigDaoImpl) validateName(orgId string, name string, respons
 	found := models.RepositoryConfiguration{}
 	query := r.db.Where("name = ? AND ORG_ID = ?", name, orgId)
 	if len(excludedUUIDS) != 0 {
-		query = query.Where("repository_configurations.uuid NOT IN ?", excludedUUIDS)
+		query = query.Where("text(repository_configurations.uuid) NOT IN ?", excludedUUIDS)
 	}
 	if err := query.Find(&found).Error; err != nil {
 		response.Valid = false
@@ -626,7 +626,7 @@ func (r repositoryConfigDaoImpl) validateUrl(orgId string, url string, response 
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid").
 		Where("Repositories.URL = ? AND ORG_ID = ?", url, orgId)
 	if len(excludedUUIDS) != 0 {
-		query = query.Where("repository_configurations.uuid NOT IN ?", excludedUUIDS)
+		query = query.Where("text(repository_configurations.uuid) NOT IN ?", excludedUUIDS)
 	}
 	if err := query.Find(&found).Error; err != nil {
 		response.URL.Valid = false

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1299,13 +1299,14 @@ func (suite *RepositoryConfigSuite) TestValidateParametersValidUrlName() {
 	assert.False(t, response.URL.Skipped)
 }
 
-func (suite *RepositoryConfigSuite) TestValidateParametersBadUrl() {
+func (suite *RepositoryConfigSuite) TestValidateParametersBadUUIDAndUrl() {
 	t := suite.T()
 	mockYumRepo, dao, repoConfig := suite.setupValidationTest()
 	// Providing a bad url that doesn't have a repo
 	parameters := api.RepositoryValidationRequest{
-		Name: pointy.String("Some bad repo!"),
-		URL:  pointy.String("http://badrepo.example.com/"),
+		UUID: pointy.Pointer("not.a.real.UUID"),
+		Name: pointy.Pointer("Some bad repo!"),
+		URL:  pointy.Pointer("http://badrepo.example.com/"),
 	}
 	mockYumRepo.Mock.On("Repomd").Return(nil, 404, nil)
 
@@ -1318,6 +1319,22 @@ func (suite *RepositoryConfigSuite) TestValidateParametersBadUrl() {
 	assert.Equal(t, response.URL.HTTPCode, 404)
 	assert.False(t, response.URL.MetadataPresent)
 	assert.False(t, response.URL.Skipped)
+}
+
+func (suite *RepositoryConfigSuite) TestValidateParametersNameBadUUID() {
+	t := suite.T()
+	mockYumRepo, dao, repoConfig := suite.setupValidationTest()
+	// Providing a bad url that doesn't have a repo
+	parameters := api.RepositoryValidationRequest{
+		Name: pointy.Pointer("Somebadrepo!"),
+	}
+	mockYumRepo.Mock.On("Repomd").Return(nil, 404, nil)
+
+	response, err := dao.ValidateParameters(repoConfig.OrgID, parameters, []string{"not.a.real.UUID"})
+	assert.NoError(t, err)
+
+	assert.True(t, response.Name.Valid)
+	assert.False(t, response.Name.Skipped)
 }
 
 func (suite *RepositoryConfigSuite) TestValidateParametersTimeOutUrl() {

--- a/pkg/handler/repository_parameters.go
+++ b/pkg/handler/repository_parameters.go
@@ -143,7 +143,7 @@ func (rph *RepositoryParameterHandler) validate(c echo.Context) error {
 	// Check for any errors and return the first one.  Errors are fatal, not errors retrieving metadata.
 	for i := 0; i < len(errors); i++ {
 		if errors[i] != nil {
-			return c.JSON(ce.HttpCodeForDaoError(errors[i]), errors[i].Error())
+			return ce.NewErrorResponse(ce.HttpCodeForDaoError(errors[i]), "Error validating repository", errors[i].Error())
 		}
 	}
 


### PR DESCRIPTION
## Summary

The validation api didn't handle bad uuids well.  In addition, the error was returned to the user but was not logged.  This adds that logging

## Testing steps
Perform this request:

```
POST http://localhost:8000/api/content-sources/v1.0/repository_parameters/validate/
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJqZG9lIn0sImludGVybmFsIjp7Im9yZ19pZCI6IjEyMyJ9fX0K

[{"url":  "http://yum.theforeman.org/pulpcore/3.16/el8/x86_64/", "uuid":  "'response.write(731,493*173,328)'", "snapshot":  false}]
```