### PR TITLE
Add IQE_ENV=ephemeral

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -11,6 +11,7 @@ DOCKERFILE="build/Dockerfile"
 IQE_PLUGINS="content-sources"  # name of the IQE plugin for this app.
 IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
 IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+IQE_ENV="ephemeral"
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
 
@@ -25,7 +26,7 @@ source $CICD_ROOT/build.sh
 
 # This script is used to deploy the ephemeral environment for smoke tests.
 # The manual steps for this can be found in:
-# https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
+# https://consoledot.pages.redhat.com/docs/dev/operating-your-app/testing-iqe/testing.html#_deploy_ephemeral_env_sh_deploys_the_test_environment
 source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # Run smoke tests using a ClowdJobInvocation and iqe-tests


### PR DESCRIPTION
  and fix doc link

## Summary

One test[1] is failing[2] because it is not supported in ephemeral env, so I want to add this env variable.

## Testing steps

pr checks pass[3]

[1] https://gitlab.cee.redhat.com/insights-qe/iqe-content-sources-plugin/-/blob/master/iqe_content_sources/tests/test_repository_api_only.py#L613

[2] https://ci.int.devshift.net/job/content-sources-backend-pr-check-main/359/testReport/junit/tests/test_repository_api_only/test_introspection_of_persistent_user/

[3] https://ci.int.devshift.net/job/content-sources-backend-pr-check-main/
