### PR TITLE
Fixes 2239: fix various 500 errors caused by bad params

### DIFF
--- a/pkg/dao/admin_tasks.go
+++ b/pkg/dao/admin_tasks.go
@@ -41,7 +41,7 @@ func (a adminTaskInfoDaoImpl) Fetch(id string) (api.AdminTaskInfoResponse, error
 		if result.Error == gorm.ErrRecordNotFound {
 			return taskInfoResponse, &ce.DaoError{NotFound: true, Message: "Could not find task with UUID " + id}
 		} else {
-			return taskInfoResponse, result.Error
+			return taskInfoResponse, DBErrorToApi(result.Error)
 		}
 	}
 
@@ -100,7 +100,7 @@ func (a adminTaskInfoDaoImpl) List(
 	filteredDB.Select("account_id").Find(&accountIds)
 
 	if filteredDB.Error != nil {
-		return api.AdminTaskInfoCollectionResponse{}, totalTasks, filteredDB.Error
+		return api.AdminTaskInfoCollectionResponse{}, totalTasks, DBErrorToApi(filteredDB.Error)
 	}
 
 	taskResponses := convertAdminTaskInfoToResponses(tasks, accountIds)

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -51,6 +51,9 @@ func DBErrorToApi(e error) *ce.DaoError {
 			}
 			return &ce.DaoError{BadValidation: true, Message: "Repository with this " + dupKeyName + " already belongs to organization"}
 		}
+		if pgError.Code == "22021" {
+			return &ce.DaoError{BadValidation: true, Message: "Request parameters contain invalid syntax"}
+		}
 	}
 	dbError, ok := e.(models.Error)
 	if ok {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -196,7 +196,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest) ([]api.Se
 		Where(orGroupPublicOrPrivate).
 		Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
 		Where(r.db.Where("repositories.url in ?", urls).
-			Or("repository_configurations.uuid in ?", uuids)).
+			Or("text(repository_configurations.uuid) in ?", uuids)).
 		Order("rpms.name ASC").
 		Limit(*request.Limit).
 		Scan(&dataResponse)

--- a/pkg/dao/task_info_test.go
+++ b/pkg/dao/task_info_test.go
@@ -82,9 +82,13 @@ func (suite *TaskInfoSuite) TestFetchNotFound() {
 	assert.True(t, ok)
 	assert.True(t, daoError.NotFound)
 
-	otherUUID := uuid.NewString()
+	_, err = dao.Fetch(task.OrgId, uuid.NewString())
+	assert.NotNil(t, err)
+	daoError, ok = err.(*ce.DaoError)
+	assert.True(t, ok)
+	assert.True(t, daoError.NotFound)
 
-	_, err = dao.Fetch(task.OrgId, otherUUID)
+	_, err = dao.Fetch(task.OrgId, "bad-uuid")
 	assert.NotNil(t, err)
 	daoError, ok = err.(*ce.DaoError)
 	assert.True(t, ok)

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -44,7 +44,7 @@ func (sh *SnapshotHandler) listSnapshots(c echo.Context) error {
 	filterData := ParseFilters(c)
 	snapshots, totalSnaps, err := sh.DaoRegistry.Snapshot.List(uuid, pageData, filterData)
 	if err != nil {
-		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing repositories", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing repository snapshots", err.Error())
 	}
 	return c.JSON(200, setCollectionResponseMetadata(&snapshots, c, totalSnaps))
 }

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -132,7 +132,7 @@ func (s *SnapshotSuite) TestSnapshot() {
 
 	// Verify the snapshot was deleted
 	snaps, _, err = s.dao.Snapshot.List(repo.UUID, api.PaginationData{}, api.FilterData{})
-	assert.NoError(s.T(), err)
+	assert.Error(s.T(), err)
 	assert.Empty(s.T(), snaps.Data)
 	time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
## Summary
There are a few different endpoints where bad params can cause 500 errors. This should fix most if not all of those endpoints.

1. GET `/repositories/{bad-uuid}/snapshots/`
2. GET `/tasks/baduuid`
3. POST `/rpms/names/` with body ` { uuids: ["John Doe"] }`
4. GET `tasks/?offset=10&limit=10&status=%00`

Note number 4 in particular, where the status is %00. That affects other endpoints params too like `/repositories/?status=`  or `/repositories/%00/snapshots`. 

## Testing steps
1. Test the endpoints listed with the params listed. You should get no 500 errors.
2. You can try similar inputs on other similar endpoints to see if anything was missed.