### PR TITLE
Fixes 3189: change gpg key file endpoint

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1005,7 +1005,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repository_gpg_key/{uuid}/": {
+        "/repository_gpg_key/{uuid}": {
             "get": {
                 "description": "Get the GPG key file for a repository.",
                 "consumes": [

--- a/api/docs.go
+++ b/api/docs.go
@@ -753,69 +753,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/repositories/{uuid}/gpg_key/": {
-            "get": {
-                "description": "Get the GPG key file for a repository.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "repositories"
-                ],
-                "summary": "Get the GPG key file for a repository",
-                "operationId": "getGpgKeyFile",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Repository ID.",
-                        "name": "uuid",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "415": {
-                        "description": "Unsupported Media Type",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/repositories/{uuid}/introspect/": {
             "post": {
                 "description": "Check for repository updates.",
@@ -1055,6 +992,69 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/repository_gpg_key/{uuid}/": {
+            "get": {
+                "description": "Get the GPG key file for a repository.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Get the GPG key file for a repository",
+                "operationId": "getGpgKeyFile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository ID.",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1703,89 +1703,6 @@
                 ]
             }
         },
-        "/repositories/{uuid}/gpg_key/": {
-            "get": {
-                "description": "Get the GPG key file for a repository.",
-                "operationId": "getGpgKeyFile",
-                "parameters": [
-                    {
-                        "description": "Repository ID.",
-                        "in": "path",
-                        "name": "uuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "400": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unauthorized"
-                    },
-                    "404": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    },
-                    "415": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unsupported Media Type"
-                    },
-                    "500": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Internal Server Error"
-                    }
-                },
-                "summary": "Get the GPG key file for a repository",
-                "tags": [
-                    "repositories"
-                ]
-            }
-        },
         "/repositories/{uuid}/introspect/": {
             "post": {
                 "description": "Check for repository updates.",
@@ -2108,6 +2025,89 @@
                     }
                 },
                 "summary": "Get configuration file of a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
+        "/repository_gpg_key/{uuid}/": {
+            "get": {
+                "description": "Get the GPG key file for a repository.",
+                "operationId": "getGpgKeyFile",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get the GPG key file for a repository",
                 "tags": [
                     "repositories"
                 ]

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2030,7 +2030,7 @@
                 ]
             }
         },
-        "/repository_gpg_key/{uuid}/": {
+        "/repository_gpg_key/{uuid}": {
             "get": {
                 "description": "Get the GPG key file for a repository.",
                 "operationId": "getGpgKeyFile",

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -143,8 +143,8 @@ objects:
               enabled: true
               apiPath: content-sources
               whitelistPaths:
-                - /api/content-sources/v1/repositories/*/gpg_key/
-                - /api/content-sources/v1.0/repositories/*/gpg_key/
+                - /api/content-sources/v1/repository_gpg_key/*
+                - /api/content-sources/v1.0/repository_gpg_key/*
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -143,7 +143,8 @@ objects:
               enabled: true
               apiPath: content-sources
               whitelistPaths:
-                - /api/content-sources/v*/repositories/*/gpg_key/
+                - /api/content-sources/v1/repositories/*/gpg_key/
+                - /api/content-sources/v1.0/repositories/*/gpg_key/
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -143,7 +143,7 @@ objects:
               enabled: true
               apiPath: content-sources
               whitelistPaths:
-                - "/api/content-sources/v*/repositories/*/gpg_key"
+                - /api/content-sources/v*/repositories/*/gpg_key/
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -184,7 +184,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("http://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+		gpgKeyField = fmt.Sprintf("https://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
 	}
 
 	// TODO purposefully setting repo_gpgcheck to 0 for now until pulp issue is resolved

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -184,7 +184,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("http://%v%v/repository_gpg_key/%v/", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+		gpgKeyField = fmt.Sprintf("http://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
 	}
 
 	// TODO purposefully setting repo_gpgcheck to 0 for now until pulp issue is resolved

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -184,7 +184,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("http://%v%v/repositories/%v/gpg_key/", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+		gpgKeyField = fmt.Sprintf("http://%v%v/repository_gpg_key/%v/", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
 	}
 
 	// TODO purposefully setting repo_gpgcheck to 0 for now until pulp issue is resolved

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -531,7 +531,7 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
-// @Router       /repositories/{uuid}/gpg_key/ [get]
+// @Router       /repository_gpg_key/{uuid}/ [get]
 func (rh *RepositoryHandler) getGpgKeyFile(c echo.Context) error {
 	uuid := c.Param("uuid")
 

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -53,7 +53,7 @@ func RegisterRepositoryRoutes(engine *echo.Group, daoReg *dao.DaoRegistry,
 	addRoute(engine, http.MethodPost, "/repositories/", rh.createRepository, rbac.RbacVerbWrite)
 	addRoute(engine, http.MethodPost, "/repositories/bulk_create/", rh.bulkCreateRepositories, rbac.RbacVerbWrite)
 	addRoute(engine, http.MethodPost, "/repositories/:uuid/introspect/", rh.introspect, rbac.RbacVerbWrite)
-	addRoute(engine, http.MethodGet, "/repositories/:uuid/gpg_key/", rh.getGpgKeyFile, rbac.RbacVerbRead)
+	addRoute(engine, http.MethodGet, "/repository_gpg_key/:uuid", rh.getGpgKeyFile, rbac.RbacVerbRead)
 }
 
 func GetIdentity(c echo.Context) (identity.XRHID, error) {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -531,7 +531,7 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
-// @Router       /repository_gpg_key/{uuid}/ [get]
+// @Router       /repository_gpg_key/{uuid} [get]
 func (rh *RepositoryHandler) getGpgKeyFile(c echo.Context) error {
 	uuid := c.Param("uuid")
 

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -1036,7 +1036,7 @@ func (suite *ReposSuite) TestGetGpgKeyFile() {
 		t.Error("Could not marshal JSON")
 	}
 
-	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/repositories/"+uuid+"/gpg_key/",
+	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/repository_gpg_key/"+uuid,
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -50,11 +50,11 @@ func SkipAuth(c echo.Context) bool {
 		}
 	}
 
-	// skip endpoint repositories/*/gpg_key
-	lengthOfSkipPath := len(strings.Split("repositories/*/gpg_key/", "/"))
+	// skip endpoint repository_gpg_key/:uuid
+	lengthOfSkipPath := len(strings.Split("repository_gpg_key/*", "/"))
 	lengthOfPath := len(strings.Split(p, "/"))
 	if strings.HasPrefix(p, "/api/"+config.DefaultAppName+"/") {
-		if lengthOfPrefix+lengthOfSkipPath == lengthOfPath && splitPath[4] == "repositories" && splitPath[6] == "gpg_key" {
+		if lengthOfPrefix+lengthOfSkipPath == lengthOfPath && splitPath[4] == "repository_gpg_key" {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
Changes the gpg key file endpoint to `repository_gpg_key/:uuid` so that it can be whitelisted i.e. skip auth
## Testing steps
1. Deploy PR in ephemeral
2. Create repository with GPG key and snapshot enabled
3. Use the GPG Key URL in the config.repo file to open a tab (in browser) to the GPG Key
4. Should be able to open the URL in your browser despite not having the correct auth

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
