### PR TITLE
Fixes 2474: Recover from tasks panics

### DIFF
--- a/pkg/tasks/worker/worker_pool_test.go
+++ b/pkg/tasks/worker/worker_pool_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	uuid2 "github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 )
@@ -30,11 +33,11 @@ func (s *WorkerSuite) TestStartStopWorkers() {
 	s.T().Setenv("TASKING_WORKER_COUNT", "3")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	mockQueue.On("Dequeue", mock.Anything, []string(nil)).Return(&models.TaskInfo{}, nil)
+	mockQueue.On("ListenForCancel", mock.Anything, uuid2.Nil, mock.Anything).Return(nil, nil)
 
-	mockQueue.On("Dequeue", ctx, []string(nil)).Times(3).Return(nil, nil)
-
-	workerPool.StartWorkers(context.Background())
-	time.Sleep(time.Millisecond * 5)
+	workerPool.StartWorkers(ctx)
+	time.Sleep(time.Millisecond * 2)
 	workerPool.Stop()
 	cancelFunc()
 }


### PR DESCRIPTION
## Summary
Previously if a task paniced for some reason, the worker routine would get 'stuck' and refuse to process anything else.  Now the task is marked as failed and the worker can continue to pick up another task.

## Testing steps

modify the pkg/taskss/introspection.go  to panic sometimes or all the time:
```
	if rand.Int()%2 == 0 {
		panic(fmt.Errorf("You are unlucky!!"))
	}
```

Create some repository with with snapshotting turned off (for simplicity)
```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJqdXN0aW4ifSwiYWNjb3VudF9udW1iZXIiOiIxMTQ4NjU4OSIsImludGVybmFsIjp7Im9yZ19pZCI6IjE2Nzg4NjE2In19fQo=" \
    -H "Content-Type: application/json" \
    -d "{
          \"name\": \"errata\",
          \"url\": \"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/\",
          \"snapshot\": false
        }"
```

Now trigger introspection: 
```
 OPTIONS_ALWAYS_RUN_CRON_TASKS=true go run cmd/external-repos/main.go nightly-jobs
```

Run this a few times.  eventually your workers will stop processing tasks.  With this PR, they should always recover and mark the task as failed.   You can check the tasks table' status column to confirm they are marked as failed.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
