### PR TITLE
Build: Add reminder to test without pulp

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
 ## Summary
 
 ## Testing steps
+
+## Checklist
+
+- [ ] Tested with snapshoting feature disabled and pulp server url not configured if appropriate

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 
 ## Checklist
 
-- [ ] Tested with snapshoting feature disabled and pulp server url not configured if appropriate
+- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate


### PR DESCRIPTION
## Summary

Production doesn't use pulp currently, lets add a reminder to test the pr without it

## Testing steps
