### PR TITLE
Fixes 3016: Reject requests with org id of -1

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -474,6 +474,6 @@ func CustomHTTPErrorHandler(err error, c echo.Context) {
 		err = c.JSON(code, message)
 	}
 	if err != nil {
-		log.Logger.Error().Err(err)
+		log.Error().Msg(err.Error())
 	}
 }

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 // WrapMiddleware wraps `func(http.Handler) http.Handler` into `echo.MiddlewareFunc`
@@ -60,4 +62,21 @@ func SkipAuth(c echo.Context) bool {
 	}
 
 	return false
+}
+
+func EnforceOrgId(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if identity.GetIdentityHeader(c.Request().Context()) == "" {
+			return next(c)
+		}
+		xRHID := identity.Get(c.Request().Context())
+
+		if xRHID.Identity.Internal.OrgID == config.RedHatOrg || xRHID.Identity.OrgID == config.RedHatOrg {
+			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -1")
+			c.Error(err)
+			return nil
+		}
+
+		return next(c)
+	}
 }

--- a/pkg/middleware/enforce_json.go
+++ b/pkg/middleware/enforce_json.go
@@ -21,10 +21,14 @@ func EnforceJSONContentType(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		mediatype, _, err := mime.ParseMediaType(c.Request().Header.Get("Content-Type"))
 		if err != nil {
-			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
+			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Error parsing content type", err.Error())
+			c.Error(err)
+			return nil
 		}
 		if mediatype != JSONMimeType {
-			return ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
+			err = ce.NewErrorResponse(http.StatusUnsupportedMediaType, "Incorrect content type", "Content-Type must be application/json")
+			c.Error(err)
+			return nil
 		}
 		return next(c)
 	}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -33,6 +33,8 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		RequestIDKey:    config.RequestIdLoggingKey,
 		Skipper:         config.SkipLogging,
 	}))
+	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
+	e.Use(middleware.EnforceOrgId)
 	e.Use(middleware.EnforceJSONContentType)
 
 	// Add routes
@@ -51,7 +53,6 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 
 	// Add additional global middlewares
 	e.Use(middleware.CreateMetricsMiddleware(metrics))
-	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
 	if config.Get().Clients.RbacEnabled {
 		rbacBaseUrl := config.Get().Clients.RbacBaseUrl
 		rbacTimeout := time.Duration(int64(config.Get().Clients.RbacTimeout) * int64(time.Second))


### PR DESCRIPTION
## Summary

Adds check to middleware to reject requests if the Org ID is -1

## Testing steps

Make a request to any endpoint with an identity header with Org ID set to -1. Response should return a 403.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
