### PR TITLE
Fixes 3032: replace nonalphanumeric chars in repo config ID

### DIFF
--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -3,7 +3,7 @@ package dao
 import (
 	"context"
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -172,7 +172,13 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 
 	contentURL := pulpContentURL(contentPath, snapshot.RepositoryPath)
 
-	repoID := strings.Replace(repoConfig.Name, " ", "_", len(repoConfig.Name))
+	// Replace any nonalphanumeric characters with an underscore
+	// e.g: "!!my repo?test15()" => "__my_repo_test15__"
+	re, err := regexp.Compile(`[^a-zA-Z0-9:space]`)
+	if err != nil {
+		return "", err
+	}
+	repoID := re.ReplaceAllString(repoConfig.Name, "_")
 
 	var gpgCheck, repoGpgCheck int
 	var gpgKeyField string


### PR DESCRIPTION
## Summary
We want to remove any nonalphanumeric characters from the label the config.repo file and replace with an underscore.

## Testing steps
1. Sync a repository with a name that has nonalphanumeric characters, like parentheses. 
2. Fetch the config.repo file from the `/respositories/:uuid/snapshots/:snapshot_uuid/config.repo` endpoint.
3. The label (the title in the square brackets) should have all the nonalphanumeric characters replaced with an underscore.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
