### PR TITLE
Fixes 2315: set proper s3 acl and update domains

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/handler"
 	m "github.com/content-services/content-sources-backend/pkg/instrumentation"
 	custom_collector "github.com/content-services/content-sources-backend/pkg/instrumentation/custom"
-	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/router"
 	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
@@ -73,10 +72,6 @@ func main() {
 		mockRbac(ctx, &wg)
 	}
 	config.SetupNotifications()
-
-	config := pulp_client.S3StorageConfiguration()
-	config["secret_key"] = "HIDDEN"
-	log.Logger.Warn().Interface("S3StorageConfig", config).Msg("Storage")
 
 	wg.Wait()
 }

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -5,8 +5,9 @@ import zest "github.com/content-services/zest/release/v2023"
 //go:generate mockery  --name PulpGlobalClient --filename pulp_global_client_mock.go --inpackage
 type PulpGlobalClient interface {
 	// Domains
-	LookupOrCreateDomain(name string) (*string, error)
-	LookupDomain(name string) (*string, error)
+	LookupOrCreateDomain(name string) (string, error)
+	LookupDomain(name string) (string, error)
+	UpdateDomainIfNeeded(name string) error
 
 	// Tasks
 	GetTask(taskHref string) (zest.TaskResponse, error)
@@ -47,8 +48,9 @@ type PulpClient interface {
 	DeleteRpmDistribution(rpmDistributionHref string) (string, error)
 
 	// Domains
-	LookupOrCreateDomain(name string) (*string, error)
-	LookupDomain(name string) (*string, error)
+	LookupOrCreateDomain(name string) (string, error)
+	LookupDomain(name string) (string, error)
+	UpdateDomainIfNeeded(name string) error
 
 	// Status
 	Status() (*zest.StatusResponse, error)

--- a/pkg/pulp_client/pulp_client_mock.go
+++ b/pkg/pulp_client/pulp_client_mock.go
@@ -419,20 +419,18 @@ func (_m *MockPulpClient) GetTask(taskHref string) (zest.TaskResponse, error) {
 }
 
 // LookupDomain provides a mock function with given fields: name
-func (_m *MockPulpClient) LookupDomain(name string) (*string, error) {
+func (_m *MockPulpClient) LookupDomain(name string) (string, error) {
 	ret := _m.Called(name)
 
-	var r0 *string
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
 		return rf(name)
 	}
-	if rf, ok := ret.Get(0).(func(string) *string); ok {
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(name)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
@@ -445,20 +443,18 @@ func (_m *MockPulpClient) LookupDomain(name string) (*string, error) {
 }
 
 // LookupOrCreateDomain provides a mock function with given fields: name
-func (_m *MockPulpClient) LookupOrCreateDomain(name string) (*string, error) {
+func (_m *MockPulpClient) LookupOrCreateDomain(name string) (string, error) {
 	ret := _m.Called(name)
 
-	var r0 *string
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
 		return rf(name)
 	}
-	if rf, ok := ret.Get(0).(func(string) *string); ok {
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(name)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
@@ -544,6 +540,20 @@ func (_m *MockPulpClient) SyncRpmRepository(rpmRpmRepositoryHref string, remoteH
 	}
 
 	return r0, r1
+}
+
+// UpdateDomainIfNeeded provides a mock function with given fields: name
+func (_m *MockPulpClient) UpdateDomainIfNeeded(name string) error {
+	ret := _m.Called(name)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UpdateRpmRemoteUrl provides a mock function with given fields: pulpHref, url

--- a/pkg/pulp_client/pulp_global_client_mock.go
+++ b/pkg/pulp_client/pulp_global_client_mock.go
@@ -37,20 +37,18 @@ func (_m *MockPulpGlobalClient) GetTask(taskHref string) (zest.TaskResponse, err
 }
 
 // LookupDomain provides a mock function with given fields: name
-func (_m *MockPulpGlobalClient) LookupDomain(name string) (*string, error) {
+func (_m *MockPulpGlobalClient) LookupDomain(name string) (string, error) {
 	ret := _m.Called(name)
 
-	var r0 *string
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
 		return rf(name)
 	}
-	if rf, ok := ret.Get(0).(func(string) *string); ok {
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(name)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
@@ -63,20 +61,18 @@ func (_m *MockPulpGlobalClient) LookupDomain(name string) (*string, error) {
 }
 
 // LookupOrCreateDomain provides a mock function with given fields: name
-func (_m *MockPulpGlobalClient) LookupOrCreateDomain(name string) (*string, error) {
+func (_m *MockPulpGlobalClient) LookupOrCreateDomain(name string) (string, error) {
 	ret := _m.Called(name)
 
-	var r0 *string
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*string, error)); ok {
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
 		return rf(name)
 	}
-	if rf, ok := ret.Get(0).(func(string) *string); ok {
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(name)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*string)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
@@ -112,6 +108,20 @@ func (_m *MockPulpGlobalClient) PollTask(taskHref string) (*zest.TaskResponse, e
 	}
 
 	return r0, r1
+}
+
+// UpdateDomainIfNeeded provides a mock function with given fields: name
+func (_m *MockPulpGlobalClient) UpdateDomainIfNeeded(name string) error {
+	ret := _m.Called(name)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 type mockConstructorTestingTNewMockPulpGlobalClient interface {

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -39,7 +39,7 @@ func lookupOptionalPulpClient(ctx context.Context, globalClient pulp_client.Pulp
 	if err != nil {
 		return nil, err
 	}
-	if domainFound != nil {
+	if domainFound != "" {
 		client := pulp_client.GetPulpClientWithDomain(ctx, domainName)
 		return &client, nil
 	}

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -48,7 +48,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestLookupOptionalPulpClient() {
 	}
 
 	s.mockDaoRegistry.Domain.On("FetchOrCreateDomain", task.OrgId).Return("myDomain", nil)
-	s.MockPulpClient.On("LookupDomain", "myDomain").Return(pointy.Pointer("somepath"), nil)
+	s.MockPulpClient.On("LookupDomain", "myDomain").Return("somepath", nil)
 	found, err := lookupOptionalPulpClient(context.Background(), s.pulpClient(), &task, s.mockDaoRegistry.ToDaoRegistry())
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), found)
@@ -62,7 +62,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestLookupOptionalPulpClientNil() {
 	}
 
 	s.mockDaoRegistry.Domain.On("FetchOrCreateDomain", task.OrgId).Return("myDomain", nil)
-	s.MockPulpClient.On("LookupDomain", "myDomain").Return(nil, nil)
+	s.MockPulpClient.On("LookupDomain", "myDomain").Return("", nil)
 	found, err := lookupOptionalPulpClient(context.Background(), s.pulpClient(), &task, s.mockDaoRegistry.ToDaoRegistry())
 	assert.NoError(s.T(), err)
 	assert.Nil(s.T(), found)

--- a/pkg/tasks/repository_snapshot.go
+++ b/pkg/tasks/repository_snapshot.go
@@ -70,6 +70,10 @@ func (sr *SnapshotRepository) Run() error {
 	if err != nil {
 		return err
 	}
+	err = sr.pulpClient.UpdateDomainIfNeeded(sr.domainName)
+	if err != nil {
+		return err
+	}
 	repoConfig, err := sr.lookupRepoObjects()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
previously domains configured with s3 were not configured with an acl that was correct.  This fixes that, but some domains may already be created improperly.  This adds the ability to update s3 storage settings in pulp if they have changed

## Testing steps
A bit hard to truly test.

1.  Create an s3 bucket on an amazon account. (default config is fine)
2.  within IAM in s3, create a user with full s3 permissions (AmazonS3FullAccess policy)
3. create an access key for them
4. on a fresh db, on 'main' branch, configure access to this account:
 ```
  pulp:
    server: http://localhost:8080
    username: admin
    password: password
    storage_type: object #object or local
    custom_repo_objects:
      url: https://s3.us-east-1.amazonaws.com/
      access_key: "MyKey"
      secret_key: "MySecret"
      name: test-pulp
      region: us-east-1
```
5.  try to create and snapshot a repo, this will error
6. switch to this branch, and start the server.
7. create a new repo in the same account. It should snapshot with no issue.