### PR TITLE
Refs 3050: delete all snapshots a second time

### DIFF
--- a/deployments/jobs.yaml
+++ b/deployments/jobs.yaml
@@ -13,3 +13,13 @@ objects:
     appName: content-sources-backend 
     jobs:
       - cleanup-snapshots-2023-11-20
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: content-sources-backend
+    name: cleanup-snapshots-2023-11-21
+  spec:
+    appName: content-sources-backend
+    jobs:
+      - cleanup-snapshots-2023-11-20


### PR DESCRIPTION
## Summary
Delete all snapshots a 2nd time

## Testing steps
none
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
