### PR TITLE
Build: Fix title regex to prevent bad multi issues

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: deepakputhraya/action-pr-title@master
       with:
-        regex: 'Build:|((Fixes |Refs )\d+(,\d+)*:) .+' # Regex the title should match.
+        regex: '^Build|^((Fixes |Refs )\d+(,\d+)*): .+' # Regex the title should match.
         allowed_prefixes: 'Refs ,Fixes ,Build ' # title should start with the given prefix
         disallowed_prefixes: '' # title should not start with the given prefix
         prefix_case_sensitive: false # title prefix are case insensitive


### PR DESCRIPTION
## Summary

Tries to prevent "Fixes 123,Fixes 456: summary" titles when doing multiple issues, but keep "Fixes 123,456: summary"

## Testing steps

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
