### PR TITLE
Fixes 3037: Adds a url validity check.

### DIFF
--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"net/url"
 	"strings"
 	"time"
 
@@ -45,6 +46,9 @@ func (r *Repository) validate() error {
 	}
 	if stringContainsInternalWhitespace(r.URL) {
 		return Error{Message: "URL cannot contain whitespace.", Validation: true}
+	}
+	if _, err := url.ParseRequestURI(r.URL); err != nil {
+		return Error{Message: "Invalid URL for request.", Validation: true}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This adds a simple check on the model for repositories.URL to see if it is a valid. 

## Testing steps

Manually testing can be done by attempting to hit any of the repositories create/edit endpoints with an incorrect URL. 

Invalid URL example: repo_2_url  

Valid URL example: https://repo_2_url.org

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate 
