### PR TITLE
Fixes 2356: rename s3 bucket

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -284,7 +284,7 @@ objects:
         version: 13
       inMemoryDb: true
       objectStore:
-        - content-sources-s3-custom-repos
+        - content-sources-custom-repos-s3
   - apiVersion: v1
     kind: Service
     metadata:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,7 +82,7 @@ type Pulp struct {
 	CustomRepoObjects *ObjectStore `mapstructure:"custom_repo_objects"`
 }
 
-const CustomRepoClowderBucketName = "content-sources-s3-custom-repos"
+const CustomRepoClowderBucketName = "content-sources-custom-repos-s3"
 
 type ObjectStore struct {
 	URL       string


### PR DESCRIPTION
## Summary
We need to rename the bucket resource we consume, due to previously using an unversioned bucket.

## Testing steps
tests pass