### PR TITLE
Fixes 2588: Existing popular repositories not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ cmd/test/
 # Prometheus
 prometheus/data
 configs/prometheus.yaml
+
+# Pulp Oci Images
+compose_files/pulp/pulp-oci-images

--- a/pkg/handler/popular_repositories.go
+++ b/pkg/handler/popular_repositories.go
@@ -92,7 +92,7 @@ func filterPopularRepositories(configData []api.PopularRepositoryResponse, filte
 func (rh *PopularRepositoriesHandler) updateIfExists(c echo.Context, repo *api.PopularRepositoryResponse) error {
 	_, orgID := getAccountIdOrgId(c)
 	// Go get the records for this URL
-	repos, _, err := rh.Dao.RepositoryConfig.List(orgID, api.PaginationData{}, api.FilterData{Search: repo.URL})
+	repos, _, err := rh.Dao.RepositoryConfig.List(orgID, api.PaginationData{Limit: 1}, api.FilterData{Search: repo.URL})
 	if err != nil {
 		return ce.NewErrorResponseFromError("Could not get repository list", err)
 	}

--- a/pkg/handler/popular_repositories_test.go
+++ b/pkg/handler/popular_repositories_test.go
@@ -78,7 +78,7 @@ func (s *PopularReposSuite) servePopularRepositoriesRouter(req *http.Request) (i
 
 func (s *PopularReposSuite) TestPopularRepos() {
 	collection := createRepoCollection(0, 10, 0)
-	paginationData := api.PaginationData{}
+	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: "https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/"}).Return(collection, int64(0), nil)
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/"}).Return(collection, int64(0), nil)
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: "https://dl.fedoraproject.org/pub/epel/7/x86_64/"}).Return(collection, int64(0), nil)
@@ -107,7 +107,7 @@ func (s *PopularReposSuite) TestPopularReposSearchWithExisting() {
 	magicalUUID := "Magical-UUID-21"
 	existingName := "bestNameEver"
 	collection := api.RepositoryCollectionResponse{Data: []api.RepositoryResponse{{UUID: magicalUUID, Name: existingName, URL: popularRepository.URL, DistributionVersions: popularRepository.DistributionVersions, DistributionArch: popularRepository.DistributionArch}}}
-	paginationData := api.PaginationData{}
+	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
 
 	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, popularRepository.URL)
@@ -134,7 +134,7 @@ func (s *PopularReposSuite) TestPopularReposSearchWithExisting() {
 
 func (s *PopularReposSuite) TestPopularReposSearchByURL() {
 	collection := createRepoCollection(0, 10, 0)
-	paginationData := api.PaginationData{}
+	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
 
 	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, popularRepository.URL)
@@ -159,7 +159,7 @@ func (s *PopularReposSuite) TestPopularReposSearchByURL() {
 
 func (s *PopularReposSuite) TestPopularReposSearchByName() {
 	collection := createRepoCollection(0, 10, 0)
-	paginationData := api.PaginationData{}
+	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
 
 	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, url.QueryEscape(popularRepository.SuggestedName))


### PR DESCRIPTION
## Summary

Fixes popular repositories not having a UUID added to their list due to a gorm default limit change. 
Previously, when limit was set to 0  (or not set, which defaults to 0) the limit was effectively infinite, the update changes that so that the limit is now actually 0. 
This made it so that on query of the repositoryConfig.List method (with the default Limit of 0), UUID updates for each item on the popular repositories list were not being applied. As "nothing" was found in the Data, despite a count of 1 being returned.

## Testing steps

- Add a popular repository
- Check that the UUID is now returned in the response
- This will also be evident in the UI by the "Remove" button being visible on the popular repositories view.