### PR TITLE
Fixes 1973: Typo in model

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1782,11 +1782,11 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "match": {
-                    "description": "This is the snapshot date (if found)",
+                    "description": "This is the snapshot (if found)",
                     "$ref": "#/definitions/api.SnapshotResponse"
                 },
-                "repository_uuids": {
-                    "description": "Repository uuids to find snapshots for",
+                "repository_uuid": {
+                    "description": "Repository uuid for associated snapshot",
                     "type": "string"
                 }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -92,8 +92,8 @@
                     "match": {
                         "$ref": "#/components/schemas/api.SnapshotResponse"
                     },
-                    "repository_uuids": {
-                        "description": "Repository uuids to find snapshots for",
+                    "repository_uuid": {
+                        "description": "Repository uuid for associated snapshot",
                         "type": "string"
                     }
                 },

--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -20,9 +20,9 @@ type ListSnapshotByDateRequest struct {
 }
 
 type ListSnapshotByDateResponse struct {
-	RepositoryUUID string            `json:"repository_uuids"` // Repository uuids to find snapshots for
-	IsAfter        bool              `json:"is_after"`         // Is the snapshot after the specified date
-	Match          *SnapshotResponse `json:"match,omitempty"`  // This is the snapshot date (if found)
+	RepositoryUUID string            `json:"repository_uuid"` // Repository uuid for associated snapshot
+	IsAfter        bool              `json:"is_after"`        // Is the snapshot after the specified date
+	Match          *SnapshotResponse `json:"match,omitempty"` // This is the snapshot (if found)
 }
 
 type SnapshotCollectionResponse struct {


### PR DESCRIPTION
## Summary

Found a typo in the response during testing, this changes: 

repository_uuid**s** => repository_uuid

## Testing steps

None

