### PR TITLE
Fixes 3171: add gpg key path for red hat repos

### DIFF
--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -19,6 +19,7 @@ const (
 )
 
 const RedHatOrg = "-1"
+const RedHatGpgKeyPath = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
 
 const IntrospectTimeInterval = time.Hour * 23
 

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1554,6 +1554,8 @@ func (suite *RepositoryConfigSuite) TestBulkDeleteRedhatRepository() {
 	orgID := config.RedHatOrg
 	repoConfigCount := 5
 
+	suite.tx.Exec("TRUNCATE repositories, snapshots, repositories_rpms, repositories_package_groups, repository_configurations")
+
 	err := seeds.SeedRepositoryConfigurations(suite.tx, repoConfigCount, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
 

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1553,8 +1553,9 @@ func (suite *RepositoryConfigSuite) TestBulkDeleteRedhatRepository() {
 	dao := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient)
 	orgID := config.RedHatOrg
 	repoConfigCount := 5
+	existingRepoConfigCount := int64(0)
 
-	suite.tx.Exec("TRUNCATE repositories, snapshots, repositories_rpms, repositories_package_groups, repository_configurations")
+	suite.tx.Model(models.RepositoryConfiguration{}).Where("org_id = ?", config.RedHatOrg).Count(&existingRepoConfigCount)
 
 	err := seeds.SeedRepositoryConfigurations(suite.tx, repoConfigCount, seeds.SeedOptions{OrgID: orgID})
 	assert.Nil(t, err)
@@ -1566,7 +1567,7 @@ func (suite *RepositoryConfigSuite) TestBulkDeleteRedhatRepository() {
 	var found []models.RepositoryConfiguration
 	err = suite.tx.Where("org_id = ?", orgID).Find(&found).Error
 	assert.NoError(t, err)
-	assert.Len(t, found, repoConfigCount)
+	assert.Len(t, found, repoConfigCount+int(existingRepoConfigCount))
 }
 
 func (suite *RepositoryConfigSuite) TestBulkDeleteMultipleNotFound() {

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -186,7 +186,11 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 	var gpgKeyField string
 	if repoConfig.GpgKey != "" {
 		gpgCheck = 1
-		gpgKeyField = fmt.Sprintf("https://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+		if repoConfig.OrgID == config.RedHatOrg {
+			gpgKeyField = config.RedHatGpgKeyPath
+		} else {
+			gpgKeyField = fmt.Sprintf("https://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+		}
 	}
 
 	moduleHotfixes := 0

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -556,6 +556,22 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(repoConfig.OrgID, snapshot.UUID, repoConfig.UUID, host)
 	assert.Error(t, err)
 	assert.Empty(t, repoConfigFile)
+
+	// Test red hat repo gpg key path is correct
+	repoConfigRh := models.RepositoryConfiguration{
+		Name:           "rh repo",
+		OrgID:          config.RedHatOrg,
+		RepositoryUUID: testRepository.UUID,
+		GpgKey:         "gpg key",
+	}
+	err = tx.Create(&repoConfigRh).Error
+	assert.NoError(t, err)
+
+	mockPulpClient.WithContextMock().On("GetContentPath").Return(testContentPath, nil).Once()
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(repoConfigRh.OrgID, snapshot.UUID, repoConfigRh.UUID, host)
+	assert.NoError(t, err)
+	assert.Contains(t, repoConfigFile, repoConfigRh.Name)
+	assert.Contains(t, repoConfigFile, config.RedHatGpgKeyPath)
 }
 
 func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {


### PR DESCRIPTION
## Summary
The repository config file wasn't providing the correct gpg key path for red hat repos. All the red hat repos have the same gpg key path, so this hard codes that value. 

## Testing steps
1. Import red hat repos and create a snapshot
2. Fetch the config.repo file from the `/repositories/:uuid/snapshots/:snap_uuid/config.repo/` endpoint
3. The config.repo file should have the red hat gpg key path

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
