### PR TITLE
Refs 3081: ignore failed intro count for public repos

### DIFF
--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -117,7 +117,7 @@ func reposForIntrospection(urls *[]string, force bool) ([]dao.Repository, []erro
 			repo, err := repoDao.FetchForUrl((*urls)[i])
 			if err != nil {
 				errors = append(errors, err)
-			} else if ignoredFailed && repo.FailedIntrospectionsCount > config.FailedIntrospectionsLimit {
+			} else if ignoredFailed && repo.FailedIntrospectionsCount > config.FailedIntrospectionsLimit && !repo.Public {
 				continue
 			} else {
 				repos = append(repos, repo)


### PR DESCRIPTION
## Summary

Found another place where its checking this

## Testing steps

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
