### PR TITLE
Fixes 3184: query last_snapshot correctly

### DIFF
--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -23,7 +23,7 @@ type RepositoryConfiguration struct {
 	Snapshot             bool           `json:"snapshot"`
 	DeletedAt            gorm.DeletedAt `json:"deleted_at"`
 	LastSnapshotUUID     string         `json:"last_snapshot_uuid" gorm:"default:null"`
-	LastSnapshot         *Snapshot      `json:"last_snapshot,omitempty"`
+	LastSnapshot         *Snapshot      `json:"last_snapshot,omitempty" gorm:"foreignKey:last_snapshot_uuid"`
 	LastSnapshotTaskUUID string         `json:"last_snapshot_task_uuid" gorm:"default:null"`
 }
 


### PR DESCRIPTION
## Summary

We weren't specifying the association foreign key correctly, so we were getting a 'random' snapshot, and not the latest

## Testing steps

Generate a repo with multiple snapshots, view the json when fetching a repo and make sure that 'last_snapshot_uuid' matches 'last_snapshot.uuid'

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
