### PR TITLE
Refs 2615: don't propagate canceled context

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -82,7 +82,7 @@ func (r *repositoryConfigDaoImpl) InitializePulpClient(ctx context.Context, orgI
 		return err
 	}
 
-	pulpClient := pulp_client.GetPulpClientWithDomain(ctx, domainName)
+	pulpClient := pulp_client.GetPulpClientWithDomain(context.TODO(), domainName)
 	r.pulpClient = pulpClient
 	return nil
 }

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -161,7 +161,7 @@ func (sDao *snapshotDaoImpl) InitializePulpClient(ctx context.Context, orgID str
 		return err
 	}
 
-	pulpClient := pulp_client.GetPulpClientWithDomain(ctx, domainName)
+	pulpClient := pulp_client.GetPulpClientWithDomain(context.TODO(), domainName)
 	sDao.pulpClient = pulpClient
 	return nil
 }

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -310,6 +310,11 @@ func (rh *RepositoryHandler) update(c echo.Context, fillDefaults bool) error {
 		repoParams.FillDefaults()
 	}
 
+	err := rh.DaoRegistry.RepositoryConfig.InitializePulpClient(c.Request().Context(), orgID)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error initializing pulp client", err.Error())
+	}
+
 	repoConfig, err := rh.DaoRegistry.RepositoryConfig.Fetch(orgID, uuid)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -860,6 +860,8 @@ func (suite *ReposSuite) TestFullUpdate() {
 		UUID:           uuid,
 		RepositoryUUID: repoUuid,
 	}, nil)
+	suite.reg.RepositoryConfig.On("Update", test_handler.MockOrgId, uuid, expected).Return(false, nil)
+	suite.reg.RepositoryConfig.On("InitializePulpClient", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId).Return(nil).Once()
 
 	mockTaskClientEnqueueIntrospect(suite.tcMock, "https://example.com", repoUuid)
 
@@ -895,6 +897,7 @@ func (suite *ReposSuite) TestPartialUpdateUrlChange() {
 	suite.reg.RepositoryConfig.On("Update", test_handler.MockOrgId, repoConfigUuid, expected).Return(true, nil)
 	suite.reg.RepositoryConfig.On("Fetch", test_handler.MockOrgId, repoConfigUuid).Return(repoConfig, nil)
 	suite.reg.TaskInfo.On("IsSnapshotInProgress", *expected.OrgID, repoUuid).Return(false, nil)
+	suite.reg.RepositoryConfig.On("InitializePulpClient", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId).Return(nil).Once()
 
 	mockTaskClientEnqueueSnapshot(suite, &repoConfig)
 	mockTaskClientEnqueueIntrospect(suite.tcMock, "https://example.com", repoUuid)
@@ -929,6 +932,7 @@ func (suite *ReposSuite) TestPartialUpdate() {
 		RepositoryUUID: repoUuid,
 		Snapshot:       false,
 	}, nil)
+	suite.reg.RepositoryConfig.On("InitializePulpClient", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId).Return(nil).Once()
 
 	mockTaskClientEnqueueIntrospect(suite.tcMock, "https://example.com", repoUuid)
 


### PR DESCRIPTION
## Summary
In PR #414, I mistakenly set context on a shared struct. This means that unless the context is manually reset by using `InitializePulpClient` before calling the `repoConfig.List` or `repoConfig.Fetch` dao methods, the request will fail with

`{"errors":[{"status":500,"title":"Error fetching repository","detail":"Get \"http://cs-pulp-api-svc.content-sources-stage.svc.cluster.local:24817/pulp/api/v3/status/\": context canceled"}]}`


This changes makes it so `context.TODO()` is used instead of the propagated context. This is only a quick and temporary fix to unblock things for now.

## Testing steps
1. Fetch a repository
2. Introspect the same repository
3. Without this change, the introspection will fail with the 500 error.
