### PR TITLE
Fixes 2419: ignore rbac check for org admins

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -211,6 +211,8 @@ objects:
                     name: cs-pulp-admin-password
                     key: password
                     optional: true
+              - name: RBAC_ORG_ADMIN_SKIP
+                value: ${{RBAC_ORG_ADMIN_SKIP}}
               - name: LOGGING_LEVEL
                 value: ${{LOGGING_LEVEL}}
               - name: CLIENTS_RBAC_BASE_URL
@@ -397,3 +399,6 @@ parameters:
     description: Whether the Admin Tasks feature should be turned on
   - name: FEATURES_ADMIN_TASKS_ACCOUNTS
     description: Comma separated list of account number that can access the feature
+  - name: RBAC_ORG_ADMIN_SKIP
+    description: skip rbac check if the user is an org admin
+    default: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	NotificationsClient cloudevents.Client `mapstructure:"notification_client"`
 	Tasking             Tasking            `mapstructure:"tasking"`
 	Features            FeatureSet         `mapstructure:"features"`
+	RbacOrgAdminSkip    bool               `mapstructure:"rbac_org_admin_skip"`
 }
 
 type Clients struct {
@@ -196,6 +197,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("Loaded", true)
 	// In viper you have to set defaults, otherwise loading from ENV doesn't work
 	//   without a config file present
+	v.SetDefault("rbac_org_admin_skip", false)
 	v.SetDefault("database.host", "")
 	v.SetDefault("database.port", "")
 	v.SetDefault("database.user", "")

--- a/pkg/rbac/client_wrapper_test.go
+++ b/pkg/rbac/client_wrapper_test.go
@@ -32,7 +32,7 @@ func (s *RbacTestSuite) SetupTest() {
 	s.echo.Add(echo.GET, mocks_rbac.RbacV1Access, mocks_rbac.MockRbac)
 	go func() {
 		err := s.echo.Start(":9932")
-		assert.True(s.T(), err == http.ErrServerClosed)
+		assert.True(s.T(), err == http.ErrServerClosed, "Unexpected error %v", err)
 	}()
 	s.mockCache = cache.NewMockRbacCache(s.T())
 	// Configure the client to use the mock rbac service


### PR DESCRIPTION
## Summary
if rbac_org_admin_skip is set to true, then don't check rbac if a user identity header tells us the user is an org_admin


## Testing steps
1.  turn on rbac_enabled in config.yaml
2. run the app with skip turned on and the mock rbac service
```
RBAC_ORG_ADMIN_SKIP=true go run cmd/content-sources/main.go api mock_rbac
```
3. use this header script to generate org_admin headers:  https://gist.github.com/jlsherrill/880bb18c288be3916c8cda94db0efacd

4.  List/create repos via the api.  Any request generated with the new script should work.  Using the older script, only those users listed in 'mocks' -> 'rbac' section of config.yaml would be allowed, all others would be rejected