### PR TITLE
Fixes 3081: always intropsect public repos

### DIFF
--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -79,7 +79,7 @@ func (p repositoryDaoImpl) List(ignoreFailed bool) ([]Repository, error) {
 	var result *gorm.DB
 
 	if ignoreFailed {
-		result = p.db.Where("failed_introspections_count < ?", config.FailedIntrospectionsLimit+1).Find(&dbRepos)
+		result = p.db.Where("public = true OR failed_introspections_count < ?", config.FailedIntrospectionsLimit+1).Find(&dbRepos)
 	} else {
 		result = p.db.Find(&dbRepos)
 	}

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -165,7 +165,20 @@ func (s *RepositorySuite) TestListIgnoreFailed() {
 		LastIntrospectionError:       s.repo.LastIntrospectionError,
 		PackageCount:                 s.repo.PackageCount,
 		FailedIntrospectionsCount:    config.FailedIntrospectionsLimit,
-		Public:                       s.repo.Public,
+		Public:                       false,
+	}
+
+	expectedNotIgnoredPublic := Repository{
+		UUID:                         uuid.NewString(),
+		URL:                          "https://public.example.com",
+		Status:                       s.repo.Status,
+		LastIntrospectionTime:        s.repo.LastIntrospectionTime,
+		LastIntrospectionUpdateTime:  s.repo.LastIntrospectionUpdateTime,
+		LastIntrospectionSuccessTime: s.repo.LastIntrospectionSuccessTime,
+		LastIntrospectionError:       s.repo.LastIntrospectionError,
+		PackageCount:                 s.repo.PackageCount,
+		FailedIntrospectionsCount:    config.FailedIntrospectionsLimit + 1,
+		Public:                       true,
 	}
 
 	expectedIgnored := Repository{
@@ -178,12 +191,14 @@ func (s *RepositorySuite) TestListIgnoreFailed() {
 		LastIntrospectionError:       s.repo.LastIntrospectionError,
 		PackageCount:                 s.repo.PackageCount,
 		FailedIntrospectionsCount:    config.FailedIntrospectionsLimit + 1,
-		Public:                       s.repo.Public,
+		Public:                       false,
 	}
 
 	err := tx.Create(expectedNotIgnored).Error
 	require.NoError(t, err)
 	err = tx.Create(expectedIgnored).Error
+	require.NoError(t, err)
+	err = tx.Create(expectedNotIgnoredPublic).Error
 	require.NoError(t, err)
 
 	dao := GetRepositoryDao(tx)
@@ -191,6 +206,7 @@ func (s *RepositorySuite) TestListIgnoreFailed() {
 	assert.NoError(t, err)
 	assert.Contains(t, repoList, expectedNotIgnored)
 	assert.NotContains(t, repoList, expectedIgnored)
+	assert.Contains(t, repoList, expectedNotIgnoredPublic)
 }
 
 func (s *RepositorySuite) TestListPublic() {


### PR DESCRIPTION
## Summary
even if failed counts has been reached

As public repos should never fail  in the real world, some action may need to be taken, and we can retry.

We add RHEL repos before they are actually on the cdn, which means it can fail introspection for some time before its officially there.  Once it is, we want to introspect it properly.

## Testing steps

I wrote a test to test this, i think test passing is sufficient. 

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
