### PR TITLE
Fixes 2450: remove org admin skip setting

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -215,8 +215,6 @@ objects:
                     name: cs-pulp-admin-password
                     key: password
                     optional: true
-              - name: RBAC_ORG_ADMIN_SKIP
-                value: ${RBAC_ORG_ADMIN_SKIP}
               - name: LOGGING_LEVEL
                 value: ${{LOGGING_LEVEL}}
               - name: CLIENTS_RBAC_BASE_URL
@@ -413,9 +411,6 @@ parameters:
     description: Whether the Admin Tasks feature should be turned on
   - name: FEATURES_ADMIN_TASKS_ACCOUNTS
     description: Comma separated list of account number that can access the feature
-  - name: RBAC_ORG_ADMIN_SKIP
-    description: skip rbac check if the user is an org admin
-    default: 'false'
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
     description: Option to make testing nightly snapshotting & introspection easier
     default: 'false'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,6 @@ type Configuration struct {
 	NotificationsClient cloudevents.Client `mapstructure:"notification_client"`
 	Tasking             Tasking            `mapstructure:"tasking"`
 	Features            FeatureSet         `mapstructure:"features"`
-	RbacOrgAdminSkip    bool               `mapstructure:"rbac_org_admin_skip"`
 }
 
 type Clients struct {
@@ -207,7 +206,6 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("Loaded", true)
 	// In viper you have to set defaults, otherwise loading from ENV doesn't work
 	//   without a config file present
-	v.SetDefault("rbac_org_admin_skip", false)
 	v.SetDefault("database.host", "")
 	v.SetDefault("database.port", "")
 	v.SetDefault("database.user", "")

--- a/pkg/rbac/client_wrapper.go
+++ b/pkg/rbac/client_wrapper.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/RedHatInsights/rbac-client-go"
 	"github.com/content-services/content-sources-backend/pkg/cache"
-	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/rs/zerolog"
 )
@@ -101,9 +100,5 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 }
 
 func skipRbacCheck(ctx context.Context) bool {
-	if config.Get().RbacOrgAdminSkip {
-		return identity.Get(ctx).Identity.User.OrgAdmin
-	} else {
-		return false
-	}
+	return identity.Get(ctx).Identity.User.OrgAdmin
 }

--- a/pkg/test/handler/utils.go
+++ b/pkg/test/handler/utils.go
@@ -11,18 +11,18 @@ import (
 
 var MockAccountNumber = seeds.RandomAccountId()
 var MockOrgId = seeds.RandomOrgId()
+var MockIdentity = identity.XRHID{
+	Identity: identity.Identity{
+		AccountNumber: MockAccountNumber,
+		Internal: identity.Internal{
+			OrgID: MockOrgId,
+		},
+		Type: "Associate",
+	},
+}
 
 func EncodedIdentity(t *testing.T) string {
-	mockIdentity := identity.XRHID{
-		Identity: identity.Identity{
-			AccountNumber: MockAccountNumber,
-			Internal: identity.Internal{
-				OrgID: MockOrgId,
-			},
-			Type: "Associate",
-		},
-	}
-	jsonIdentity, err := json.Marshal(mockIdentity)
+	jsonIdentity, err := json.Marshal(MockIdentity)
 	if err != nil {
 		t.Error("Could not marshal JSON")
 	}

--- a/scripts/header_org_admin.sh
+++ b/scripts/header_org_admin.sh
@@ -30,7 +30,7 @@ fi
 
 case "$( uname -s )" in
 "Darwin" )
-  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"username\":\"${USER_NAME}\"},\"account_number\":\"${ACCOUNT_ID}\",\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -b 0)"
+  ENC="$(echo "{\"identity\":{\"type\":\"User\",\"user\":{\"is_org_admin\":true, \"username\":\"${USER_NAME}\"},\"account_number\":\"${ACCOUNT_ID}\",\"internal\":{\"org_id\":\"${ORG_ID}\"}}}" | base64 -b 0)"
 ;;
 
 "Linux" | *)


### PR DESCRIPTION
## Summary
Removes the setting that enables/disables "org admin rbac skip", but keeps the functionality i.e. it is permanently enabled. This allows a user with the org admin field set to true to skip the rbac check.

## Testing steps
1. In your `config.yaml` set `clients: rbac_enabled` to true.
2. When your start the server, start it with the `mock_rbac` argument. i.e. `go run cmd/content-sources/main.go api consumer instrumentation mock_rbac`
1. GET repositories with a user that does not have read permissions and the org admin field is _false_. You should get a 401. For example `./scripts/header.sh <org_id> usernoperms` will generate the identity.
3. GET repositories with a user that does not have read permissions and the org admin field is _true_. You should get a 200 response. For example `./scripts/header_org_admin.sh <org_id> usernoperms` will generate the identity.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
