### PR TITLE
Fixes 3016: Reject requests with org id of -1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -474,6 +474,6 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 		err = c.JSON(code, message)
 	}
 	if err != nil {
-		log.Logger.Error().Err(err)
+		log.Error().Msg(err.Error())
 	}
 }

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -70,7 +70,7 @@ func EnforceOrgId(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		xRHID := identity.Get(c.Request().Context())
 
-		if xRHID.Identity.Internal.OrgID == "-1" || xRHID.Identity.OrgID == "-1" {
+		if xRHID.Identity.Internal.OrgID == config.RedHatOrg || xRHID.Identity.OrgID == config.RedHatOrg {
 			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -1")
 			c.Error(err)
 			return nil

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -70,10 +71,8 @@ func EnforceOrgId(next echo.HandlerFunc) echo.HandlerFunc {
 		xRHID := identity.Get(c.Request().Context())
 
 		if xRHID.Identity.Internal.OrgID == "-1" || xRHID.Identity.OrgID == "-1" {
-			//err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -1") // this causes a 500 in the test only, not sure why
-			err := echo.ErrForbidden
+			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -1")
 			c.Error(err)
-			c.Request().Context().Done()
 			return nil
 		}
 

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -14,14 +14,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-type XRHID struct {
-	Type          string `json:"type"`
-	AccountNumber string `json:"account_number"`
-	Internal      struct {
-		OrgID string `json:"org_id"`
-	} `json:"internal"`
-}
-
 // WrapMiddleware wraps `func(http.Handler) http.Handler` into `echo.MiddlewareFunc`
 func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_middleware.Skipper) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/pkg/middleware/enforce_identity_test.go
+++ b/pkg/middleware/enforce_identity_test.go
@@ -148,6 +148,7 @@ func TestWrapMiddlewareWithSkipper(t *testing.T) {
 func TestEnforceOrgId(t *testing.T) {
 	e := echo.New()
 	e.Use(EnforceOrgId)
+	e.HTTPErrorHandler = config.CustomHTTPErrorHandler
 
 	// Test org ID of -1 returns an error response
 	req := httptest.NewRequest(http.MethodGet, urlPrefix+"/v1/repository_parameters/", nil)
@@ -169,7 +170,7 @@ func TestEnforceOrgId(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 
 	assert.NoError(t, err)
-	assert.Contains(t, string(body), "Forbidden")
+	assert.Contains(t, string(body), "Invalid org ID")
 	assert.Equal(t, http.StatusForbidden, res.Code)
 
 	// Test valid org ID returns success

--- a/pkg/middleware/enforce_json.go
+++ b/pkg/middleware/enforce_json.go
@@ -21,10 +21,14 @@ func EnforceJSONContentType(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		mediatype, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
 		if err != nil {
-			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
+			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
+			c.Error(err)
+			return nil
 		}
 		if mediatype != JSONMimeType {
-			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
+			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
+			c.Error(err)
+			return nil
 		}
 		return next(c)
 	}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -34,6 +34,7 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		Skipper:         config.SkipLogging,
 	}))
 	e.Use(middleware.EnforceJSONContentType)
+	e.Use(middleware.EnforceOrgId)
 
 	// Add routes
 	handler.RegisterPing(e)


### PR DESCRIPTION
## Summary

Adds check to middleware to reject requests if the Org ID is -1

## Testing steps

Make a request to any endpoint with an identity header with Org ID set to -1. Response should return a 403. 

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
