### PR TITLE
Fixes 3066: introspect aarch64 repositories

### DIFF
--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -88,5 +88,83 @@
     },
     {
         "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
+    },
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/aarch64/os/"
+    },
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/"
+    },
+    {
+        "base_url": "http://mirror.centos.org/centos/8-stream/extras/aarch64/os/"
+    },
+    {
+        "base_url": "http://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/"
+    },
+    {
+        "base_url": "http://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.5/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.5/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.6/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.6/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.7/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.7/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.8/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.8/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.9/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.9/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.1/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.1/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.2/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.2/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.3/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.3/aarch64/baseos/os"
     }
 ]


### PR DESCRIPTION
## Summary
Google aarch64 repositories don't need to be introspected yet, as we don't build aarch64 images for google cloud.



## Testing steps


## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
