### PR TITLE
Refs 3016: revert org id check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -476,6 +476,6 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 		err = c.JSON(code, message)
 	}
 	if err != nil {
-		log.Error().Msg(err.Error())
+		log.Logger.Error().Err(err)
 	}
 }

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -6,10 +6,8 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
-	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 // WrapMiddleware wraps `func(http.Handler) http.Handler` into `echo.MiddlewareFunc`
@@ -19,7 +17,6 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_midd
 			if skip != nil && skip(c) {
 				return next(c)
 			}
-
 			m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				c.SetRequest(r)
 				c.SetResponse(echo.NewResponse(w, c.Echo()))
@@ -29,7 +26,6 @@ func WrapMiddlewareWithSkipper(m func(http.Handler) http.Handler, skip echo_midd
 				}
 				err = next(c)
 			})).ServeHTTP(c.Response(), c.Request())
-
 			return
 		}
 	}
@@ -64,18 +60,4 @@ func SkipAuth(c echo.Context) bool {
 	}
 
 	return false
-}
-
-func EnforceOrgId(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		xRHID := identity.Get(c.Request().Context())
-
-		if xRHID.Identity.Internal.OrgID == config.RedHatOrg || xRHID.Identity.OrgID == config.RedHatOrg {
-			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -1")
-			c.Error(err)
-			return nil
-		}
-
-		return next(c)
-	}
 }

--- a/pkg/middleware/enforce_identity_test.go
+++ b/pkg/middleware/enforce_identity_test.go
@@ -1,9 +1,7 @@
 package middleware
 
 import (
-	"context"
 	"encoding/base64"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -143,53 +141,4 @@ func TestWrapMiddlewareWithSkipper(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, bodyResponse, rec.Body.String())
 	}
-}
-
-func TestEnforceOrgId(t *testing.T) {
-	e := echo.New()
-	e.Use(EnforceOrgId)
-	e.HTTPErrorHandler = config.CustomHTTPErrorHandler
-
-	// Test org ID of -1 returns an error response
-	req := httptest.NewRequest(http.MethodGet, urlPrefix+"/v1/repository_parameters/", nil)
-
-	var xrhid identity.XRHID
-
-	xrhid.Identity.OrgID = "-1"
-	xrhid.Identity.AccountNumber = "11111"
-	xrhid.Identity.User.Username = "user"
-	xrhid.Identity.Internal.OrgID = "-1"
-
-	ctx := req.Context()
-	ctx = context.WithValue(ctx, identity.Key, xrhid)
-	req = req.WithContext(ctx)
-
-	res := httptest.NewRecorder()
-	e.ServeHTTP(res, req)
-
-	body, err := io.ReadAll(res.Body)
-
-	assert.NoError(t, err)
-	assert.Contains(t, string(body), "Invalid org ID")
-	assert.Equal(t, http.StatusForbidden, res.Code)
-
-	// Test valid org ID returns success
-	xrhid.Identity.OrgID = "7066"
-	xrhid.Identity.AccountNumber = "11111"
-	xrhid.Identity.User.Username = "user"
-	xrhid.Identity.Internal.OrgID = "7066"
-
-	ctx = req.Context()
-	ctx = context.WithValue(ctx, identity.Key, xrhid)
-	req = req.WithContext(ctx)
-
-	res = httptest.NewRecorder()
-	e.Add(req.Method, req.URL.Path, handleItWorked)
-	e.ServeHTTP(res, req)
-
-	body, err = io.ReadAll(res.Body)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "\"It worked\"\n", string(body))
-	assert.Equal(t, http.StatusOK, res.Code)
 }

--- a/pkg/middleware/enforce_json.go
+++ b/pkg/middleware/enforce_json.go
@@ -21,14 +21,10 @@ func EnforceJSONContentType(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		mediatype, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
 		if err != nil {
-			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
-			c.Error(err)
-			return nil
+			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
 		}
 		if mediatype != JSONMimeType {
-			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
-			c.Error(err)
-			return nil
+			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
 		}
 		return next(c)
 	}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -18,7 +18,6 @@ import (
 
 func ConfigureEcho(allRoutes bool) *echo.Echo {
 	e := echo.New()
-
 	// Add global middlewares
 	echoLogger := lecho.From(log.Logger,
 		lecho.WithTimestamp(),
@@ -34,8 +33,6 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		RequestIDKey:    config.RequestIdLoggingKey,
 		Skipper:         config.SkipLogging,
 	}))
-	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	e.Use(middleware.EnforceOrgId)
 	e.Use(middleware.EnforceJSONContentType)
 
 	// Add routes
@@ -54,6 +51,7 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 
 	// Add additional global middlewares
 	e.Use(middleware.CreateMetricsMiddleware(metrics))
+	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	if config.Get().Clients.RbacEnabled {
 		rbacBaseUrl := config.Get().Clients.RbacBaseUrl
 		rbacTimeout := time.Duration(int64(config.Get().Clients.RbacTimeout) * int64(time.Second))


### PR DESCRIPTION
This reverts commit 2802ea28c793aec866a79f89115d06e75adc2729.

## Summary

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
