### PR TITLE
Fixes 2890: don't query pulp if not enabled

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -76,6 +76,10 @@ func DBErrorToApi(e error) *ce.DaoError {
 }
 
 func (r *repositoryConfigDaoImpl) InitializePulpClient(ctx context.Context, orgID string) error {
+	if !config.Get().Features.Snapshots.Enabled {
+		return nil
+	}
+
 	dDao := GetDomainDao(r.db)
 	domainName, err := dDao.Fetch(orgID)
 	if err != nil {
@@ -270,7 +274,7 @@ func (r repositoryConfigDaoImpl) List(
 		return api.RepositoryCollectionResponse{}, totalRepos, filteredDB.Error
 	}
 
-	if r.pulpClient != nil {
+	if r.pulpClient != nil && config.Get().Features.Snapshots.Enabled {
 		contentPath, err = r.pulpClient.GetContentPath()
 		if err != nil {
 			return api.RepositoryCollectionResponse{}, totalRepos, err
@@ -369,7 +373,7 @@ func (r repositoryConfigDaoImpl) Fetch(orgID string, uuid string) (api.Repositor
 
 	ModelToApiFields(repoConfig, &repo)
 
-	if repoConfig.LastSnapshot != nil {
+	if repoConfig.LastSnapshot != nil && config.Get().Features.Snapshots.Enabled {
 		if r.pulpClient == nil {
 			return api.RepositoryResponse{}, fmt.Errorf("pulpClient cannot be nil")
 		}

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -618,7 +618,9 @@ func (suite *RepositoryConfigSuite) TestFetch() {
 		Error
 	assert.NoError(t, err)
 
-	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	if config.Get().Features.Snapshots.Enabled {
+		mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	}
 
 	fetched, err := rDao.Fetch(found.OrgID, found.UUID)
 	assert.Nil(t, err)
@@ -626,7 +628,10 @@ func (suite *RepositoryConfigSuite) TestFetch() {
 	assert.Equal(t, found.Name, fetched.Name)
 	assert.Equal(t, found.Repository.URL, fetched.URL)
 	assert.Equal(t, found.LastSnapshot.UUID, fetched.LastSnapshot.UUID)
-	assert.Equal(t, testContentPath+"/", fetched.LastSnapshot.URL)
+
+	if config.Get().Features.Snapshots.Enabled {
+		assert.Equal(t, testContentPath+"/", fetched.LastSnapshot.URL)
+	}
 }
 
 func (suite *RepositoryConfigSuite) TestFetchByRepo() {
@@ -755,7 +760,9 @@ func (suite *RepositoryConfigSuite) TestList() {
 
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: mockPulpClient}
-	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	if config.Get().Features.Snapshots.Enabled {
+		mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	}
 
 	response, total, err := rDao.List(orgID, pageData, filterData)
 	assert.Nil(t, err)
@@ -765,8 +772,10 @@ func (suite *RepositoryConfigSuite) TestList() {
 		assert.Equal(t, repoConfig.Name, response.Data[0].Name)
 		assert.Equal(t, repoConfig.Repository.URL, response.Data[0].URL)
 		assert.Equal(t, repoConfig.LastSnapshot.UUID, response.Data[0].LastSnapshot.UUID)
-		assert.Equal(t, testContentPath+"/", response.Data[0].LastSnapshot.URL)
 		assert.Equal(t, repoConfig.LastSnapshot.RepositoryPath, response.Data[0].LastSnapshot.RepositoryPath)
+		if config.Get().Features.Snapshots.Enabled {
+			assert.Equal(t, testContentPath+"/", response.Data[0].LastSnapshot.URL)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Seeing error where if pulp isn't enabled, certain API endpoints are broken because there are dao functions that query pulp. This checks if snapshots are enabled in all of those places before querying pulp.

## Testing steps
Turn off pulp and see if the errors are still present when listing/fetching repositories.