### PR TITLE
Refs 3053: Move to new bucket name

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -309,7 +309,7 @@ objects:
         version: 15
       inMemoryDb: true
       objectStore:
-        - content-sources-s3-custom-repos
+        - content-sources-s3-repos
   - apiVersion: v1
     kind: Service
     metadata:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,7 +81,7 @@ type Pulp struct {
 	DownloadPolicy    string       `mapstructure:"download_policy"` // on_demand or immediate
 }
 
-const CustomRepoClowderBucketName = "content-sources-s3-custom-repos"
+const RepoClowderBucketName = "content-sources-s3-repos"
 
 type ObjectStore struct {
 	URL       string
@@ -302,9 +302,9 @@ func Load() {
 				log.Error().Err(err).Msg("Cannot read RDS CA cert")
 			}
 
-			bucket, ok := clowder.ObjectBuckets[CustomRepoClowderBucketName]
+			bucket, ok := clowder.ObjectBuckets[RepoClowderBucketName]
 			if !ok {
-				log.Logger.Error().Msgf("Expected S3 Bucket named %v but not found", CustomRepoClowderBucketName)
+				log.Logger.Error().Msgf("Expected S3 Bucket named %v but not found", RepoClowderBucketName)
 			} else {
 				v.Set("clients.pulp.storage_type", "object")
 				v.Set("clients.pulp.custom_repo_objects.url", ClowderS3Url(*clowder.LoadedConfig.ObjectStore))


### PR DESCRIPTION
## Summary
Change to a new bucket name for our clowder provided resource.  The previous name was reused across buckets resulting in both buckets having the same 'name' internally.

## Testing steps
IQE tests Pass

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
