### PR TITLE
Refs 2675: rename kafka-consumer deployment

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -24,7 +24,7 @@ objects:
           replicas: 3
           topicName: platform.notifications.ingress
       deployments:
-        - name: kafka-consumer
+        - name: task-worker
           replicas: 3
           minReplicas: 3  # deprecated
           podSpec:


### PR DESCRIPTION
## Summary

Rename the kafka-consumer deployment prior to adding alerting around the pods

## Testing steps

tests pass?

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
