### PR TITLE
Fixes 3144: check for orphan repo versions

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -93,6 +93,7 @@ type SnapshotDao interface {
 	Delete(snapUUID string) error
 	FetchLatestSnapshot(repoConfigUUID string) (api.SnapshotResponse, error)
 	FetchSnapshotsByDateAndRepository(orgID string, request api.ListSnapshotByDateRequest) ([]api.ListSnapshotByDateResponse, error)
+	FetchSnapshotByVersionHref(repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
 	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, host string) (string, error)
 	WithContext(ctx context.Context) SnapshotDao
 	Fetch(uuid string) (api.SnapshotResponse, error)

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -250,6 +250,24 @@ func (sDao *snapshotDaoImpl) FetchLatestSnapshot(repoConfigUUID string) (api.Sna
 	return apiSnap, nil
 }
 
+func (sDao *snapshotDaoImpl) FetchSnapshotByVersionHref(repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error) {
+	var snap models.Snapshot
+	result := sDao.db.
+		Where("snapshots.repository_configuration_uuid = ? AND version_href = ?", repoConfigUUID, versionHref).
+		Order("created_at DESC").
+		Limit(1).
+		Find(&snap)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if snap.UUID == "" {
+		return nil, nil
+	}
+	var apiSnap api.SnapshotResponse
+	snapshotModelToApi(snap, &apiSnap)
+	return &apiSnap, nil
+}
+
 // FetchSnapshotsByDateAndRepository returns a list of snapshots by date.
 func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(orgID string, request api.ListSnapshotByDateRequest) ([]api.ListSnapshotByDateResponse, error) {
 	snaps := []models.Snapshot{}

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -119,6 +119,32 @@ func (_m *MockSnapshotDao) FetchLatestSnapshot(repoConfigUUID string) (api.Snaps
 	return r0, r1
 }
 
+// FetchSnapshotByVersionHref provides a mock function with given fields: repoConfigUUID, versionHref
+func (_m *MockSnapshotDao) FetchSnapshotByVersionHref(repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error) {
+	ret := _m.Called(repoConfigUUID, versionHref)
+
+	var r0 *api.SnapshotResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*api.SnapshotResponse, error)); ok {
+		return rf(repoConfigUUID, versionHref)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *api.SnapshotResponse); ok {
+		r0 = rf(repoConfigUUID, versionHref)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.SnapshotResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(repoConfigUUID, versionHref)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchSnapshotsByDateAndRepository provides a mock function with given fields: orgID, request
 func (_m *MockSnapshotDao) FetchSnapshotsByDateAndRepository(orgID string, request api.ListSnapshotByDateRequest) ([]api.ListSnapshotByDateResponse, error) {
 	ret := _m.Called(orgID, request)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	uuid2 "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 )
@@ -482,25 +483,25 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(response))
-	//target 1
+	// target 1
 	assert.Equal(t, false, response[0].IsAfter)
 	assert.Equal(t, target1.Base.UUID, response[0].Match.UUID)
 	assert.Equal(t, target1.Base.CreatedAt.Day(), response[0].Match.CreatedAt.Day())
 
-	//target 2
+	// target 2
 	assert.Equal(t, true, response[1].IsAfter)
 	assert.Equal(t, target2.Base.UUID, response[1].Match.UUID)
 	assert.Equal(t, target2.Base.CreatedAt.Day(), response[1].Match.CreatedAt.Day())
 
-	//target 3 < RedHat repo before the expected date
+	// target 3 < RedHat repo before the expected date
 	assert.Equal(t, false, response[2].IsAfter)
 	assert.Equal(t, target3.Base.UUID, response[2].Match.UUID)
 	assert.Equal(t, target3.Base.CreatedAt.Day(), response[2].Match.CreatedAt.Day())
 
-	//target 4 < RandomUUID Expect empty state
+	// target 4 < RandomUUID Expect empty state
 	assert.Equal(t, randomUUID.String(), response[3].RepositoryUUID)
 	assert.Equal(t, false, response[3].IsAfter)
-	assert.Empty(t, response[3].Match) //Expect empty struct
+	assert.Empty(t, response[3].Match) // Expect empty struct
 }
 
 func (s *SnapshotsSuite) TestFetchLatestSnapshotNotFound() {
@@ -606,4 +607,21 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 		assert.True(t, daoError.NotFound)
 	}
 	assert.Empty(t, repoConfigFile)
+}
+
+func (s *SnapshotsSuite) TestFetchSnapshotByVersionHref() {
+	t := s.T()
+	tx := s.tx
+
+	sDao := snapshotDaoImpl{db: tx}
+	repoConfig := s.createRepository()
+	snapshot := s.createSnapshot(repoConfig)
+
+	snap, err := sDao.FetchSnapshotByVersionHref(repoConfig.UUID, snapshot.VersionHref)
+	require.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	snap, err = sDao.FetchSnapshotByVersionHref(repoConfig.UUID, "Not areal href")
+	require.NoError(t, err)
+	assert.Nil(t, snap)
 }


### PR DESCRIPTION
## Summary

during snapshot, and if one is found use that to continue.  

This helps the situation where some issue occurs and the pulp repo sync is successful, but the task dies, panics, or the publication creation fails.  If the repo hasn't changed at the next snapshot time, no new snapshot gets created.  With this change, the previously created repo version is re-used if there isn't a new one during the sync.

## Testing steps

I couldn't figure out a way to simulate this, so instead we can manually clear the db.  On a fresh empty db:

1)  create  a repo with snapshotting enabled.  Wait for it to finish snapshotting
2) within the database delete the snapshot:    `make db-cli-connect`
```
 delete * from snapshots;
```
3) trigger the snapshot manually:

```
POST http://localhost:8000/api/content-sources/v1.0/repositories/659bc4b3-b1a8-4d02-8d73-f36fe2b47d00/snapshot/
```

4) Check the db and notice a new snapshot was created, pointing to the old repo version (1)
```
# select version_href from snapshots;
```
```
                                        version_href                                         
---------------------------------------------------------------------------------------------
 /pulp/399c928e/api/v3/repositories/rpm/rpm/018cd9dd-d4bf-7683-9610-8299e4eccfd6/versions/1/

```
## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
