### PR TITLE
Refs 1963: Bump mem request to 200Mi

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -358,7 +358,7 @@ parameters:
   - name: MEMORY_LIMIT
     value: 1Gi
   - name: MEMORY_REQUESTS
-    value: 100Mi
+    value: 200Mi
   - name: LOGGING_LEVEL
     value: debug
   - name: CLIENTS_RBAC_BASE_URL
@@ -404,4 +404,3 @@ parameters:
   - name: RBAC_ORG_ADMIN_SKIP
     description: skip rbac check if the user is an org admin
     default: 'false'
-


### PR DESCRIPTION
## Summary

The kafka consumer init container is crashing while trying to introspect repos (On startup, all repos in the database are introspected.). This problem only occurs in ephemeral env.

As per @jrusz 's suggestion, this issue could be due to memory taking to long to be increased, so bumping the request size to see if that helps to get the memory increased before the pod crashes. 

## Testing steps

Check for content-sources-backend-kafka-consumer restarting multiple times.
