### PR TITLE
Fixes 2777: removed duplicate key from config example

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -82,11 +82,6 @@ clients:
     server: http://localhost:8080
     username: admin
     password: password
-    entitled_users:  ["pulp"]
-  pulp:
-    server: http://localhost:8080
-    username: admin
-    password: password
     storage_type: local #object or local
     download_policy: on_demand #on_demand or immediate
     custom_repo_objects:


### PR DESCRIPTION
## Summary

Removed duplicate pulp key in config.yaml.example that was causing issues when running the app for the first time.

## Testing steps
