### PR TITLE
Fixes 1973: Prevents snapshots on non-snapshot enabled repos

### DIFF
--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -483,6 +483,10 @@ func (rh *RepositoryHandler) createSnapshot(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusConflict, "Error snapshotting repository", "This repository is currently being snapshotted.")
 	}
 
+	if !response.Snapshot {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Error snapshotting repository", "Snapshotting not yet enabled for this repository.")
+	}
+
 	rh.enqueueSnapshotEvent(c, &response)
 
 	return c.NoContent(http.StatusNoContent)


### PR DESCRIPTION
## Summary
Prevents snapshots on non-snapshot enabled repos

## Testing steps

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
