### PR TITLE
Fixes 2776: set max pg pool for task db

### DIFF
--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -189,6 +189,7 @@ func (d *dequeuers) notifyAll() {
 
 func NewPgxPool(url string) (*pgxpool.Pool, error) {
 	pxConfig, err := pgxpool.ParseConfig(url)
+	pxConfig.MaxConns = int32(config.Get().Database.PoolLimit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Previously the db pool max limit was defaulting to 8 in ephemeral.  This wasn't enough for 2 tasks to run at the same time, due to needing a connection for:
* heartbeat update
* cancel listener
* updating payloads
* finishing the task

If enough of these things happened at once, it could exceede 8.

## Testing steps

ci passes