### PR TITLE
Refs 3050: repair redhat repos

### DIFF
--- a/cmd/repair_latest/main.go
+++ b/cmd/repair_latest/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/pulp_client"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/lib/pq"
+	"github.com/rs/zerolog/log"
+)
+
+func main() {
+	args := os.Args
+	config.Load()
+	config.ConfigureLogging()
+	err := db.Connect()
+
+	if err != nil {
+		log.Panic().Err(err).Msg("Failed to connect to database")
+	}
+
+	if len(args) < 2 || args[1] != "--force" {
+		log.Fatal().Msg("Requires arguments: --force")
+	}
+
+	daoReg := dao.GetDaoRegistry(db.DB)
+	repoConfigs := []models.RepositoryConfiguration{}
+	result := db.DB.Where("org_id = ?", config.RedHatOrg).Preload("Repository").Preload("LastSnapshot").Find(&repoConfigs)
+	if result.Error != nil {
+		log.Panic().Err(err).Msg("Failed to list repo configs")
+	}
+	domainName, err := daoReg.Domain.Fetch(config.RedHatOrg)
+	if err != nil {
+		log.Panic().Err(err).Msg("Failed to lookup domain name")
+	}
+	pulpClient := pulp_client.GetPulpClientWithDomain(context.Background(), domainName)
+	tasks := []string{}
+	for _, repoConfig := range repoConfigs {
+		repairTasks, err := repairRepo(daoReg, pulpClient, repoConfig)
+		if err != nil {
+			log.Logger.Error().Err(err).Msgf("could not repair repo %v (%v)", repoConfig.Name, repoConfig.UUID)
+		}
+		tasks = append(tasks, repairTasks...)
+	}
+	for i, task := range tasks {
+		log.Logger.Debug().Msgf("Polling task %v of %v", i, len(tasks))
+		_, err = pulpClient.PollTask(task)
+		if err != nil {
+			log.Logger.Error().Err(err).Msg("failed polling task")
+		}
+	}
+}
+
+func repairRepo(daoReg *dao.DaoRegistry, pulpClient pulp_client.PulpClient, repoConfig models.RepositoryConfiguration) ([]string, error) {
+	tasks := []string{}
+	repoResp, err := pulpClient.GetRpmRepositoryByName(repoConfig.UUID)
+	if err != nil {
+		return tasks, fmt.Errorf("error fetching repository by name: %w", err)
+	}
+	if repoResp == nil {
+		return tasks, fmt.Errorf("requested Repository is not found")
+	}
+	if repoResp.LatestVersionHref != nil {
+		task, err := pulpClient.RepairRpmRepositoryVersion(*repoResp.LatestVersionHref)
+		if err != nil {
+			return tasks, fmt.Errorf("trror starting repair: %w", err)
+		}
+		tasks = append(tasks, task)
+
+		// If the repo doesn't have a last snapshot, or the latestVersion doesn't match, try to delete it, if it's not version zero
+		if repoConfig.LastSnapshot == nil || *repoResp.LatestVersionHref != repoConfig.LastSnapshot.VersionHref {
+			versionResp, err := pulpClient.GetRpmRepositoryVersion(*repoResp.LatestVersionHref)
+			if err != nil {
+				return tasks, fmt.Errorf("couldn't get repo version: %w", err)
+			}
+			if versionResp.Number != nil && *versionResp.Number > int64(0) {
+				task, err := pulpClient.DeleteRpmRepositoryVersion(*repoResp.LatestVersionHref)
+				if err != nil {
+					return tasks, fmt.Errorf("couldn't delete repo version: %w", err)
+				}
+				tasks = append(tasks, task)
+			}
+		}
+	}
+
+	return tasks, nil
+}

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -247,6 +247,16 @@ objects:
               - mountPath: /tmp
                 name: tmpdir
       jobs:
+        - name: repair-redhat
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /repair_latest
+              - --force
         - name: cleanup-snapshots-2023-11-20
           podSpec:
             securityContext:

--- a/deployments/jobs.yaml
+++ b/deployments/jobs.yaml
@@ -13,3 +13,13 @@ objects:
     appName: content-sources-backend 
     jobs:
       - cleanup-snapshots-2023-11-20
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: content-sources-backend
+    name: repair-redhat-2023-11-22
+  spec:
+    appName: content-sources-backend
+    jobs:
+      - repair-redhat

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -45,6 +45,7 @@ type PulpClient interface {
 	// Rpm Repository Version
 	GetRpmRepositoryVersion(href string) (*zest.RepositoryVersionResponse, error)
 	DeleteRpmRepositoryVersion(href string) (string, error)
+	RepairRpmRepositoryVersion(href string) (string, error)
 
 	// RpmPublication
 	CreateRpmPublication(versionHref string) (*string, error)

--- a/pkg/pulp_client/pulp_client_mock.go
+++ b/pkg/pulp_client/pulp_client_mock.go
@@ -566,6 +566,30 @@ func (_m *MockPulpClient) PollTask(taskHref string) (*zest.TaskResponse, error) 
 	return r0, r1
 }
 
+// RepairRpmRepositoryVersion provides a mock function with given fields: href
+func (_m *MockPulpClient) RepairRpmRepositoryVersion(href string) (string, error) {
+	ret := _m.Called(href)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(href)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(href)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(href)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Status provides a mock function with given fields:
 func (_m *MockPulpClient) Status() (*zest.StatusResponse, error) {
 	ret := _m.Called()

--- a/pkg/pulp_client/rpm_repository_version.go
+++ b/pkg/pulp_client/rpm_repository_version.go
@@ -1,6 +1,9 @@
 package pulp_client
 
-import zest "github.com/content-services/zest/release/v2023"
+import (
+	zest "github.com/content-services/zest/release/v2023"
+	"github.com/openlyinc/pointy"
+)
 
 // GetRpmRepositoryVersion Finds a repository version given its href
 func (r *pulpDaoImpl) GetRpmRepositoryVersion(href string) (*zest.RepositoryVersionResponse, error) {
@@ -20,6 +23,16 @@ func (r *pulpDaoImpl) DeleteRpmRepositoryVersion(href string) (string, error) {
 		if err.Error() == "404 Not Found" {
 			return "", nil
 		}
+		return "", err
+	}
+	defer httpResp.Body.Close()
+	return resp.Task, nil
+}
+
+func (r *pulpDaoImpl) RepairRpmRepositoryVersion(href string) (string, error) {
+	resp, httpResp, err := r.client.RepositoriesRpmVersionsAPI.RepositoriesRpmRpmVersionsRepair(r.ctx, href).
+		Repair(zest.Repair{VerifyChecksums: pointy.Pointer(true)}).Execute()
+	if err != nil {
 		return "", err
 	}
 	defer httpResp.Body.Close()


### PR DESCRIPTION
and delete newest version if does not match latest snapshot

## Summary

Currently in stage we have a couple issues, stemming from a repository snapshotting, and the publish failed due to a missing metadata file (that is downloaded, not generated).  

So for each red hat org's repository, we grab the latest_version_href from pulp and trigger a repair.  If this latest version doesn't match the repo's latest snapshot, we delete it. 

## Testing steps

You might edit the redhat_repo.json file and delete all except for the `Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)` repo.  
Run 
```make repos-import```
```go run cmd/external_repos/main.go nightly-jobs```

This will sync the red hat repo.   Then run:

```go run cmd/repair_latest/main.go --force```

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
