### PR TITLE
Fixes 3250: provide filter for excluding loaded RH repos

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -13,6 +13,8 @@ IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
 IQE_FILTER_EXPRESSION="not test_introspection_of_persistent_user"  # This is the value passed to pytest -k
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
+# Only deploy one small red hat repo
+EXTRA_DEPLOY_ARGS="--set-parameter content-sources-backend/OPTIONS_REPOSITORY_IMPORT_FILTER=small"
 
 # Install bonfire repo/initialize
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -123,6 +123,8 @@ objects:
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
                 value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: OPTIONS_REPOSITORY_IMPORT_FILTER
+                value: ${OPTIONS_REPOSITORY_IMPORT_FILTER}
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -149,24 +151,6 @@ objects:
             securityContext:
               runAsNonRoot: true
               runAsUser: 1001
-            initContainers:
-              - name: db-migrate
-                inheritEnv: true
-                args:
-                  - /dbmigrate
-                  - up
-              - name: external-repos-import
-                inheritEnv: true
-                args:
-                  - /external-repos
-                  - import
-              - name: introspect-single-repo
-                inheritEnv: true
-                args:
-                  - /external-repos
-                  - introspect
-                  - https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os
-                  - https://cdn.redhat.com/content/dist/rhel8/8.7/x86_64/baseos/os
             image: ${IMAGE}:${IMAGE_TAG}
             command:
               - /content-sources
@@ -532,3 +516,6 @@ parameters:
   - name: OPTIONS_ENABLE_NOTIFICATIONS
     description: Send notifications via kafka
     default: 'false'
+  - name: OPTIONS_REPOSITORY_IMPORT_FILTER
+    description: Optionally filter preset repos that are imported
+    default: ''

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,8 +151,9 @@ type Options struct {
 	PagedRpmInsertsLimit      int `mapstructure:"paged_rpm_inserts_limit"`
 	IntrospectApiTimeLimitSec int `mapstructure:"introspect_api_time_limit_sec"`
 	// If true, introspection and snapshotting always runs for nightly job invocation, regardless of how soon they happened previously.  Used for testing.
-	AlwaysRunCronTasks  bool `mapstructure:"always_run_cron_tasks"`
-	EnableNotifications bool `mapstructure:"enable_notifications"`
+	AlwaysRunCronTasks     bool   `mapstructure:"always_run_cron_tasks"`
+	EnableNotifications    bool   `mapstructure:"enable_notifications"`
+	RepositoryImportFilter string `mapstructure:"repository_import_filter"` // Used by qe to control which repos are imported
 }
 
 type Metrics struct {
@@ -214,6 +215,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("options.introspect_api_time_limit_sec", DefaultIntrospectApiTimeLimitSec)
 	v.SetDefault("options.always_run_cron_tasks", false)
 	v.SetDefault("options.enable_notifications", false)
+	v.SetDefault("options.repository_import_filter", "")
 	v.SetDefault("logging.level", "info")
 	v.SetDefault("logging.console", true)
 	v.SetDefault("metrics.path", "/metrics")

--- a/pkg/external_repos/redhat_repos.go
+++ b/pkg/external_repos/redhat_repos.go
@@ -23,6 +23,7 @@ type RedHatRepo struct {
 	Name                string `json:"name"`
 	Arch                string `json:"arch"`
 	DistributionVersion string `json:"distribution_version"`
+	Selector            string `json:"selector"`
 	GpgKey              string `json:"gpg_key"`
 }
 
@@ -91,5 +92,12 @@ func (rhr *RedHatRepoImporter) loadFromFile() ([]RedHatRepo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return repos, nil
+	filteredRepos := []RedHatRepo{}
+	filter := config.Get().Options.RepositoryImportFilter
+	for _, repo := range repos {
+		if filter == "" || repo.Selector == filter {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
 }

--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -4,7 +4,8 @@
         "url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os",
         "content_label": "ansible-2-for-rhel-8-x86_64-rpms",
         "arch": "x86_64",
-        "distribution_version": "8"
+        "distribution_version": "8",
+        "selector": "small"
     },
     {
         "name": "Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)",


### PR DESCRIPTION
## Summary

Provide an env variable that can be used to exclude some or all of the red hat repos from being loaded.  

## Testing steps

In dev,
In between each test, a ```make compose-clean compose-up``` is needed to clear out what is there.
With backend and frontend running:
```
go run ./cmd/external-repos/main.go import
```

should still import all red hat repos (can check in the UI).  
```
OPTIONS_REPOSITORY_IMPORT_FILTER="small" go run ./cmd/external-repos/main.go import
```

should import only 1 small ansible redhat repo

```
OPTIONS_REPOSITORY_IMPORT_FILTER="none" go run ./cmd/external-repos/main.go import
```
should cause no red hat repos to be imported.

For QE, you can use with bonfire: 

--set-parameter content-sources-backend/OPTIONS_REPOSITORY_IMPORT_FILTER=small
--set-parameter content-sources-backend/OPTIONS_REPOSITORY_IMPORT_FILTER=none

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
