### PR TITLE
Fixes 2616: add gpg key file endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -780,7 +780,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.RepositoryResponse"
+                            "type": "string"
                         }
                     },
                     "400": {

--- a/api/docs.go
+++ b/api/docs.go
@@ -753,6 +753,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/{uuid}/gpg_key/": {
+            "get": {
+                "description": "Get the GPG key file for a repository.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Get the GPG key file for a repository",
+                "operationId": "getGpgKeyFile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository ID.",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.RepositoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}/introspect/": {
             "post": {
                 "description": "Check for repository updates.",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1723,7 +1723,7 @@
                         "content": {
                             "text/plain": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/api.RepositoryResponse"
+                                    "type": "string"
                                 }
                             }
                         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1703,6 +1703,89 @@
                 ]
             }
         },
+        "/repositories/{uuid}/gpg_key/": {
+            "get": {
+                "description": "Get the GPG key file for a repository.",
+                "operationId": "getGpgKeyFile",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get the GPG key file for a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
         "/repositories/{uuid}/introspect/": {
             "post": {
                 "description": "Check for repository updates.",

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -142,7 +142,8 @@ objects:
             public:
               enabled: true
               apiPath: content-sources
-              whitelistPaths: /api/content-sources/v*/repositories/*/gpg_key
+              whitelistPaths:
+                - "/api/content-sources/v*/repositories/*/gpg_key"
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -142,6 +142,7 @@ objects:
             public:
               enabled: true
               apiPath: content-sources
+              whitelistPaths: /api/content-sources/v*/repositories/*/gpg_key
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,15 @@
 package api
 
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/content-services/content-sources-backend/pkg/config"
+)
+
 const IdentityHeader = "x-rh-identity"
+const ApiVersion = "1.0"
+const ApiVersionMajor = "1"
 
 // CollectionMetadataSettable a collection response with settable metadata
 type CollectionMetadataSettable interface {
@@ -47,4 +56,24 @@ type AdminTaskFilterData struct {
 	Status    string `json:"status"` // Comma separated list of statuses to optionally filter on.
 	OrgId     string `json:"org_id"`
 	AccountId string `json:"account_id"`
+}
+
+func RootPrefix() string {
+	pathPrefix, present := os.LookupEnv("PATH_PREFIX")
+	if !present {
+		pathPrefix = "api"
+	}
+
+	appName, present := os.LookupEnv("APP_NAME")
+	if !present {
+		appName = config.DefaultAppName
+	}
+	return filepath.Join("/", pathPrefix, appName)
+}
+
+func FullRootPath() string {
+	return filepath.Join(RootPrefix(), "v"+ApiVersion)
+}
+func MajorRootPath() string {
+	return filepath.Join(RootPrefix(), "v"+ApiVersionMajor)
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -62,6 +62,7 @@ type RepositoryConfigDao interface {
 	UpdateLastSnapshotTask(taskUUID string, orgID string, repoUUID string) error
 	InternalOnly_RefreshRedHatRepo(request api.RepositoryRequest) (*api.RepositoryResponse, error)
 	WithContext(ctx context.Context) RepositoryConfigDao
+	FetchWithoutOrgID(uuid string) (api.RepositoryResponse, error)
 }
 
 //go:generate mockery --name RpmDao --filename rpms_mock.go --inpackage
@@ -89,8 +90,8 @@ type SnapshotDao interface {
 	FetchForRepoConfigUUID(repoConfigUUID string) ([]models.Snapshot, error)
 	Delete(snapUUID string) error
 	FetchLatestSnapshot(repoConfigUUID string) (api.SnapshotResponse, error)
-	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, refererHeader string) (string, error)
 	WithContext(ctx context.Context) SnapshotDao
+	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, host string) (string, error)
 	Fetch(uuid string) (api.SnapshotResponse, error)
 }
 

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -89,8 +89,9 @@ type SnapshotDao interface {
 	FetchForRepoConfigUUID(repoConfigUUID string) ([]models.Snapshot, error)
 	Delete(snapUUID string) error
 	FetchLatestSnapshot(repoConfigUUID string) (api.SnapshotResponse, error)
-	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID string) (string, error)
+	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, refererHeader string) (string, error)
 	WithContext(ctx context.Context) SnapshotDao
+	Fetch(uuid string) (api.SnapshotResponse, error)
 }
 
 //go:generate mockery --name MetricsDao --filename metrics_mock.go --inpackage

--- a/pkg/dao/repository_configs_mock.go
+++ b/pkg/dao/repository_configs_mock.go
@@ -147,6 +147,30 @@ func (_m *MockRepositoryConfigDao) FetchByRepoUuid(orgID string, repoUuid string
 	return r0, r1
 }
 
+// FetchWithoutOrgID provides a mock function with given fields: uuid
+func (_m *MockRepositoryConfigDao) FetchWithoutOrgID(uuid string) (api.RepositoryResponse, error) {
+	ret := _m.Called(uuid)
+
+	var r0 api.RepositoryResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (api.RepositoryResponse, error)); ok {
+		return rf(uuid)
+	}
+	if rf, ok := ret.Get(0).(func(string) api.RepositoryResponse); ok {
+		r0 = rf(uuid)
+	} else {
+		r0 = ret.Get(0).(api.RepositoryResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(uuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // InternalOnly_FetchRepoConfigsForRepoUUID provides a mock function with given fields: uuid
 func (_m *MockRepositoryConfigDao) InternalOnly_FetchRepoConfigsForRepoUUID(uuid string) []api.RepositoryResponse {
 	ret := _m.Called(uuid)

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -687,7 +687,7 @@ func (suite *RepositoryConfigSuite) TestFetchWithoutOrgID() {
 		Error
 	assert.NoError(t, err)
 
-	fetched, err := GetRepositoryConfigDao(suite.tx).FetchWithoutOrgID(found.UUID)
+	fetched, err := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient).FetchWithoutOrgID(found.UUID)
 	assert.Nil(t, err)
 	assert.Equal(t, found.UUID, fetched.UUID)
 	assert.Equal(t, found.Name, fetched.Name)

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -673,6 +673,26 @@ func (suite *RepositoryConfigSuite) TestFetchByRepo() {
 	assert.Equal(t, found.Repository.URL, fetched.URL)
 }
 
+func (suite *RepositoryConfigSuite) TestFetchWithoutOrgID() {
+	t := suite.T()
+	tx := suite.tx
+	orgID := seeds.RandomOrgId()
+	var err error
+
+	err = seeds.SeedRepositoryConfigurations(suite.tx, 1, seeds.SeedOptions{OrgID: orgID})
+	assert.Nil(t, err)
+	found := models.RepositoryConfiguration{}
+	err = tx.
+		First(&found, "org_id = ?", orgID).
+		Error
+	assert.NoError(t, err)
+
+	fetched, err := GetRepositoryConfigDao(suite.tx).FetchWithoutOrgID(found.UUID)
+	assert.Nil(t, err)
+	assert.Equal(t, found.UUID, fetched.UUID)
+	assert.Equal(t, found.Name, fetched.Name)
+}
+
 func (suite *RepositoryConfigSuite) TestFetchNotFound() {
 	t := suite.T()
 	orgID := seeds.RandomOrgId()

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -180,9 +180,10 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 		gpgCheck = 1
 		gpgKeyField = fmt.Sprintf("http://%v%v/repositories/%v/gpg_key/", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
 	}
-	if repoConfig.MetadataVerification {
-		repoGpgCheck = 1
-	}
+
+	// TODO purposefully setting repo_gpgcheck to 0 for now until pulp issue is resolved
+	// normally set to 1 when metadata verification is enabled
+	repoGpgCheck = 0
 
 	fileConfig := fmt.Sprintf(""+
 		"[%v]\n"+

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -152,7 +152,7 @@ func (sDao *snapshotDaoImpl) fetch(uuid string) (models.Snapshot, error) {
 	return snapshot, nil
 }
 
-func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, refererHeader string) (string, error) {
+func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, host string) (string, error) {
 	rcDao := repositoryConfigDaoImpl{db: sDao.db}
 	repoConfig, err := rcDao.fetchRepoConfig(orgID, repoConfigUUID, true)
 	if err != nil {
@@ -178,7 +178,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("http://%v/%v/repositories/%v/gpg_key", refererHeader, api.RootPrefix(), repoConfigUUID)
+		gpgKeyField = fmt.Sprintf("http://%v/%v/repositories/%v/gpg_key/", host, api.RootPrefix(), repoConfigUUID)
 	}
 	if repoConfig.MetadataVerification {
 		repoGpgCheck = 1

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -178,7 +178,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("http://%v/%v/repositories/%v/gpg_key/", host, api.RootPrefix(), repoConfigUUID)
+		gpgKeyField = fmt.Sprintf("http://%v%v/repositories/%v/gpg_key/", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
 	}
 	if repoConfig.MetadataVerification {
 		repoGpgCheck = 1

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -119,23 +119,23 @@ func (_m *MockSnapshotDao) FetchLatestSnapshot(repoConfigUUID string) (api.Snaps
 	return r0, r1
 }
 
-// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, repoConfigUUID, refererHeader
-func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, repoConfigUUID string, refererHeader string) (string, error) {
-	ret := _m.Called(orgID, snapshotUUID, repoConfigUUID, refererHeader)
+// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, repoConfigUUID, host
+func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, repoConfigUUID string, host string) (string, error) {
+	ret := _m.Called(orgID, snapshotUUID, repoConfigUUID, host)
 
 	var r0 string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string, string, string, string) (string, error)); ok {
-		return rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
+		return rf(orgID, snapshotUUID, repoConfigUUID, host)
 	}
 	if rf, ok := ret.Get(0).(func(string, string, string, string) string); ok {
-		r0 = rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
+		r0 = rf(orgID, snapshotUUID, repoConfigUUID, host)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
+		r1 = rf(orgID, snapshotUUID, repoConfigUUID, host)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -45,6 +45,30 @@ func (_m *MockSnapshotDao) Delete(snapUUID string) error {
 	return r0
 }
 
+// Fetch provides a mock function with given fields: uuid
+func (_m *MockSnapshotDao) Fetch(uuid string) (api.SnapshotResponse, error) {
+	ret := _m.Called(uuid)
+
+	var r0 api.SnapshotResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (api.SnapshotResponse, error)); ok {
+		return rf(uuid)
+	}
+	if rf, ok := ret.Get(0).(func(string) api.SnapshotResponse); ok {
+		r0 = rf(uuid)
+	} else {
+		r0 = ret.Get(0).(api.SnapshotResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(uuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchForRepoConfigUUID provides a mock function with given fields: repoConfigUUID
 func (_m *MockSnapshotDao) FetchForRepoConfigUUID(repoConfigUUID string) ([]models.Snapshot, error) {
 	ret := _m.Called(repoConfigUUID)
@@ -95,23 +119,23 @@ func (_m *MockSnapshotDao) FetchLatestSnapshot(repoConfigUUID string) (api.Snaps
 	return r0, r1
 }
 
-// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, repoConfigUUID
-func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, repoConfigUUID string) (string, error) {
-	ret := _m.Called(orgID, snapshotUUID, repoConfigUUID)
+// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, repoConfigUUID, refererHeader
+func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, repoConfigUUID string, refererHeader string) (string, error) {
+	ret := _m.Called(orgID, snapshotUUID, repoConfigUUID, refererHeader)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string) (string, error)); ok {
-		return rf(orgID, snapshotUUID, repoConfigUUID)
+	if rf, ok := ret.Get(0).(func(string, string, string, string) (string, error)); ok {
+		return rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
-		r0 = rf(orgID, snapshotUUID, repoConfigUUID)
+	if rf, ok := ret.Get(0).(func(string, string, string, string) string); ok {
+		r0 = rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = rf(orgID, snapshotUUID, repoConfigUUID)
+	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
+		r1 = rf(orgID, snapshotUUID, repoConfigUUID, refererHeader)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -405,7 +405,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	t := s.T()
 	tx := s.tx
 
-	refererHeader := "example.com:9000"
+	host := "example.com:9000/"
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
 	repoConfig := s.createRepository()
@@ -413,14 +413,14 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 
 	// Test happy scenario
 	mockPulpClient.WithContextMock().On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, refererHeader)
+	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, host)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfig.Name)
 	assert.Contains(t, repoConfigFile, testContentPath)
 
 	// Test error from pulp call
 	mockPulpClient.WithContextMock().On("GetContentPath").Return("", fmt.Errorf("some error")).Once()
-	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, refererHeader)
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, host)
 	assert.Error(t, err)
 	assert.Empty(t, repoConfigFile)
 }
@@ -429,7 +429,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	t := s.T()
 	tx := s.tx
 
-	refererHeader := "example.com:9000"
+	host := "example.com:9000/"
 	mockPulpClient := pulp_client.MockPulpClient{}
 	sDao := snapshotDaoImpl{db: tx, pulpClient: &mockPulpClient}
 	repoConfig := s.createRepository()
@@ -441,7 +441,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 
 	// Test bad repo UUID
 	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err := sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, uuid2.NewString(), refererHeader)
+	repoConfigFile, err := sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, uuid2.NewString(), host)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)
@@ -453,7 +453,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 
 	// Test bad snapshot UUID
 	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, uuid2.NewString(), repoConfig.UUID, refererHeader)
+	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, uuid2.NewString(), repoConfig.UUID, host)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)
@@ -465,7 +465,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 
 	//  Test bad org ID
 	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile("bad orgID", snapshot.UUID, repoConfig.UUID, refererHeader)
+	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile("bad orgID", snapshot.UUID, repoConfig.UUID, host)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -407,7 +407,8 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 
 	host := "example.com:9000/"
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
-	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	sDaoImpl := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	sDao := sDaoImpl.WithContext(context.Background())
 	repoConfig := s.createRepository()
 	snapshot := s.createSnapshot(repoConfig)
 

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -405,22 +405,22 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	t := s.T()
 	tx := s.tx
 
+	refererHeader := "example.com:9000"
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
-
 	repoConfig := s.createRepository()
 	snapshot := s.createSnapshot(repoConfig)
 
 	// Test happy scenario
 	mockPulpClient.WithContextMock().On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err := sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID)
+	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, refererHeader)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfig.Name)
 	assert.Contains(t, repoConfigFile, testContentPath)
 
 	// Test error from pulp call
 	mockPulpClient.WithContextMock().On("GetContentPath").Return("", fmt.Errorf("some error")).Once()
-	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID)
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, refererHeader)
 	assert.Error(t, err)
 	assert.Empty(t, repoConfigFile)
 }
@@ -429,9 +429,9 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	t := s.T()
 	tx := s.tx
 
+	refererHeader := "example.com:9000"
 	mockPulpClient := pulp_client.MockPulpClient{}
 	sDao := snapshotDaoImpl{db: tx, pulpClient: &mockPulpClient}
-
 	repoConfig := s.createRepository()
 	snapshot := s.createSnapshot(repoConfig)
 
@@ -440,7 +440,8 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	}
 
 	// Test bad repo UUID
-	repoConfigFile, err := sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, uuid2.NewString())
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
+	repoConfigFile, err := sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, uuid2.NewString(), refererHeader)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)
@@ -451,7 +452,8 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	assert.Empty(t, repoConfigFile)
 
 	// Test bad snapshot UUID
-	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, uuid2.NewString(), repoConfig.UUID)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
+	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile(repoConfig.OrgID, uuid2.NewString(), repoConfig.UUID, refererHeader)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)
@@ -462,7 +464,8 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	assert.Empty(t, repoConfigFile)
 
 	//  Test bad org ID
-	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile("bad orgID", snapshot.UUID, repoConfig.UUID)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
+	repoConfigFile, err = sDao.WithContext(context.Background()).GetRepositoryConfigurationFile("bad orgID", snapshot.UUID, repoConfig.UUID, refererHeader)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)

--- a/pkg/handler/admin_tasks_test.go
+++ b/pkg/handler/admin_tasks_test.go
@@ -72,7 +72,7 @@ func (suite *AdminTasksSuite) serveAdminTasksRouter(req *http.Request, enabled b
 	}))
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	if enabled {
 		config.Get().Features.AdminTasks.Enabled = true
@@ -118,7 +118,7 @@ func (suite *AdminTasksSuite) TestSimple() {
 	filterData := api.AdminTaskFilterData{}
 	suite.reg.AdminTask.On("List", paginationData, filterData).Return(collection, int64(1), nil)
 
-	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -154,7 +154,7 @@ func (suite *AdminTasksSuite) TestListNoTasks() {
 	filterData := api.AdminTaskFilterData{}
 	suite.reg.AdminTask.On("List", paginationData, filterData).Return(collection, int64(0), nil)
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/", nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveAdminTasksRouter(req, true, true)
@@ -168,14 +168,14 @@ func (suite *AdminTasksSuite) TestListNoTasks() {
 	assert.Equal(t, int64(0), response.Meta.Count)
 	assert.Equal(t, 100, response.Meta.Limit)
 	assert.Equal(t, 0, len(response.Data))
-	assert.Equal(t, fullRootPath()+"/admin/tasks/?limit=100&offset=0", response.Links.Last)
-	assert.Equal(t, fullRootPath()+"/admin/tasks/?limit=100&offset=0", response.Links.First)
+	assert.Equal(t, api.FullRootPath()+"/admin/tasks/?limit=100&offset=0", response.Links.Last)
+	assert.Equal(t, api.FullRootPath()+"/admin/tasks/?limit=100&offset=0", response.Links.First)
 }
 
 func (suite *AdminTasksSuite) TestListDisabled() {
 	t := suite.T()
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/", nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveAdminTasksRouter(req, false, false)
@@ -191,7 +191,7 @@ func (suite *AdminTasksSuite) TestListDisabled() {
 func (suite *AdminTasksSuite) TestListNotAccessible() {
 	t := suite.T()
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/", nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveAdminTasksRouter(req, true, false)
@@ -214,7 +214,7 @@ func (suite *AdminTasksSuite) TestListPagedExtraRemaining() {
 	suite.reg.AdminTask.On("List", paginationData1, api.AdminTaskFilterData{}).Return(collection, int64(102), nil).Once()
 	suite.reg.AdminTask.On("List", paginationData2, api.AdminTaskFilterData{}).Return(collection, int64(102), nil).Once()
 
-	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -252,7 +252,7 @@ func (suite *AdminTasksSuite) TestListPagedNoRemaining() {
 	suite.reg.AdminTask.On("List", paginationData1, api.AdminTaskFilterData{}).Return(collection, int64(100), nil)
 	suite.reg.AdminTask.On("List", paginationData2, api.AdminTaskFilterData{}).Return(collection, int64(100), nil)
 
-	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/admin/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -289,7 +289,7 @@ func (suite *AdminTasksSuite) TestFetch() {
 
 	var body []byte
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/"+task.UUID,
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/"+task.UUID,
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
@@ -318,7 +318,7 @@ func (suite *AdminTasksSuite) TestFetchNotFound() {
 
 	var body []byte
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/"+task.UUID,
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/"+task.UUID,
 		bytes.NewReader(body))
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -331,7 +331,7 @@ func (suite *AdminTasksSuite) TestFetchDisabled() {
 
 	task := createAdminTask()
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/"+task.UUID, nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/"+task.UUID, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveAdminTasksRouter(req, false, false)
@@ -346,7 +346,7 @@ func (suite *AdminTasksSuite) TestFetchNotAccessible() {
 
 	task := createAdminTask()
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/admin/tasks/"+task.UUID, nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/admin/tasks/"+task.UUID, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveAdminTasksRouter(req, true, false)

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -32,8 +30,6 @@ const DefaultAvailableForArch = ""
 const DefaultAvailableForVersion = ""
 const DefaultStatus = ""
 const MaxLimit = 200
-const ApiVersion = "1.0"
-const ApiVersionMajor = "1"
 const DefaultAdminTaskStatus = ""
 const DefaultOrgId = ""
 const DefaultAccountId = ""
@@ -58,7 +54,7 @@ func RegisterRoutes(engine *echo.Echo) {
 		err     error
 		pgqueue queue.PgQueue
 	)
-	paths := []string{fullRootPath(), majorRootPath()}
+	paths := []string{api.FullRootPath(), api.MajorRootPath()}
 	pgqueue, err = queue.NewPgQueue(db.GetUrl())
 	if err != nil {
 		panic(err)
@@ -117,26 +113,6 @@ func openapi(c echo.Context) error {
 		return err
 	}
 	return c.JSONBlob(200, foo)
-}
-
-func rootPrefix() string {
-	pathPrefix, present := os.LookupEnv("PATH_PREFIX")
-	if !present {
-		pathPrefix = "api"
-	}
-
-	appName, present := os.LookupEnv("APP_NAME")
-	if !present {
-		appName = config.DefaultAppName
-	}
-	return filepath.Join("/", pathPrefix, appName)
-}
-
-func fullRootPath() string {
-	return filepath.Join(rootPrefix(), "v"+ApiVersion)
-}
-func majorRootPath() string {
-	return filepath.Join(rootPrefix(), "v"+ApiVersionMajor)
 }
 
 func createLink(c echo.Context, offset int) string {

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -45,10 +45,10 @@ func TestPing(t *testing.T) {
 
 func TestPingV1IsNotAvailable(t *testing.T) {
 	paths := []string{
-		fullRootPath() + "/ping",
-		fullRootPath() + "/ping/",
-		majorRootPath() + "/ping",
-		majorRootPath() + "/ping/",
+		api.FullRootPath() + "/ping",
+		api.FullRootPath() + "/ping/",
+		api.MajorRootPath() + "/ping",
+		api.MajorRootPath() + "/ping/",
 	}
 	for _, path := range paths {
 		t.Log(path)
@@ -75,14 +75,14 @@ func TestOpenapi(t *testing.T) {
 }
 
 func getTestContext(params string) echo.Context {
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/repositories/"+params, nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/repositories/"+params, nil)
 	rec := httptest.NewRecorder()
 	e := echo.New()
 	return e.NewContext(req, rec)
 }
 
 func TestRootRoute(t *testing.T) {
-	assert.Equal(t, fullRootPath(), "/api/"+config.DefaultAppName+"/v1.0")
+	assert.Equal(t, api.FullRootPath(), "/api/"+config.DefaultAppName+"/v1.0")
 }
 
 func TestParsePagination(t *testing.T) {

--- a/pkg/handler/features_test.go
+++ b/pkg/handler/features_test.go
@@ -39,7 +39,7 @@ func serveFeaturesRouter(req *http.Request) (int, []byte, error) {
 	router := echo.New()
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	RegisterFeaturesRoutes(pathPrefix)
 
@@ -63,7 +63,7 @@ type FeatureTestCase struct {
 
 func TestFeatures(t *testing.T) {
 	config.Get().Features.Snapshots.Enabled = true
-	path := fmt.Sprintf("%s/features/", fullRootPath())
+	path := fmt.Sprintf("%s/features/", api.FullRootPath())
 	req, _ := http.NewRequest("GET", path, nil)
 	user := identity.Identity{
 		Type:          "User",

--- a/pkg/handler/popular_repositories_test.go
+++ b/pkg/handler/popular_repositories_test.go
@@ -62,7 +62,7 @@ func (s *PopularReposSuite) servePopularRepositoriesRouter(req *http.Request) (i
 	router := echo.New()
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	RegisterPopularRepositoriesRoutes(pathPrefix, s.dao.ToDaoRegistry())
 
@@ -83,7 +83,7 @@ func (s *PopularReposSuite) TestPopularRepos() {
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/"}).Return(collection, int64(0), nil)
 	s.dao.RepositoryConfig.On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: "https://dl.fedoraproject.org/pub/epel/7/x86_64/"}).Return(collection, int64(0), nil)
 
-	path := fmt.Sprintf("%s/popular_repositories/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/popular_repositories/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(s.T()))
 
@@ -110,7 +110,7 @@ func (s *PopularReposSuite) TestPopularReposSearchWithExisting() {
 	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.WithContextMock().On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
 
-	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, popularRepository.URL)
+	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", api.FullRootPath(), 10, popularRepository.URL)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(s.T()))
 
@@ -136,7 +136,7 @@ func (s *PopularReposSuite) TestPopularReposSearchByURL() {
 	collection := createRepoCollection(0, 10, 0)
 	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.WithContextMock().On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
-	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, popularRepository.URL)
+	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", api.FullRootPath(), 10, popularRepository.URL)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(s.T()))
 
@@ -161,7 +161,7 @@ func (s *PopularReposSuite) TestPopularReposSearchByName() {
 	paginationData := api.PaginationData{Limit: 1}
 	s.dao.RepositoryConfig.WithContextMock().On("List", test_handler.MockOrgId, paginationData, api.FilterData{Search: popularRepository.URL}).Return(collection, int64(0), nil)
 
-	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", fullRootPath(), 10, url.QueryEscape(popularRepository.SuggestedName))
+	path := fmt.Sprintf("%s/popular_repositories/?limit=%d&search=%s", api.FullRootPath(), 10, url.QueryEscape(popularRepository.SuggestedName))
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(s.T()))
 

--- a/pkg/handler/public_repositories_test.go
+++ b/pkg/handler/public_repositories_test.go
@@ -40,7 +40,7 @@ func (suite *PublicReposSuite) serveRepositoriesRouter(req *http.Request) (int, 
 	}))
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	RegisterPublicRepositoriesRoutes(pathPrefix, suite.reg.ToDaoRegistry())
 
@@ -61,7 +61,7 @@ func (suite *PublicReposSuite) TestList() {
 	paginationData := api.PaginationData{Limit: 10, Offset: DefaultOffset}
 	suite.reg.Repository.On("ListPublic", paginationData, api.FilterData{}).Return(collection, int64(1), nil)
 
-	path := fmt.Sprintf("%s/public_repositories/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/public_repositories/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -90,7 +90,7 @@ func (suite *PublicReposSuite) TestListNoRepositories() {
 	paginationData := api.PaginationData{Limit: DefaultLimit, Offset: DefaultOffset}
 	suite.reg.Repository.On("ListPublic", paginationData, api.FilterData{}).Return(collection, int64(0), nil)
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/public_repositories/", nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/public_repositories/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveRepositoriesRouter(req)
@@ -104,8 +104,8 @@ func (suite *PublicReposSuite) TestListNoRepositories() {
 	assert.Equal(t, int64(0), response.Meta.Count)
 	assert.Equal(t, 100, response.Meta.Limit)
 	assert.Equal(t, 0, len(response.Data))
-	assert.Equal(t, fullRootPath()+"/public_repositories/?limit=100&offset=0", response.Links.Last)
-	assert.Equal(t, fullRootPath()+"/public_repositories/?limit=100&offset=0", response.Links.First)
+	assert.Equal(t, api.FullRootPath()+"/public_repositories/?limit=100&offset=0", response.Links.Last)
+	assert.Equal(t, api.FullRootPath()+"/public_repositories/?limit=100&offset=0", response.Links.First)
 }
 
 func (suite *PublicReposSuite) TestListPagedExtraRemaining() {
@@ -118,7 +118,7 @@ func (suite *PublicReposSuite) TestListPagedExtraRemaining() {
 	suite.reg.Repository.On("ListPublic", paginationData1, api.FilterData{}).Return(collection, int64(102), nil).Once()
 	suite.reg.Repository.On("ListPublic", paginationData2, api.FilterData{}).Return(collection, int64(102), nil).Once()
 
-	path := fmt.Sprintf("%s/public_repositories/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/public_repositories/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -156,7 +156,7 @@ func (suite *PublicReposSuite) TestListPagedNoRemaining() {
 	suite.reg.Repository.On("ListPublic", paginationData1, api.FilterData{}).Return(collection, int64(100), nil)
 	suite.reg.Repository.On("ListPublic", paginationData2, api.FilterData{}).Return(collection, int64(100), nil)
 
-	path := fmt.Sprintf("%s/public_repositories/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/public_repositories/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -195,7 +195,7 @@ func (suite *PublicReposSuite) TestListDaoError() {
 	suite.reg.Repository.On("ListPublic", paginationData, api.FilterData{}).
 		Return(api.PublicRepositoryCollectionResponse{}, int64(0), &daoError)
 
-	path := fmt.Sprintf("%s/public_repositories/", fullRootPath())
+	path := fmt.Sprintf("%s/public_repositories/", api.FullRootPath())
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -525,7 +525,7 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 // @Accept       json
 // @Produce      text/plain
 // @Param  uuid       path    string  true  "Repository ID."
-// @Success      200 {object}  api.RepositoryResponse
+// @Success      200 {object}  string
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -533,15 +533,9 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/{uuid}/gpg_key/ [get]
 func (rh *RepositoryHandler) getGpgKeyFile(c echo.Context) error {
-	_, orgID := getAccountIdOrgId(c)
 	uuid := c.Param("uuid")
 
-	err := rh.DaoRegistry.RepositoryConfig.InitializePulpClient(c.Request().Context(), orgID)
-	if err != nil {
-		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error initializing pulp client", err.Error())
-	}
-
-	resp, err := rh.DaoRegistry.RepositoryConfig.Fetch(orgID, uuid)
+	resp, err := rh.DaoRegistry.RepositoryConfig.FetchWithoutOrgID(uuid)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -1029,8 +1029,7 @@ func (suite *ReposSuite) TestGetGpgKeyFile() {
 		UUID:   uuid,
 		GpgKey: "gpg",
 	}
-	suite.reg.RepositoryConfig.On("InitializePulpClient", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId).Return(nil)
-	suite.reg.RepositoryConfig.On("Fetch", test_handler.MockOrgId, uuid).Return(repo, nil).Once()
+	suite.reg.RepositoryConfig.On("FetchWithoutOrgID", uuid).Return(repo, nil).Once()
 
 	body, err := json.Marshal(repo)
 	if err != nil {
@@ -1055,8 +1054,7 @@ func (suite *ReposSuite) TestGetGpgKeyFile() {
 		URL:  "https://example.com",
 		UUID: uuid,
 	}
-	suite.reg.RepositoryConfig.On("InitializePulpClient", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId).Return(nil)
-	suite.reg.RepositoryConfig.On("Fetch", test_handler.MockOrgId, uuid).Return(repoNoGPG, nil).Once()
+	suite.reg.RepositoryConfig.On("FetchWithoutOrgID", uuid).Return(repoNoGPG, nil).Once()
 
 	req = httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/repositories/"+uuid+"/gpg_key/",
 		bytes.NewReader(body))

--- a/pkg/handler/repository_parameters_test.go
+++ b/pkg/handler/repository_parameters_test.go
@@ -38,7 +38,7 @@ func (s *RepositoryParameterSuite) serveRepositoryParametersRouter(req *http.Req
 	router := echo.New()
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	RegisterRepositoryParameterRoutes(pathPrefix, s.mockDao.ToDaoRegistry())
 
@@ -54,7 +54,7 @@ func (s *RepositoryParameterSuite) serveRepositoryParametersRouter(req *http.Req
 
 func (s *RepositoryParameterSuite) TestListParams() {
 	t := s.T()
-	path := fmt.Sprintf("%s/repository_parameters/", fullRootPath())
+	path := fmt.Sprintf("%s/repository_parameters/", api.FullRootPath())
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	setHeaders(t, req)
 	code, body, err := s.serveRepositoryParametersRouter(req)
@@ -73,7 +73,7 @@ func (s *RepositoryParameterSuite) TestListParams() {
 func (s *RepositoryParameterSuite) TestValidate() {
 	t := s.T()
 
-	path := fmt.Sprintf("%s/repository_parameters/validate/", fullRootPath())
+	path := fmt.Sprintf("%s/repository_parameters/validate/", api.FullRootPath())
 
 	requestBody := []api.RepositoryValidationRequest{
 		{

--- a/pkg/handler/repository_rpms_test.go
+++ b/pkg/handler/repository_rpms_test.go
@@ -54,7 +54,7 @@ func (suite *RpmSuite) serveRpmsRouter(req *http.Request) (int, []byte, error) {
 		TargetHeader: "x-rh-insights-request-id",
 	}))
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
 
@@ -76,7 +76,7 @@ func (suite *RpmSuite) serveRpmsRouter(req *http.Request) (int, []byte, error) {
 func (suite *RpmSuite) TestRegisterRepositoryRpmRoutes() {
 	t := suite.T()
 	router := suite.echo
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	rh := RepositoryRpmHandler{
 		Dao: *suite.dao.ToDaoRegistry(),
@@ -146,7 +146,7 @@ func (suite *RpmSuite) TestListRepositoryRpms() {
 	for _, testCase := range testCases {
 		suite.T().Log(testCase.Name)
 
-		path := fmt.Sprintf("%s/repositories/%s/rpms?%s", fullRootPath(), testCase.Given.UUID, testCase.Given.Params)
+		path := fmt.Sprintf("%s/repositories/%s/rpms?%s", api.FullRootPath(), testCase.Given.UUID, testCase.Given.Params)
 		switch {
 		case testCase.Expected.Code >= 200 && testCase.Expected.Code < 300:
 			{
@@ -373,7 +373,7 @@ func (suite *RpmSuite) TestSearchRpmByName() {
 	for _, testCase := range testCases {
 		t.Log(testCase.Name)
 
-		path := fmt.Sprintf("%s/rpms/names", fullRootPath())
+		path := fmt.Sprintf("%s/rpms/names", api.FullRootPath())
 		switch {
 		case testCase.Expected.Code >= 200 && testCase.Expected.Code < 300:
 			{

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -71,9 +71,8 @@ func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 	_, orgID := getAccountIdOrgId(c)
 	uuid := c.Param("uuid")
 	snapshotUUID := c.Param("snapshot_uuid")
-	var repoConfigFile string
 
-	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid)
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, c.Request().Header.Get("referer"))
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
 	}

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -72,7 +72,7 @@ func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 	uuid := c.Param("uuid")
 	snapshotUUID := c.Param("snapshot_uuid")
 
-	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, c.Request().Header.Get("referer"))
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, c.Request().Host)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
 	}

--- a/pkg/handler/task_info_test.go
+++ b/pkg/handler/task_info_test.go
@@ -51,7 +51,7 @@ func (suite *TaskInfoSuite) serveTasksRouter(req *http.Request) (int, []byte, er
 	}))
 	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
-	pathPrefix := router.Group(fullRootPath())
+	pathPrefix := router.Group(api.FullRootPath())
 
 	th := TaskInfoHandler{
 		TaskClient: suite.tcMock,
@@ -90,7 +90,7 @@ func (suite *TaskInfoSuite) TestSimple() {
 	paginationData := api.PaginationData{Limit: 10, Offset: DefaultOffset}
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData, api.TaskInfoFilterData{}).Return(collection, int64(1), nil)
 
-	path := fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -120,7 +120,7 @@ func (suite *TaskInfoSuite) TestListNoTasks() {
 	paginationData := api.PaginationData{Limit: DefaultLimit, Offset: DefaultOffset}
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData, api.TaskInfoFilterData{}).Return(collection, int64(0), nil)
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/tasks/", nil)
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/tasks/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
 	code, body, err := suite.serveTasksRouter(req)
@@ -134,8 +134,8 @@ func (suite *TaskInfoSuite) TestListNoTasks() {
 	assert.Equal(t, int64(0), response.Meta.Count)
 	assert.Equal(t, 100, response.Meta.Limit)
 	assert.Equal(t, 0, len(response.Data))
-	assert.Equal(t, fullRootPath()+"/tasks/?limit=100&offset=0", response.Links.Last)
-	assert.Equal(t, fullRootPath()+"/tasks/?limit=100&offset=0", response.Links.First)
+	assert.Equal(t, api.FullRootPath()+"/tasks/?limit=100&offset=0", response.Links.Last)
+	assert.Equal(t, api.FullRootPath()+"/tasks/?limit=100&offset=0", response.Links.First)
 }
 
 func (suite *TaskInfoSuite) TestListPagedExtraRemaining() {
@@ -148,7 +148,7 @@ func (suite *TaskInfoSuite) TestListPagedExtraRemaining() {
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData1, api.TaskInfoFilterData{}).Return(collection, int64(102), nil).Once()
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData2, api.TaskInfoFilterData{}).Return(collection, int64(102), nil).Once()
 
-	path := fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -186,7 +186,7 @@ func (suite *TaskInfoSuite) TestListPagedNoRemaining() {
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData1, api.TaskInfoFilterData{}).Return(collection, int64(100), nil)
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData2, api.TaskInfoFilterData{}).Return(collection, int64(100), nil)
 
-	path := fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path := fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -225,7 +225,7 @@ func (suite *TaskInfoSuite) TestListStatusFilter() {
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData, api.TaskInfoFilterData{}).Return(collection, int64(110), nil)
 
 	// Listing with filter
-	path := fmt.Sprintf("%s/tasks/?limit=%d&status=%s", fullRootPath(), 10, filterData.Status)
+	path := fmt.Sprintf("%s/tasks/?limit=%d&status=%s", api.FullRootPath(), 10, filterData.Status)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -242,7 +242,7 @@ func (suite *TaskInfoSuite) TestListStatusFilter() {
 	assert.NotEmpty(t, response.Links.Last)
 
 	// Listing without filter
-	path = fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path = fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req = httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -270,7 +270,7 @@ func (suite *TaskInfoSuite) TestListTypeFilter() {
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData, api.TaskInfoFilterData{}).Return(collection, int64(110), nil)
 
 	// Listing with filter
-	path := fmt.Sprintf("%s/tasks/?limit=%d&type=%s", fullRootPath(), 10, filterData.Typename)
+	path := fmt.Sprintf("%s/tasks/?limit=%d&type=%s", api.FullRootPath(), 10, filterData.Typename)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -287,7 +287,7 @@ func (suite *TaskInfoSuite) TestListTypeFilter() {
 	assert.NotEmpty(t, response.Links.Last)
 
 	// Listing without filter
-	path = fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path = fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req = httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -315,7 +315,7 @@ func (suite *TaskInfoSuite) TestListRepoUuidFilter() {
 	suite.reg.TaskInfo.On("List", test_handler.MockOrgId, paginationData, api.TaskInfoFilterData{}).Return(collection, int64(110), nil)
 
 	// Listing with filter
-	path := fmt.Sprintf("%s/tasks/?limit=%d&repository_uuid=%s", fullRootPath(), 10, filterData.RepoConfigUUID)
+	path := fmt.Sprintf("%s/tasks/?limit=%d&repository_uuid=%s", api.FullRootPath(), 10, filterData.RepoConfigUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -332,7 +332,7 @@ func (suite *TaskInfoSuite) TestListRepoUuidFilter() {
 	assert.NotEmpty(t, response.Links.Last)
 
 	// Listing without filter
-	path = fmt.Sprintf("%s/tasks/?limit=%d", fullRootPath(), 10)
+	path = fmt.Sprintf("%s/tasks/?limit=%d", api.FullRootPath(), 10)
 	req = httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 
@@ -371,7 +371,7 @@ func (suite *TaskInfoSuite) TestFetch() {
 		t.Error("Could not marshal JSON")
 	}
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/tasks/"+uuid,
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/tasks/"+uuid,
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
@@ -413,7 +413,7 @@ func (suite *TaskInfoSuite) TestFetchNotFound() {
 		t.Error("Could not marshal JSON")
 	}
 
-	req := httptest.NewRequest(http.MethodGet, fullRootPath()+"/tasks/"+uuid,
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/tasks/"+uuid,
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,35 @@
+package utils
+
+// SlicesEqual returns true if s1 and s2 have the same elements in the same order
+func SlicesEqual[T comparable](s1 []T, s2 []T) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// AtIndexes returns a slice of the indexes of elems that contain v
+func AtIndexes[T comparable](elems []T, v T) []int {
+	var indexes []int
+	for i, s := range elems {
+		if s == v {
+			indexes = append(indexes, i)
+		}
+	}
+	return indexes
+}
+
+// Contains returns true if elems contains v
+func Contains[T comparable](elems []T, v T) bool {
+	for _, s := range elems {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Adds an endpoint that returns the GPG key of a repository as a file.

Also adds updates the fields in the config.repo file that is returned by the config.repo file endpoint.

## Testing steps
1. Create a repository with and without a GPG Key
2. Query the `repositories/:uuid/snapshots/:snapshot_uuid/config.repo` and `repositories/:uuid/gpg_key`
3. Verify the correct returns.
