### PR TITLE
Fixes 2490: make migrations idempotent

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -120,5 +120,17 @@ jobs:
           CLIENTS_PULP_SERVER: http://localhost:8080
           CLIENTS_PULP_USERNAME: admin
           CLIENTS_PULP_PASSWORD: password
+      - name: db migration tests
+        run: |
+          make test-db-migrations
+        env:
+          DATABASE_HOST: localhost
+          DATABASE_PORT: 5433
+          DATABASE_USER: postgres
+          DATABASE_NAME: postgres
+          DATABASE_PASSWORD: postgres
+          CLIENTS_PULP_SERVER: http://localhost:8080
+          CLIENTS_PULP_USERNAME: admin
+          CLIENTS_PULP_PASSWORD: password
 
 

--- a/db/migrations/20220512132042_create_repository_configurations_table.up.sql
+++ b/db/migrations/20220512132042_create_repository_configurations_table.up.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS repositories (
 );
 
 ALTER TABLE repositories
+DROP CONSTRAINT IF EXISTS repositories_unique_url,
 ADD CONSTRAINT repositories_unique_url UNIQUE (url);
 
 --
@@ -38,15 +39,18 @@ CREATE TABLE IF NOT EXISTS repository_configurations(
 );
 
 ALTER TABLE repository_configurations
+DROP CONSTRAINT IF EXISTS repo_and_org_id_unique,
 ADD CONSTRAINT repo_and_org_id_unique UNIQUE (repository_uuid, org_id);
 
 ALTER TABLE repository_configurations
+DROP CONSTRAINT IF EXISTS fk_repository,
 ADD CONSTRAINT fk_repository
 FOREIGN KEY (repository_uuid)
 REFERENCES repositories(uuid)
 ON DELETE SET NULL;
 
 ALTER TABLE repository_configurations
+DROP CONSTRAINT IF EXISTS name_and_org_id_unique,
 ADD CONSTRAINT name_and_org_id_unique UNIQUE (name, org_id);
 
 --
@@ -68,6 +72,7 @@ CREATE TABLE IF NOT EXISTS rpms (
 );
 
 ALTER TABLE IF EXISTS rpms
+DROP CONSTRAINT IF EXISTS rpms_checksum_unique,
 ADD CONSTRAINT rpms_checksum_unique UNIQUE (checksum);
 
 CREATE INDEX IF NOT EXISTS index_rpms_name ON rpms(name);
@@ -75,20 +80,23 @@ CREATE INDEX IF NOT EXISTS index_rpms_name ON rpms(name);
 --
 -- repositories_rpms
 --
-CREATE TABLE repositories_rpms (
+CREATE TABLE IF NOT EXISTS repositories_rpms (
     repository_uuid UUID NOT NULL,
     rpm_uuid UUID NOT NULL
 );
 
 ALTER TABLE ONLY repositories_rpms
+DROP CONSTRAINT IF EXISTS repositories_rpms_pkey,
 ADD CONSTRAINT repositories_rpms_pkey PRIMARY KEY (repository_uuid, rpm_uuid);
 
 ALTER TABLE ONLY repositories_rpms
+DROP CONSTRAINT IF EXISTS fk_repositories_rpms_rpm,
 ADD CONSTRAINT fk_repositories_rpms_rpm
 FOREIGN KEY (rpm_uuid) REFERENCES rpms(uuid)
 ON DELETE CASCADE;
 
 ALTER TABLE ONLY repositories_rpms
+DROP CONSTRAINT IF EXISTS fk_repositories_rpms_repository,
 ADD CONSTRAINT fk_repositories_rpms_repository
 FOREIGN KEY (repository_uuid) REFERENCES repositories(uuid)
 ON DELETE CASCADE;

--- a/db/migrations/20220923124812_add_package_count.down.sql
+++ b/db/migrations/20220923124812_add_package_count.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repositories drop column package_count;
+alter table repositories drop column if exists package_count;
 
 COMMIT;

--- a/db/migrations/20220923124812_add_package_count.up.sql
+++ b/db/migrations/20220923124812_add_package_count.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repositories add column package_count int default 0;
+alter table repositories add column if not exists package_count int default 0;
 
 COMMIT;

--- a/db/migrations/20221130134116_move_revision_to_checksum.down.sql
+++ b/db/migrations/20221130134116_move_revision_to_checksum.down.sql
@@ -1,3 +1,3 @@
 BEGIN;
-alter table repositories drop column repomd_checksum;
+alter table repositories drop column if exists repomd_checksum;
 COMMIT;

--- a/db/migrations/20221130134116_move_revision_to_checksum.up.sql
+++ b/db/migrations/20221130134116_move_revision_to_checksum.up.sql
@@ -1,3 +1,3 @@
 BEGIN;
-alter table repositories add column repomd_checksum varchar not null default '';
+alter table repositories add column if not exists repomd_checksum varchar not null default '';
 COMMIT;

--- a/db/migrations/20221212134912_remove_revision.down.sql
+++ b/db/migrations/20221212134912_remove_revision.down.sql
@@ -1,3 +1,3 @@
 BEGIN;
-alter table repositories add column revision varchar(255);
+alter table repositories add column if not exists revision varchar(255);
 COMMIT;

--- a/db/migrations/20221212134912_remove_revision.up.sql
+++ b/db/migrations/20221212134912_remove_revision.up.sql
@@ -1,3 +1,3 @@
 BEGIN;
-alter table repositories drop column revision;
+alter table repositories drop column if exists revision;
 COMMIT;

--- a/db/migrations/20230322110439_add_failed_introspection_count_to_repositories.down.sql
+++ b/db/migrations/20230322110439_add_failed_introspection_count_to_repositories.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repositories drop column failed_introspections_count;
+alter table repositories drop column if exists failed_introspections_count;
 
 COMMIT;

--- a/db/migrations/20230322110439_add_failed_introspection_count_to_repositories.up.sql
+++ b/db/migrations/20230322110439_add_failed_introspection_count_to_repositories.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repositories add column failed_introspections_count int default 0 not null;
+alter table repositories add column if not exists failed_introspections_count int default 0 not null;
 
 COMMIT;

--- a/db/migrations/20230330144631_snapshotting_custom.down.sql
+++ b/db/migrations/20230330144631_snapshotting_custom.down.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+ALTER TABLE snapshots DROP CONSTRAINT IF EXISTS fk_repository;
+
 DROP TABLE snapshots;
 
 COMMIT;

--- a/db/migrations/20230330144631_snapshotting_custom.up.sql
+++ b/db/migrations/20230330144631_snapshotting_custom.up.sql
@@ -16,9 +16,17 @@ CREATE TABLE IF NOT EXISTS snapshots (
     org_id varchar NOT NULL
 );
 
+-- adding these columns here is only to support rerunning migration after db has been migrated
+-- they are removed in a later migration
+ALTER TABLE snapshots
+ADD COLUMN IF NOT EXISTS org_id varchar,
+ADD COLUMN IF NOT EXISTS repository_uuid UUID;
+
+
 CREATE INDEX IF NOT EXISTS snapshots_org_id_repo_uuid ON snapshots(org_id, repository_uuid);
 
 ALTER TABLE snapshots
+    DROP CONSTRAINT IF EXISTS fk_repository,
     ADD CONSTRAINT fk_repository
         FOREIGN KEY (repository_uuid)
             REFERENCES repositories(uuid);

--- a/db/migrations/20230410105610_add_jobqueue.down.sql
+++ b/db/migrations/20230410105610_add_jobqueue.down.sql
@@ -1,7 +1,14 @@
 BEGIN;
 
+ALTER TABLE task_dependencies
+DROP CONSTRAINT task_dependencies_dependency_id_fkey,
+DROP CONSTRAINT task_dependencies_task_id_fkey;
+
+ALTER TABLE task_heartbeats
+DROP CONSTRAINT task_heartbeats_id_fkey;
+
 DROP VIEW IF EXISTS ready_tasks;
 
-DROP TABLE IF EXISTS tasks, task_dependencies, heartbeats;
+DROP TABLE IF EXISTS tasks, task_dependencies, task_heartbeats;
 
 COMMIT;

--- a/db/migrations/20230410105610_add_jobqueue.up.sql
+++ b/db/migrations/20230410105610_add_jobqueue.up.sql
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS task_heartbeats(
                                CHECK (token != uuid_nil())
     );
 
-CREATE VIEW ready_tasks AS
+CREATE OR REPLACE VIEW ready_tasks AS
 SELECT *
 FROM tasks
 WHERE started_at IS NULL
@@ -59,9 +59,9 @@ ORDER BY queued_at ASC;
 
 ALTER TABLE task_dependencies
 
-DROP CONSTRAINT task_dependencies_dependency_id_fkey,
+DROP CONSTRAINT IF EXISTS task_dependencies_dependency_id_fkey,
 
-DROP CONSTRAINT task_dependencies_task_id_fkey,
+DROP CONSTRAINT IF EXISTS task_dependencies_task_id_fkey,
 
 ADD CONSTRAINT task_dependencies_dependency_id_fkey
 FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
@@ -71,7 +71,7 @@ FOREIGN KEY (dependency_id) REFERENCES tasks(id) ON DELETE CASCADE;
 
 ALTER TABLE task_heartbeats
 
-DROP CONSTRAINT task_heartbeats_id_fkey,
+DROP CONSTRAINT IF EXISTS task_heartbeats_id_fkey,
 
 ADD CONSTRAINT task_heartbeats_id_fkey
 FOREIGN KEY (id) REFERENCES tasks(id) ON DELETE CASCADE;

--- a/db/migrations/20230706145024_add_request_id_to_tasks.down.sql
+++ b/db/migrations/20230706145024_add_request_id_to_tasks.down.sql
@@ -1,5 +1,20 @@
 BEGIN;
 
-alter table tasks drop column request_id;
+-- dropping and recreating view to support down migration
+drop view if exists ready_tasks;
+
+alter table tasks drop column if exists request_id;
+
+CREATE OR REPLACE VIEW ready_tasks AS
+SELECT *
+FROM tasks
+WHERE started_at IS NULL
+  AND (status != 'canceled' OR status is null)
+  AND id NOT IN (
+    SELECT task_id
+    FROM task_dependencies JOIN tasks ON dependency_id = id
+    WHERE finished_at IS NULL
+)
+ORDER BY queued_at ASC;
 
 COMMIT;

--- a/db/migrations/20230706145024_add_request_id_to_tasks.up.sql
+++ b/db/migrations/20230706145024_add_request_id_to_tasks.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table tasks add column request_id varchar;
+alter table tasks add column if not exists request_id varchar;
 
 COMMIT;

--- a/db/migrations/20230707065625_add_repository_path.down.sql
+++ b/db/migrations/20230707065625_add_repository_path.down.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
 DROP INDEX snapshots_distribution_path_idx;
-ALTER TABLE snapshots DROP COLUMN repository_path;
+ALTER TABLE snapshots DROP COLUMN if exists repository_path;
 
 COMMIT;

--- a/db/migrations/20230707065625_add_repository_path.up.sql
+++ b/db/migrations/20230707065625_add_repository_path.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-alter table snapshots add column repository_path varchar default '' not null;
+alter table snapshots add column if not exists repository_path varchar default '' not null;
 
 CREATE UNIQUE INDEX IF NOT EXISTS snapshots_distribution_path_idx ON snapshots(distribution_path);
 

--- a/db/migrations/20230804092757_add_domains.up.sql
+++ b/db/migrations/20230804092757_add_domains.up.sql
@@ -7,9 +7,11 @@ CREATE TABLE IF NOT EXISTS domains (
 
 
 ALTER TABLE domains
+DROP CONSTRAINT IF EXISTS domains_org_id_unique,
 ADD CONSTRAINT domains_org_id_unique UNIQUE (org_id);
 
 ALTER TABLE domains
+DROP CONSTRAINT IF EXISTS domains_name_unique,
 ADD CONSTRAINT domains_name_unique UNIQUE (domain_name);
 
 COMMIT;

--- a/db/migrations/20230807161216_refactor_snapshots.up.sql
+++ b/db/migrations/20230807161216_refactor_snapshots.up.sql
@@ -2,8 +2,9 @@ BEGIN;
 
 -- we intentionally do not have a foreign key here, so that the deletion workflow 
 --  can remove a repo_config while the snapshot deletion happens in the background
-alter table snapshots add column repository_configuration_uuid UUID;
+alter table snapshots add column if not exists repository_configuration_uuid UUID;
 ALTER TABLE snapshots
+    DROP CONSTRAINT IF EXISTS fk_snapshots_repo_config_uuid,
     ADD CONSTRAINT fk_snapshots_repo_config_uuid
         FOREIGN KEY (repository_configuration_uuid)
             REFERENCES repository_configurations(uuid)
@@ -22,19 +23,19 @@ CREATE INDEX IF NOT EXISTS snapshots_repo_config_uuid ON snapshots(repository_co
 alter table snapshots drop column repository_uuid;
 alter table snapshots drop column org_id;
 
-alter table repository_configurations add column deleted_at TIMESTAMP WITH TIME ZONE;
+alter table repository_configurations add column if not exists deleted_at TIMESTAMP WITH TIME ZONE;
 
 
 ALTER TABLE repository_configurations
     DROP CONSTRAINT name_and_org_id_unique;
 
-CREATE UNIQUE INDEX repo_config_name_deleted_org_id_unique
+CREATE UNIQUE INDEX IF NOT EXISTS repo_config_name_deleted_org_id_unique
     ON repository_configurations(name, org_id)
     WHERE deleted_at IS NULL;
 
 ALTER TABLE repository_configurations
     DROP CONSTRAINT repo_and_org_id_unique;
-CREATE UNIQUE INDEX repo_config_repo_org_id_deleted_null_unique
+CREATE UNIQUE INDEX IF NOT EXISTS repo_config_repo_org_id_deleted_null_unique
     ON repository_configurations(repository_uuid, org_id)
     WHERE deleted_at IS NULL;
 

--- a/db/migrations/20230814125610_add_snapshot_added_removed.down.sql
+++ b/db/migrations/20230814125610_add_snapshot_added_removed.down.sql
@@ -1,7 +1,8 @@
 BEGIN;
 
-alter table snapshots drop column added_counts;
-alter table snapshots drop column removed_counts;
-alter table repository_configurations drop column latest_snapshot_uuid;
+alter table snapshots drop column if exists added_counts;
+alter table snapshots drop column if exists removed_counts;
+alter table repository_configurations drop constraint if exists fk_last_snapshot;
+alter table repository_configurations drop column if exists latest_snapshot_uuid;
 
 COMMIT;

--- a/db/migrations/20230814125610_add_snapshot_added_removed.up.sql
+++ b/db/migrations/20230814125610_add_snapshot_added_removed.up.sql
@@ -1,10 +1,11 @@
 BEGIN;
 
-alter table snapshots add column added_counts jsonb NOT NULL  DEFAULT '{}'::jsonb;
-alter table snapshots add column removed_counts jsonb NOT NULL  DEFAULT '{}'::jsonb;
+alter table snapshots add column if not exists added_counts jsonb NOT NULL  DEFAULT '{}'::jsonb;
+alter table snapshots add column if not exists removed_counts jsonb NOT NULL  DEFAULT '{}'::jsonb;
 
-alter table repository_configurations add column last_snapshot_uuid UUID DEFAULT NULL;
+alter table repository_configurations add column if not exists last_snapshot_uuid UUID DEFAULT NULL;
 ALTER TABLE repository_configurations
+    DROP CONSTRAINT IF EXISTS fk_last_snapshot,
     ADD CONSTRAINT fk_last_snapshot
         FOREIGN KEY (last_snapshot_uuid)
             REFERENCES snapshots(uuid)

--- a/db/migrations/20230823115016_add_last_snapshot_task.down.sql
+++ b/db/migrations/20230823115016_add_last_snapshot_task.down.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repository_configurations drop column last_snapshot_task_uuid;
+alter table repository_configurations drop column if exists last_snapshot_task_uuid;
 
 COMMIT;

--- a/db/migrations/20230823115016_add_last_snapshot_task.up.sql
+++ b/db/migrations/20230823115016_add_last_snapshot_task.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-alter table repository_configurations add column last_snapshot_task_uuid UUID DEFAULT NULL;
+alter table repository_configurations add column if not exists last_snapshot_task_uuid UUID DEFAULT NULL;
 
 COMMIT;

--- a/db/migrations/20230831162419_add_repo_fields.down.sql
+++ b/db/migrations/20230831162419_add_repo_fields.down.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+alter table snapshots drop constraint if exists fk_repository;
 alter table repositories drop column if exists origin;
 alter table repositories drop column if exists content_type;
 

--- a/db/migrations/20230831162419_add_repo_fields.up.sql
+++ b/db/migrations/20230831162419_add_repo_fields.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-ALTER TABLE repositories ADD COLUMN  IF NOT EXISTS origin varchar default 'external' not null;
-ALTER TABLE repositories ADD COLUMN  IF NOT EXISTS content_type varchar default 'rpm' not null;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS origin varchar default 'external' not null;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS content_type varchar default 'rpm' not null;
 
 COMMIT;


### PR DESCRIPTION
## Summary
Makes it so migrations be be re-run on an already migrated database. Also fixed a few down migrations that were not working. Adds a CI test for migrations.

## Testing steps
1. Migrate up
2. Migrate down
3. Migrate up
4. Drop the `schema_migrations` table
5. Migrate up again