### PR TITLE
Fixes 2310: fix 404 err on delete task

### DIFF
--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -6,6 +6,7 @@ import zest "github.com/content-services/zest/release/v2023"
 type PulpGlobalClient interface {
 	// Domains
 	LookupOrCreateDomain(name string) (*string, error)
+	LookupDomain(name string) (*string, error)
 
 	// Tasks
 	GetTask(taskHref string) (zest.TaskResponse, error)
@@ -47,6 +48,7 @@ type PulpClient interface {
 
 	// Domains
 	LookupOrCreateDomain(name string) (*string, error)
+	LookupDomain(name string) (*string, error)
 
 	// Status
 	Status() (*zest.StatusResponse, error)

--- a/pkg/pulp_client/pulp_client_mock.go
+++ b/pkg/pulp_client/pulp_client_mock.go
@@ -418,6 +418,32 @@ func (_m *MockPulpClient) GetTask(taskHref string) (zest.TaskResponse, error) {
 	return r0, r1
 }
 
+// LookupDomain provides a mock function with given fields: name
+func (_m *MockPulpClient) LookupDomain(name string) (*string, error) {
+	ret := _m.Called(name)
+
+	var r0 *string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) *string); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LookupOrCreateDomain provides a mock function with given fields: name
 func (_m *MockPulpClient) LookupOrCreateDomain(name string) (*string, error) {
 	ret := _m.Called(name)

--- a/pkg/pulp_client/pulp_global_client_mock.go
+++ b/pkg/pulp_client/pulp_global_client_mock.go
@@ -36,6 +36,32 @@ func (_m *MockPulpGlobalClient) GetTask(taskHref string) (zest.TaskResponse, err
 	return r0, r1
 }
 
+// LookupDomain provides a mock function with given fields: name
+func (_m *MockPulpGlobalClient) LookupDomain(name string) (*string, error) {
+	ret := _m.Called(name)
+
+	var r0 *string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) *string); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LookupOrCreateDomain provides a mock function with given fields: name
 func (_m *MockPulpGlobalClient) LookupOrCreateDomain(name string) (*string, error) {
 	ret := _m.Called(name)

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -83,7 +83,7 @@ func (s *DeleteTest) TestSnapshot() {
 	})
 	assert.NoError(s.T(), err)
 	s.WaitOnTask(taskUuid)
-	
+
 	results, _, err := s.dao.RepositoryConfig.List(accountId, api.PaginationData{}, api.FilterData{
 		Name: repo.Name,
 	})

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -83,8 +83,7 @@ func (s *DeleteTest) TestSnapshot() {
 	})
 	assert.NoError(s.T(), err)
 	s.WaitOnTask(taskUuid)
-
-	// List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)
+	
 	results, _, err := s.dao.RepositoryConfig.List(accountId, api.PaginationData{}, api.FilterData{
 		Name: repo.Name,
 	})

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	m "github.com/content-services/content-sources-backend/pkg/instrumentation"
+	"github.com/content-services/content-sources-backend/pkg/tasks"
+	"github.com/content-services/content-sources-backend/pkg/tasks/client"
+	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	"github.com/content-services/content-sources-backend/pkg/tasks/worker"
+	uuid2 "github.com/google/uuid"
+	"github.com/openlyinc/pointy"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// This is a delete integration tests without any snapshotting
+type DeleteTest struct {
+	Suite
+	dao   *dao.DaoRegistry
+	queue queue.PgQueue
+}
+
+func (s *DeleteTest) SetupTest() {
+	s.Suite.SetupTest()
+
+	wkrQueue, err := queue.NewPgQueue(db.GetUrl())
+	require.NoError(s.T(), err)
+	s.queue = wkrQueue
+
+	wrk := worker.NewTaskWorkerPool(&wkrQueue, m.NewMetrics(prometheus.NewRegistry()))
+	wrk.RegisterHandler(config.DeleteRepositorySnapshotsTask, tasks.DeleteSnapshotHandler)
+	wrk.HeartbeatListener()
+
+	wkrCtx := context.Background()
+	go (wrk).StartWorkers(wkrCtx)
+	go func() {
+		<-wkrCtx.Done()
+		wrk.Stop()
+	}()
+	// Force local storage for integration tests
+	config.Get().Clients.Pulp.StorageType = "local"
+}
+
+func TestDeleteTest(t *testing.T) {
+	suite.Run(t, new(DeleteTest))
+}
+
+func (s *DeleteTest) TestSnapshot() {
+	s.dao = dao.GetDaoRegistry(db.DB)
+
+	// Setup the repository
+	accountId := uuid2.NewString()
+	repo, err := s.dao.RepositoryConfig.Create(api.RepositoryRequest{
+		Name:      pointy.Pointer(uuid2.NewString()),
+		URL:       pointy.Pointer("https://fixtures.pulpproject.org/rpm-unsigned/"),
+		AccountID: pointy.Pointer(accountId),
+		OrgID:     pointy.Pointer(accountId),
+		Snapshot:  pointy.Pointer(false),
+	})
+	assert.NoError(s.T(), err)
+	repoUuid, err := uuid2.Parse(repo.RepositoryUUID)
+	assert.NoError(s.T(), err)
+
+	// Start the task
+	taskClient := client.NewTaskClient(&s.queue)
+
+	// Delete the repository
+	taskUuid, err := taskClient.Enqueue(queue.Task{
+		Typename:       config.DeleteRepositorySnapshotsTask,
+		Payload:        tasks.DeleteRepositorySnapshotsPayload{RepoConfigUUID: repo.UUID},
+		OrgId:          repo.OrgID,
+		RepositoryUUID: repoUuid.String(),
+	})
+	assert.NoError(s.T(), err)
+	s.WaitOnTask(taskUuid)
+
+	// List(orgID string, paginationData api.PaginationData, filterData api.FilterData) (api.RepositoryCollectionResponse, int64, error)
+	results, _, err := s.dao.RepositoryConfig.List(accountId, api.PaginationData{}, api.FilterData{
+		Name: repo.Name,
+	})
+	assert.NoError(s.T(), err)
+	assert.Empty(s.T(), results.Data)
+}
+
+func (s *DeleteTest) WaitOnTask(taskUuid uuid2.UUID) {
+	// Poll until the task is complete
+	taskInfo, err := s.queue.Status(taskUuid)
+	assert.NoError(s.T(), err)
+	for {
+		if taskInfo.Status == config.TaskStatusRunning || taskInfo.Status == config.TaskStatusPending {
+			log.Logger.Error().Msg("SLEEPING")
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+		taskInfo, err = s.queue.Status(taskUuid)
+		assert.NoError(s.T(), err)
+	}
+	if taskInfo.Error != nil {
+		assert.Nil(s.T(), *taskInfo.Error)
+	}
+
+	assert.Equal(s.T(), config.TaskStatusCompleted, taskInfo.Status)
+}


### PR DESCRIPTION
## Summary
if no domain was ever created

## Testing steps

In an org that has never created any repos (or at least none that were snapshotted).  Create a repo:

```
POST http://localhost:8000/api/content-sources/v1.0/repositories/
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJmb28ifSwiYWNjb3VudF9udW1iZXIiOiIzMCIsImludGVybmFsIjp7Im9yZ19pZCI6IjMwIn19fQo=
x-Rh-Insights-Request-Id: 9876


{"name":"pulp 3.16","url":"http://yum.theforeman.org/pulpcore/3.16/el8/x86_64/","snapshot": false}
```

get the UUID of the created repo and delete it:

```

DELETE http://localhost:8000/api/content-sources/v1.0/repositories/14c3a83d-7574-4654-9a2d-8d4c92254b39
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJmb28ifSwiYWNjb3VudF9udW1iZXIiOiIzMCIsImludGVybmFsIjp7Im9yZ19pZCI6IjMwIn19fQo=

```

Now check the tasks:

```
GET http://localhost:8000/api/content-sources/v1.0/tasks/
Content-Type: application/json
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJmb28ifSwiYWNjb3VudF9udW1iZXIiOiIzMCIsImludGVybmFsIjp7Im9yZ19pZCI6IjMwIn19fQo=
```

the delete task should not be in error state
