### PR TITLE
Refs 1581: cancel task with cause

### DIFF
--- a/pkg/tasks/introspect.go
+++ b/pkg/tasks/introspect.go
@@ -41,7 +41,7 @@ func IntrospectHandler(ctx context.Context, task *models.TaskInfo, q *queue.Queu
 
 	select {
 	case <-ctx.Done():
-		return queue.ErrCanceled
+		return queue.ErrTaskCanceled
 	default:
 		return nil
 	}

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -714,6 +714,7 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 	logger := zerolog.Ctx(ctx)
 	conn, err := p.Pool.Acquire(ctx)
 	if err != nil {
+		// If the task is finished before listen is initiated, a context canceled error is expected
 		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
 			logger.Error().Err(err).Msg("ListenForCancel: error acquiring connection")
 		}

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -710,11 +710,13 @@ func (p *PgQueue) RemoveAllTasks() error {
 	return nil
 }
 
-func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelFunc) {
+func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelCauseFunc) {
 	logger := zerolog.Ctx(ctx)
 	conn, err := p.Pool.Acquire(ctx)
 	if err != nil {
-		logger.Error().Err(err).Msg("ListenForCancel: error acquiring connection")
+		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
+			logger.Error().Err(err).Msg("ListenForCancel: error acquiring connection")
+		}
 		return
 	}
 	defer conn.Release()
@@ -723,7 +725,9 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 	channelName := getCancelChannelName(taskID)
 	_, err = conn.Conn().Exec(ctx, "listen "+channelName)
 	if err != nil {
-		logger.Error().Err(err).Msg("ListenForCancel: error registering channel")
+		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
+			logger.Error().Err(err).Msg("ListenForCancel: error registering channel")
+		}
 		return
 	}
 
@@ -738,15 +742,17 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 
 	// Wait for a notification on the channel. This blocks until the channel receives a notification.
 	_, err = conn.Conn().WaitForNotification(ctx)
-	if err != nil && !errors.Is(ctx.Err(), context.Canceled) {
-		logger.Error().Err(err).Msg("ListenForCancel: error waiting for notification")
+	if err != nil {
+		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
+			logger.Error().Err(err).Msg("ListenForCancel: error waiting for notification")
+		}
 		return
 	}
 
 	// Cancel context only if context has not already been canceled. If the context has already been canceled, the task has finished.
 	if !errors.Is(ctx.Err(), context.Canceled) {
 		logger.Debug().Msg("[Canceled Task]")
-		cancelFunc()
+		cancelFunc(ErrTaskCanceled)
 	}
 }
 

--- a/pkg/tasks/queue/pgqueue_test.go
+++ b/pkg/tasks/queue/pgqueue_test.go
@@ -245,7 +245,7 @@ func (s *QueueSuite) TestCancelChannel() {
 		dequeuers: newDequeuers(),
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancelCause(context.Background())
 	go pgQueue.ListenForCancel(ctx, uuid.Nil, cancelFunc)
 	time.Sleep(time.Millisecond * 200)
 
@@ -254,5 +254,5 @@ func (s *QueueSuite) TestCancelChannel() {
 	time.Sleep(time.Millisecond * 100)
 
 	// Tests that ListenForCancel unblocks because context was canceled by notification. Otherwise, would be context.DeadlineExceeded.
-	assert.Equal(s.T(), context.Canceled, ctx.Err())
+	assert.Equal(s.T(), ErrTaskCanceled, context.Cause(ctx))
 }

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -41,7 +41,7 @@ type Queue interface {
 	// UpdatePayload update the payload on a task
 	UpdatePayload(task *models.TaskInfo, payload interface{}) (*models.TaskInfo, error)
 	// ListenForCancel registers a channel and listens for notification for given task, then calls cancelFunc on receive. Should run as goroutine.
-	ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelFunc)
+	ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelCauseFunc)
 	// SendCancelNotification sends notification to cancel given task
 	SendCancelNotification(ctx context.Context, taskId uuid.UUID) error
 }
@@ -49,7 +49,7 @@ type Queue interface {
 var (
 	ErrNotExist        = fmt.Errorf("task does not exist")
 	ErrNotRunning      = fmt.Errorf("task is not running")
-	ErrCanceled        = fmt.Errorf("task was canceled")
+	ErrTaskCanceled    = fmt.Errorf("task was canceled")
 	ErrContextCanceled = fmt.Errorf("dequeue context timed out or was canceled")
 	ErrRowsNotAffected = fmt.Errorf("no rows were affected")
 )

--- a/pkg/tasks/queue/queue_mock.go
+++ b/pkg/tasks/queue/queue_mock.go
@@ -18,20 +18,6 @@ type MockQueue struct {
 	mock.Mock
 }
 
-// Cancel provides a mock function with given fields: taskId
-func (_m *MockQueue) Cancel(taskId uuid.UUID) error {
-	ret := _m.Called(taskId)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(uuid.UUID) error); ok {
-		r0 = rf(taskId)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Dequeue provides a mock function with given fields: ctx, taskTypes
 func (_m *MockQueue) Dequeue(ctx context.Context, taskTypes []string) (*models.TaskInfo, error) {
 	ret := _m.Called(ctx, taskTypes)
@@ -148,7 +134,7 @@ func (_m *MockQueue) IdFromToken(token uuid.UUID) (uuid.UUID, bool, error) {
 }
 
 // ListenForCancel provides a mock function with given fields: ctx, taskID, cancelFunc
-func (_m *MockQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelFunc) {
+func (_m *MockQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelCauseFunc) {
 	_m.Called(ctx, taskID, cancelFunc)
 }
 

--- a/pkg/tasks/worker/worker.go
+++ b/pkg/tasks/worker/worker.go
@@ -40,7 +40,7 @@ type runningTask struct {
 	token          uuid.UUID
 	typename       string
 	requestID      string
-	taskCancelFunc context.CancelFunc
+	taskCancelFunc context.CancelCauseFunc
 	cancelled      bool
 }
 
@@ -93,7 +93,7 @@ func (w *worker) start(ctx context.Context) {
 			}
 			return
 		case <-w.readyChan:
-			taskCtx, taskCancel := context.WithCancel(ctx)
+			taskCtx, taskCancel := context.WithCancelCause(ctx)
 			w.runningTask.taskCancelFunc = taskCancel
 
 			taskInfo, err := w.dequeue(taskCtx)
@@ -190,7 +190,7 @@ func (w *worker) process(ctx context.Context, taskInfo *models.TaskInfo) {
 	} else {
 		logger.Warn().Msg("handler not found for task type")
 	}
-	w.runningTask.taskCancelFunc()
+	w.runningTask.taskCancelFunc(queue.ErrNotRunning)
 	w.readyChan <- struct{}{}
 }
 


### PR DESCRIPTION
## Summary
We're seeing an issue where ListenForCancel is erroring because context is canceled. Likely happening because the task is finishing before the listener is ready to wait for a notification.

You can see the timestamps are very close.
```
Oct 5, 2023 @ 08:01:11.935 --> time right before registering listener

Oct 5, 2023 @ 08:01:12.006 --> time failed because context cancelled
```

There are many cases where this does not happen and the listener has time to finish registering, which should rule out an issue with the register command hanging.

This adds `context.CancelWithCause` so that we can identify when the context is canceled because the task is finished. If the task is finished, we simply ignore these errors.

## Testing steps
You might try to reproduce this locally, but I was not able to.
