### PR TITLE
Refs 1947: Increase selenium container memory

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -95,7 +95,7 @@ objects:
           resources:
             limits:
               cpu: 500m
-              memory: 1.5Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 256Mi


### PR DESCRIPTION
We are seeing some out of memory errors while capturing the browser logs. I'm hoping that increasing the limit will resolve this.

## Summary

## Testing steps
