### PR TITLE
Fixes 2717: add config to turn off notifs

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -56,7 +56,7 @@ certs:
 options:
   paged_rpm_inserts_limit: 100
   introspect_api_time_limit_sec: 0
-
+  enable_notifications: true
 # metrics:
 #   path: "/metrics"
 #   port: 9000

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -116,6 +116,8 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -231,6 +233,8 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -300,6 +304,8 @@ objects:
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
       database:
         name: content-sources
         version: 13
@@ -412,4 +418,7 @@ parameters:
     default: 'false'
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
     description: Option to make testing nightly snapshotting & introspection easier
+    default: 'false'
+  - name: OPTIONS_ENABLE_NOTIFICATIONS
+    description: Send notifications via kafka
     default: 'false'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,7 +149,8 @@ type Options struct {
 	PagedRpmInsertsLimit      int `mapstructure:"paged_rpm_inserts_limit"`
 	IntrospectApiTimeLimitSec int `mapstructure:"introspect_api_time_limit_sec"`
 	// If true, introspection and snapshotting always runs for nightly job invocation, regardless of how soon they happened previously.  Used for testing.
-	AlwaysRunCronTasks bool `mapstructure:"always_run_cron_tasks"`
+	AlwaysRunCronTasks  bool `mapstructure:"always_run_cron_tasks"`
+	EnableNotifications bool `mapstructure:"enable_notifications"`
 }
 
 type Metrics struct {
@@ -211,6 +212,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("options.paged_rpm_inserts_limit", DefaultPagedRpmInsertsLimit)
 	v.SetDefault("options.introspect_api_time_limit_sec", DefaultIntrospectApiTimeLimitSec)
 	v.SetDefault("options.always_run_cron_tasks", false)
+	v.SetDefault("options.enable_notifications", false)
 	v.SetDefault("logging.level", "info")
 	v.SetDefault("logging.console", true)
 	v.SetDefault("metrics.path", "/metrics")
@@ -470,6 +472,10 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 }
 
 func SetupNotifications() {
+	if !LoadedConfig.Options.EnableNotifications {
+		return
+	}
+
 	if len(LoadedConfig.Kafka.Bootstrap.Servers) == 0 {
 		log.Warn().Msg("SetupNotifications: clowder.KafkaServers and configured broker was empty")
 	}

--- a/pkg/notifications/client.go
+++ b/pkg/notifications/client.go
@@ -42,7 +42,7 @@ func SendNotification(orgID string, eventName EventName, repos []repositories.Re
 			return
 		}
 		ctx.Done()
-	} else {
+	} else if config.Get().Options.EnableNotifications {
 		log.Warn().Msgf("config.Get().NotificationsClient is null")
 	}
 }


### PR DESCRIPTION
## Summary
so we can disable it in prod

## Testing steps

in one terminal: 
```
make kafka-topic-consume KAFKA_TOPIC=platform.notifications.ingress
```
in another:
``` go run cmd/content-sources/main.go api consumer ```

Then create a repo for introspection:
```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/" \
    -H "Content-Type: application/json" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiIxIn0sImFjY291bnRfbnVtYmVyIjoiMSIsImludGVybmFsIjp7Im9yZ19pZCI6IjEifX19Cg==" \
    -H "x-Rh-Insights-Request-Id: 9876" \
    -d "{
          \"name\": \"pulp3.16-8\",
          \"url\": \"http://yum.theforeman.org/pulpcore/3.16/el8/x86_64/\",
          \"snapshot\": false
        }"
```

You should see no messages comes through.   Finally, turn it on:

``` OPTIONS_ENABLE_NOTIFICATIONS=true  go run cmd/content-sources/main.go api consumer ```

create and introspect a new repo, now see messages