### PR TITLE
Fixes 3271: remove redundant lint CI tests

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -34,26 +34,6 @@ jobs:
           generator: python
           openapi-file: api/openapi.json
 
-  gofmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
-      - uses: Jerome1337/gofmt-action@v1.0.4
-
-  govet:
-    name: Vet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
-      - run: |
-          go vet ./...
   golangci:
     name: Lint
     runs-on: ubuntu-latest
@@ -67,7 +47,7 @@ jobs:
         with:
           version: v1.54.2
           skip-go-installation: true
-          args: --enable gci,bodyclose,forcetypeassert,misspell --timeout=5m
+          args: --timeout=5m
 
   gotest:
     name: Test


### PR DESCRIPTION
## Summary
- govet and gofmt are already tested by golangci-lint
- there's also no need to explicitly enable tests in the args for the golangci-lint action because we have a config file for it

## Testing steps
tests pass
## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
