### PR TITLE
Refs 2190: adding enabled check to accessible

### DIFF
--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -54,11 +54,11 @@ func (fh *FeaturesHandler) listFeatures(c echo.Context) error {
 }
 
 func accessible(ctx context.Context, feature config.Feature) bool {
-	if feature.Accounts == nil && feature.Users == nil {
-		return true
-	}
 	if !feature.Enabled {
 		return false
+	}
+	if feature.Accounts == nil && feature.Users == nil {
+		return true
 	}
 	identity := identity.Get(ctx)
 	if feature.Accounts != nil && slices.Contains(*feature.Accounts, identity.Identity.AccountNumber) {

--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -57,6 +57,9 @@ func accessible(ctx context.Context, feature config.Feature) bool {
 	if feature.Accounts == nil && feature.Users == nil {
 		return true
 	}
+	if !feature.Enabled {
+		return false
+	}
 	identity := identity.Get(ctx)
 	if feature.Accounts != nil && slices.Contains(*feature.Accounts, identity.Identity.AccountNumber) {
 		return true


### PR DESCRIPTION
## Summary

Adding check so that if a feature is not enabled, it is also not accessible

## Testing steps

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
