### PR TITLE
Fixes 2018: add task cleanup

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -128,6 +128,15 @@ func enqueueIntrospectAllRepos() error {
 	c := client.NewTaskClient(&q)
 
 	repoDao := dao.GetRepositoryDao(db.DB)
+	err = repoDao.OrphanCleanup()
+	if err != nil {
+		log.Err(err).Msg("error during orphan cleanup")
+	}
+	err = dao.GetTaskInfoDao(db.DB).Cleanup()
+	if err != nil {
+		log.Err(err).Msg("error during task cleanup")
+	}
+
 	repos, err := repoDao.List(true)
 	if err != nil {
 		return fmt.Errorf("error getting repositories: %w", err)
@@ -145,9 +154,6 @@ func enqueueIntrospectAllRepos() error {
 			log.Err(err).Msgf("error enqueueing introspecting for repository %v", repo.URL)
 		}
 	}
-	err = repoDao.OrphanCleanup()
-	if err != nil {
-		log.Err(err).Msg("error during orphan cleanup")
-	}
+
 	return nil
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -94,6 +94,7 @@ type TaskInfoDao interface {
 	Fetch(OrgID string, id string) (api.TaskInfoResponse, error)
 	List(OrgID string, pageData api.PaginationData, filterData api.TaskInfoFilterData) (api.TaskInfoCollectionResponse, int64, error)
 	IsSnapshotInProgress(orgID, repoUUID string) (bool, error)
+	Cleanup() error
 }
 
 type AdminTaskDao interface {

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -1,12 +1,14 @@
 package dao
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 )
 
@@ -94,6 +96,34 @@ func (t taskInfoDaoImpl) List(
 	}
 	taskResponses := convertTaskInfoToResponses(tasks)
 	return api.TaskInfoCollectionResponse{Data: taskResponses}, totalTasks, nil
+}
+
+func (t taskInfoDaoImpl) Cleanup() error {
+	// Delete all completed or failed introspection tasks that are older than 10 days
+	// Delete all finished Repo delete tasks that are older 10 days
+	q := "delete from tasks where " +
+		"(type = '%v' and (status = 'completed' or status = 'failed') and finished_at < (current_date - interval '10' day)) OR" +
+		"(type = '%v' and status = 'completed' and  finished_at < (current_date - interval '10' day))"
+	q = fmt.Sprintf(q, config.IntrospectTask, config.DeleteRepositorySnapshotsTask)
+	result := t.db.Exec(q)
+	if result.Error != nil {
+		return result.Error
+	}
+	log.Logger.Debug().Msgf("Cleaned up %v old tasks", result.RowsAffected)
+
+	// Delete all snapshot tasks that no longer have repo configs (User deleted their repository)
+	orpahnQ := "DELETE FROM tasks WHERE id IN ( " +
+		"SELECT t.id FROM tasks AS t " +
+		"LEFT JOIN repository_configurations AS rc ON t.org_id = rc.org_id and t.repository_uuid = rc.repository_uuid " +
+		"WHERE t.repository_uuid is NOT NULL AND rc.repository_uuid is null AND t.type = '%v')"
+	orpahnQ = fmt.Sprintf(orpahnQ, config.RepositorySnapshotTask)
+
+	result = t.db.Exec(orpahnQ)
+	if result.Error != nil {
+		return result.Error
+	}
+	log.Logger.Debug().Msgf("Cleaned up %v orphan snapshot tasks", result.RowsAffected)
+	return nil
 }
 
 func (t taskInfoDaoImpl) IsSnapshotInProgress(orgID, repoUUID string) (bool, error) {

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -112,13 +112,13 @@ func (t taskInfoDaoImpl) Cleanup() error {
 	log.Logger.Debug().Msgf("Cleaned up %v old tasks", result.RowsAffected)
 
 	// Delete all snapshot tasks that no longer have repo configs (User deleted their repository)
-	orpahnQ := "DELETE FROM tasks WHERE id IN ( " +
+	orphanQ := "DELETE FROM tasks WHERE id IN ( " +
 		"SELECT t.id FROM tasks AS t " +
 		"LEFT JOIN repository_configurations AS rc ON t.org_id = rc.org_id and t.repository_uuid = rc.repository_uuid " +
 		"WHERE t.repository_uuid is NOT NULL AND rc.repository_uuid is null AND t.type = '%v')"
-	orpahnQ = fmt.Sprintf(orpahnQ, config.RepositorySnapshotTask)
+	orphanQ = fmt.Sprintf(orphanQ, config.RepositorySnapshotTask)
 
-	result = t.db.Exec(orpahnQ)
+	result = t.db.Exec(orphanQ)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/pkg/dao/task_info_mock.go
+++ b/pkg/dao/task_info_mock.go
@@ -12,6 +12,20 @@ type MockTaskInfoDao struct {
 	mock.Mock
 }
 
+// Cleanup provides a mock function with given fields:
+func (_m *MockTaskInfoDao) Cleanup() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Fetch provides a mock function with given fields: OrgID, id
 func (_m *MockTaskInfoDao) Fetch(OrgID string, id string) (api.TaskInfoResponse, error) {
 	ret := _m.Called(OrgID, id)

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -170,14 +170,6 @@ func IntrospectAll(ctx context.Context, urls *[]string, force bool) (int64, []er
 			errors = append(errors, err)
 		}
 	}
-	err = dao.Repository.OrphanCleanup()
-	if err != nil {
-		errors = append(errors, err)
-	}
-	err = dao.Repository.OrphanCleanup()
-	if err != nil {
-		errors = append(errors, err)
-	}
 
 	// Logic to handle notifications
 	sendIntrospectionNotifications(introspectSuccessUuids, introspectFailedUuids, dao)


### PR DESCRIPTION
## Summary
according to the following rules:
* repo delete tasks that are older than 10 days and not failed
* introspect tasks that are older than 10 days
* snapshot tasks where the repository config has been deleted

Previously orphan cleanup was also being run multiple times, this reduces it to just once per nightly job (before starting the introspection jobs)

## Testing steps

On a freshly cleaned db, use this main script:   https://gist.github.com/jlsherrill/efe0bd375a46f32ed3a562e130bb8371
to create some tasks.

This creates similar tasks to the unit test i wrote. 
You can then use 'make db-cli-connect' to look at the tasks.

run: ```go run cmd/external-repos/main.go  nightly-jobs```  to cleanup the tasks.


## QE testing steps
QE can only really easily test the 3rd of the rules above. 
* Create a repository with snapshotting enabled.  
* Wait for it to finish snapshotting.  
* Fetch its snapshot tasks via the tasks api. 
*  Delete the repository. 
* wait ~8 hours
* try to fetch the task again, should be a 404