### PR TITLE
Refs 3016: fix order of middleware for metrics endpoint

### DIFF
--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -33,8 +33,6 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		RequestIDKey:    config.RequestIdLoggingKey,
 		Skipper:         config.SkipLogging,
 	}))
-	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
-	e.Use(middleware.EnforceOrgId)
 	e.Use(middleware.EnforceJSONContentType)
 
 	// Add routes
@@ -52,6 +50,8 @@ func ConfigureEchoWithMetrics(metrics *instrumentation.Metrics) *echo.Echo {
 	e := ConfigureEcho(true)
 
 	// Add additional global middlewares
+	e.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipAuth))
+	e.Use(middleware.EnforceOrgId)
 	e.Use(middleware.CreateMetricsMiddleware(metrics))
 	if config.Get().Clients.RbacEnabled {
 		rbacBaseUrl := config.Get().Clients.RbacBaseUrl


### PR DESCRIPTION
## Summary

Fixes `missing x-rh-identity-header` in /metrics endpoint

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
