### PR TITLE
Refs 2776: make pgx logging work by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -243,6 +243,7 @@ func setDefaults(v *viper.Viper) {
 
 	v.SetDefault("tasking.heartbeat", 1*time.Minute)
 	v.SetDefault("tasking.worker_count", 3)
+	v.SetDefault("tasking.pgx_logging", true)
 
 	v.SetDefault("features.snapshots.enabled", false)
 	v.SetDefault("features.snapshots.accounts", nil)

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -194,6 +194,10 @@ func NewPgxPool(url string) (*pgxpool.Pool, error) {
 	}
 	if config.Get().Tasking.PGXLogging {
 		pxConfig.ConnConfig.Logger = zerologadapter.NewLogger(log.Logger)
+		pxConfig.ConnConfig.LogLevel, err = pgx.LogLevelFromString(config.Get().Logging.Level)
+		if err != nil {
+			log.Error().Err(err).Msg("Error setting Pgx log level")
+		}
 	}
 	pool, err := pgxpool.ConnectConfig(context.Background(), pxConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary

This turns on logging by default and sets the proper level, but does not expose it via a parameter in deployment.yaml (yet).  

## Testing steps
