### PR TITLE
Fixes 3231: remove non-UTF8 chars from introspection error

### DIFF
--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"strings"
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -199,7 +200,8 @@ func internalToModel(internal RepositoryUpdate, model *models.Repository) {
 		model.Public = *internal.Public
 	}
 	if internal.LastIntrospectionError != nil {
-		model.LastIntrospectionError = internal.LastIntrospectionError
+		cleaned := strings.ToValidUTF8(*internal.LastIntrospectionError, "")
+		model.LastIntrospectionError = &cleaned
 	}
 	if internal.LastIntrospectionTime != nil {
 		model.LastIntrospectionTime = internal.LastIntrospectionTime

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -372,6 +372,14 @@ func (s *RepositorySuite) TestUpdateRepository() {
 		LastIntrospectionError: pointy.Pointer(errorMsg[0:256]),
 	})
 	assert.NoError(t, err)
+
+	// Test that it removes non-UTF8 characters from introspection error
+	errMsg := "introspection \xc5 failed"
+	err = dao.Update(RepositoryUpdate{
+		UUID:                   s.repo.UUID,
+		LastIntrospectionError: pointy.Pointer(errMsg),
+	})
+	assert.NoError(t, err)
 }
 
 func (s *RepositorySuite) TestFetchRpmCount() {

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -506,7 +506,7 @@ func (p *PgQueue) Finish(taskId uuid.UUID, taskError error) error {
 		} else {
 			status = config.TaskStatusFailed
 		}
-		s := taskError.Error()
+		s := strings.ToValidUTF8(taskError.Error(), "")
 		errMsg = &s
 	} else {
 		status = config.TaskStatusCompleted

--- a/pkg/tasks/queue/pgqueue_test.go
+++ b/pkg/tasks/queue/pgqueue_test.go
@@ -176,6 +176,23 @@ func (s *QueueSuite) TestFinish() {
 	assert.Equal(s.T(), config.TaskStatusFailed, info.Status)
 
 	assert.Equal(s.T(), 4000, len(*info.Error))
+
+	// Test finish where error has non-UTF8 chars
+	id, err = s.queue.Enqueue(&testTask)
+	require.NoError(s.T(), err)
+	assert.NotEqual(s.T(), uuid.Nil, id)
+
+	_, err = s.queue.Dequeue(context.Background(), []string{testTaskType})
+	require.NoError(s.T(), err)
+
+	err = s.queue.Finish(id, fmt.Errorf("something went \xc5wrong"))
+	require.NoError(s.T(), err)
+
+	info, err = s.queue.Status(id)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), info.Finished)
+	assert.Equal(s.T(), config.TaskStatusFailed, info.Status)
+	assert.Equal(s.T(), "something went wrong", *info.Error)
 }
 
 func (s *QueueSuite) TestRequeue() {


### PR DESCRIPTION
## Summary
When introspecting, certain error messages may contain non-UTF8 characters. The database doesn't like non-UTF8 characters. This removes those characters before the error messages are inserted into the database.

## Testing steps

1. Assuming [this yummy PR](https://github.com/content-services/yummy/pull/21) is not integrated into the backend, introspect this repository: https://fixtures.pulpproject.org/rpm-pkglists-updateinfo/
2. Without this PR you will get the error: "invalid byte sequence for encoding \"UTF8\": 0xf4 0x62 0x20 0x28 (SQLSTATE 22021)"
3. With this PR, you should get no error

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
