### PR TITLE
Build: use ubi-micro

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,9 +13,14 @@ USER 0
 
 RUN make get-deps build
 
-FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+FROM registry.redhat.io/ubi8/ubi-minimal:latest as ca-source
+FROM registry.redhat.io/ubi8/ubi-micro:latest
 
 WORKDIR /
+
+
+COPY --from=ca-source /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/
 
 COPY --from=builder /go/src/app/release/* ./
 RUN mkdir ./db/


### PR DESCRIPTION
## Summary

Switches to using the ubi-micro container, which appears to have everything we need other than a ca-trust, which we can copy from ubi-minimal

This reduces our security footprint and potential attack vectors

## Testing steps

tests pass
