### PR TITLE
Fixes 2768: add canceling state to PollTask

### DIFF
--- a/pkg/pulp_client/task.go
+++ b/pkg/pulp_client/task.go
@@ -19,6 +19,7 @@ const (
 	RUNNING   string = "running"
 	SKIPPED   string = "skipped"
 	CANCELED  string = "canceled"
+	CANCELING string = "canceling"
 	FAILED    string = "failed"
 )
 
@@ -66,7 +67,7 @@ func (r pulpDaoImpl) PollTask(taskHref string) (*zest.TaskResponse, error) {
 		}
 		taskState := *task.State
 		switch {
-		case slices.Contains([]string{WAITING, RUNNING}, taskState):
+		case slices.Contains([]string{WAITING, RUNNING, CANCELING}, taskState):
 			logger.Debug().Str("task_href", *task.PulpHref).Str("type", task.GetName()).Str("state", taskState).Msg("Running pulp task")
 		case slices.Contains([]string{COMPLETED, SKIPPED, CANCELED}, taskState):
 			logger.Debug().Str("task_href", *task.PulpHref).Str("type", task.GetName()).Str("state", taskState).Msg("Stopped pulp task")


### PR DESCRIPTION
## Summary
Adds "canceling" as one of the possible states while polling a pulp task. Previously it was jumping to the default case of "Pulp task with unexpected state" and logging an error.

If you search for "canceling" [here in the pulp docs](https://docs.pulpproject.org/pulpcore/restapi.html#tag/Tasks/operation/tasks_list), you can see it is a valid state.

## Testing steps
I can't find a reliable way to reproduce this, but it's a very small and simple change.

You can try

1. Creating a larger repo like epel 9, with snapshot enabled.
2. Canceling that task using the cancel endpoint (`/tasks/:uuid/cancel/`), and the `last_snapshot_task_uuid` from the create response.
3. You may or may not see the new state logged.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
