### PR TITLE
Fixes 2543: use a null uuid for bad uuids

### DIFF
--- a/pkg/dao/admin_tasks.go
+++ b/pkg/dao/admin_tasks.go
@@ -30,7 +30,8 @@ func GetAdminTaskDao(db *gorm.DB, pulpClient pulp_client.PulpClient) AdminTaskDa
 
 func (a adminTaskInfoDaoImpl) Fetch(id string) (api.AdminTaskInfoResponse, error) {
 	taskInfo := models.TaskInfo{}
-	query := a.db.Where("text(id) = ?", id).Joins("LEFT JOIN repository_configurations ON (tasks.repository_uuid = repository_configurations.repository_uuid AND tasks.org_id = repository_configurations.org_id)")
+	query := a.db.Where("id = ?", UuidifyString(id)).
+		Joins("LEFT JOIN repository_configurations ON (tasks.repository_uuid = repository_configurations.repository_uuid AND tasks.org_id = repository_configurations.org_id)")
 	result := query.First(&taskInfo)
 	var account_id sql.NullString
 	query.Select("account_id").First(&account_id)

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -1,6 +1,26 @@
 package dao
 
-import "strings"
+import (
+	"strings"
+
+	uuid2 "github.com/google/uuid"
+)
+
+func UuidifyString(possibleUuid string) uuid2.UUID {
+	uuid, err := uuid2.Parse(possibleUuid)
+	if err != nil {
+		return uuid2.Nil
+	}
+	return uuid
+}
+
+func UuidifyStrings(possibleUuids []string) []uuid2.UUID {
+	var uuids []uuid2.UUID
+	for _, possibleUuid := range possibleUuids {
+		uuids = append(uuids, UuidifyString(possibleUuid))
+	}
+	return uuids
+}
 
 func convertSortByToSQL(SortBy string, SortMap map[string]string, defaultSortBy string) string {
 	sqlOrderBy := ""

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -265,7 +265,7 @@ func (r repositoryConfigDaoImpl) List(
 
 func (r repositoryConfigDaoImpl) InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse {
 	repoConfigs := make([]models.RepositoryConfiguration, 0)
-	filteredDB := r.db.Where("text(repositories.uuid) = ?", uuid).
+	filteredDB := r.db.Where("repositories.uuid = ?", UuidifyString(uuid)).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
 
 	filteredDB.Preload("Repository").Preload("LastSnapshot").Find(&repoConfigs)
@@ -293,7 +293,7 @@ func (r repositoryConfigDaoImpl) fetchRepoConfig(orgID string, uuid string) (mod
 	found := models.RepositoryConfiguration{}
 	result := r.db.
 		Preload("Repository").Preload("LastSnapshot").
-		Where("text(UUID) = ? AND ORG_ID = ?", uuid, orgID).
+		Where("UUID = ? AND ORG_ID = ?", UuidifyString(uuid), orgID).
 		First(&found)
 
 	if result.Error != nil {
@@ -313,7 +313,7 @@ func (r repositoryConfigDaoImpl) FetchByRepoUuid(orgID string, repoUuid string) 
 	result := r.db.
 		Preload("Repository").Preload("LastSnapshot").
 		Joins("Inner join repositories on repositories.uuid = repository_configurations.repository_uuid").
-		Where("text(Repositories.UUID) = ? AND ORG_ID = ?", repoUuid, orgID).
+		Where("Repositories.UUID = ? AND ORG_ID = ?", UuidifyString(repoUuid), orgID).
 		First(&repoConfig)
 
 	if result.Error != nil {
@@ -645,7 +645,7 @@ func (r repositoryConfigDaoImpl) validateName(orgId string, name string, respons
 	found := models.RepositoryConfiguration{}
 	query := r.db.Where("name = ? AND ORG_ID = ?", name, orgId)
 	if len(excludedUUIDS) != 0 {
-		query = query.Where("text(repository_configurations.uuid) NOT IN ?", excludedUUIDS)
+		query = query.Where("repository_configurations.uuid NOT IN ?", UuidifyStrings(excludedUUIDS))
 	}
 	if err := query.Find(&found).Error; err != nil {
 		response.Valid = false
@@ -675,7 +675,7 @@ func (r repositoryConfigDaoImpl) validateUrl(orgId string, url string, response 
 		Where("Repositories.URL = ? AND ORG_ID = ?", url, orgId)
 
 	if len(excludedUUIDS) != 0 {
-		query = query.Where("text(repository_configurations.uuid) NOT IN ?", excludedUUIDS)
+		query = query.Where("repository_configurations.uuid NOT IN ?", UuidifyStrings(excludedUUIDS))
 	}
 
 	if err := query.Find(&found).Error; err != nil {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -28,7 +28,7 @@ func (r rpmDaoImpl) isOwnedRepository(orgID string, repositoryConfigUUID string)
 	var repoConfigs []models.RepositoryConfiguration
 	var count int64
 	if err := r.db.
-		Where("org_id = ? and text(uuid) = ?", orgID, repositoryConfigUUID).
+		Where("org_id = ? and uuid = ?", orgID, UuidifyString(repositoryConfigUUID)).
 		Find(&repoConfigs).
 		Count(&count).
 		Error; err != nil {
@@ -196,7 +196,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.SearchRpmRequest) ([]api.Se
 		Where(orGroupPublicOrPrivate).
 		Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
 		Where(r.db.Where("repositories.url in ?", urls).
-			Or("text(repository_configurations.uuid) in ?", uuids)).
+			Or("repository_configurations.uuid in ?", UuidifyStrings(uuids))).
 		Order("rpms.name ASC").
 		Limit(*request.Limit).
 		Scan(&dataResponse)

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -44,7 +44,7 @@ func (sDao snapshotDaoImpl) List(repoConfigUuid string, paginationData api.Pagin
 	var repoConfig models.RepositoryConfiguration
 
 	// First check if repo config exists
-	result := sDao.db.Where("text(uuid) = ?", repoConfigUuid).First(&repoConfig)
+	result := sDao.db.Where("uuid = ?", UuidifyString(repoConfigUuid)).First(&repoConfig)
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			return api.SnapshotCollectionResponse{}, totalSnaps, &ce.DaoError{
@@ -61,7 +61,7 @@ func (sDao snapshotDaoImpl) List(repoConfigUuid string, paginationData api.Pagin
 	order := convertSortByToSQL(paginationData.SortBy, sortMap, "created_at asc")
 
 	filteredDB := sDao.db.
-		Where("text(snapshots.repository_configuration_uuid) = ?", repoConfigUuid)
+		Where("snapshots.repository_configuration_uuid = ?", UuidifyString(repoConfigUuid))
 
 	// Get count
 	filteredDB.

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -42,9 +42,8 @@ func (t taskInfoDaoImpl) Fetch(orgID string, id string) (api.TaskInfoResponse, e
 
 	result := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
-		Joins("LEFT JOIN repositories r on t.repository_uuid = r.uuid").
-		Joins("LEFT JOIN repository_configurations rc on r.uuid = rc.repository_uuid").
-		Where("text(t.id) = ? AND t.org_id = ?", id, orgID).First(&taskInfo)
+		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid").
+		Where("t.id = ? AND t.org_id = ?", UuidifyString(id), orgID).First(&taskInfo)
 
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
@@ -69,8 +68,7 @@ func (t taskInfoDaoImpl) List(
 
 	filteredDB := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
-		Joins("LEFT JOIN repositories r on t.repository_uuid = r.uuid").
-		Joins("LEFT JOIN repository_configurations rc on r.uuid = rc.repository_uuid").
+		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid").
 		Where("t.org_id = ?", orgID)
 
 	if filterData.Status != "" {


### PR DESCRIPTION
## Summary

instead of converting to text in queries, as
that has a performance penalty

## Testing steps

Tests pass

Here's the explain plan comparing two queries, the one with text(uuid) has a MUCH higher 'cost':
```
content=# explain SELECT * FROM repository_configurations WHERE (text(UUID) = '59a54071-06fb-45b6-b721-09bd0fb767cf' AND ORG_ID = '16791776') AND repository_configurations.deleted_at IS NULL ORDER BY repository_configurations.uuid LIMIT 1
;
                                                        QUERY PLAN                                                         
---------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=3529.23..3529.23 rows=1 width=172)
   ->  Sort  (cost=3529.23..3529.23 rows=1 width=172)
         Sort Key: uuid
         ->  Bitmap Heap Scan on repository_configurations  (cost=3197.68..3529.22 rows=1 width=172)
               Recheck Cond: (((org_id)::text = '16791776'::text) AND (deleted_at IS NULL))
               Filter: ((uuid)::text = '59a54071-06fb-45b6-b721-09bd0fb767cf'::text)
               ->  Bitmap Index Scan on repo_config_repo_org_id_deleted_null_unique  (cost=0.00..3197.68 rows=100 width=0)
                     Index Cond: ((org_id)::text = '16791776'::text)
(8 rows)
content=# explain SELECT * FROM repository_configurations WHERE (UUID = '59a54071-06fb-45b6-b721-09bd0fb767cf' AND ORG_ID = '16791776') AND repository_configurations.deleted_at IS NULL ORDER BY repository_configurations.uuid LIMIT 1
;
                                                       QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.42..8.44 rows=1 width=172)
   ->  Index Scan using repository_configurations_pkey on repository_configurations  (cost=0.42..8.44 rows=1 width=172)
         Index Cond: (uuid = '59a54071-06fb-45b6-b721-09bd0fb767cf'::uuid)
         Filter: ((deleted_at IS NULL) AND ((org_id)::text = '16791776'::text))
(4 rows)
```