### PR TITLE
Fixes 3252: listing with limit=0 causes divide by 0 panic

### DIFF
--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -201,6 +201,9 @@ func ParsePagination(c echo.Context) api.PaginationData {
 	if pageData.Limit > MaxLimit {
 		pageData.Limit = MaxLimit
 	}
+	if pageData.Limit == 0 {
+		pageData.Limit = DefaultLimit
+	}
 	return pageData
 }
 

--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -99,6 +99,9 @@ func TestParsePagination(t *testing.T) {
 
 	pageInfo = ParsePagination(getTestContext("?sort_by=status"))
 	assert.Equal(t, "status", pageInfo.SortBy)
+
+	pageInfo = ParsePagination(getTestContext("?limit=0"))
+	assert.Equal(t, DefaultLimit, pageInfo.Limit)
 }
 
 func TestCollectionResponse(t *testing.T) {


### PR DESCRIPTION
## Summary

Updates limit in API request to `DefaultLimit` (100) if ever set to 0

## Testing steps

Test any listing API endpoint (`/repositories`, `/popular_repositories`, `/repositories/:uuid/rpms`, etc) and set the limit to 0. Should not panic and update limit to default of 100.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
