### PR TITLE
Fixes 3232: add gh action to prevent out of order migrations

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -48,6 +48,37 @@ jobs:
           version: v1.54.2
           skip-go-installation: true
           args: --timeout=5m
+  
+  checkmigrations:
+    name: Check db migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: tj-actions/changed-files@v40
+        id: files
+      - run: |
+          #!/bin/bash
+
+          migrations_latest=$(cat db/migrations.latest)
+          num_files_added=${{ steps.files.outputs.added_files_count }}
+
+          if [ "$num_files_added" -gt 0 ]; then 
+            new_migrations_added=$(echo "${{ steps.files.outputs.added_files }}" | grep 'db/migrations' || true)
+            if [ -n "$new_migrations_added" ]; then
+              if echo "$new_migrations_added" | grep -q "$migrations_latest"; then
+                echo "OK: Latest migration content (db/migrations.latest) reflects the timestamp of the latest migrations added."
+              else 
+                echo "Error: Latest migration content (db/migrations.latest) does NOT reflect the timestamp of the latest migrations added."
+                echo "New migration files added: $new_migrations_added"
+                echo "In db/migration.latest: $migrations_latest"
+                exit 1
+              fi
+            else
+              echo "OK: No new migration files added."
+            fi
+          else
+            echo "OK: No new files added."
+          fi
 
   gotest:
     name: Test


### PR DESCRIPTION
## Summary

Added Github Action to check for out of order database migrations.

## Testing steps

If the content in `db/migrations.latest` does not reflect the timestamp of the newest added set of migration files in `db/migrations`, the job will fail. If these timestamps match or if there are no new migrations, the job will succeed. 

Can test by:
- Adding a set of test migration files with an earlier timestamp than the latest and not updating the `db/migrations.latest`. This should cause the job to fail.
- Removing the test migration files. The `db/migrations.latest` content should reflect the newest added set of migration files. This should cause the job to succeed.
- Adding a set of test migration files with a timestamp that matches the timestamp in `db/migrations.latest`. This should cause the job to succeed.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
