### PR TITLE
Fixes 3033: calculate timestamp to snapshot based off now()

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -69,7 +69,7 @@ func DBErrorToApi(e error) *ce.DaoError {
 
 	return &ce.DaoError{
 		Message:  e.Error(),
-		NotFound: ce.HttpCodeForDaoError(e) == 404, //Check if isNotFoundError
+		NotFound: ce.HttpCodeForDaoError(e) == 404, // Check if isNotFoundError
 	}
 }
 
@@ -221,7 +221,7 @@ func (p repositoryConfigDaoImpl) InternalOnly_ListReposToSnapshot(filter *ListRe
 		query = p.db.Where("snapshot IS TRUE")
 	} else {
 		query = p.db.Where("snapshot IS TRUE").Joins("LEFT JOIN tasks on last_snapshot_task_uuid = tasks.id").
-			Where(p.db.Where("tasks.queued_at <= (current_date - cast(? as interval))", interval).
+			Where(p.db.Where("tasks.queued_at <= (now() - cast(? as interval))", interval).
 				Or("tasks.status NOT IN ?", []string{config.TaskStatusCompleted, config.TaskStatusPending, config.TaskStatusRunning}).
 				Or("last_snapshot_task_uuid is NULL"))
 	}


### PR DESCRIPTION
## Summary
and not current_date

## Testing steps
1.  ```make repos-import```
2.  adjust SnapshotInterval in value_constraints.go to 0
3. run  ```go run ./cmd/external-repos/main.go nightly-jobs```   Notice snapshot tasks get created
4. wait for them to finish
5. run  ```go run ./cmd/external-repos/main.go nightly-jobs```  again, Notice snapshot tasks get created. Without this pr, you wouldn't see them

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
