### PR TITLE
Fixes 3170: use x-forward-host hdr for repo config

### DIFF
--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -126,7 +126,12 @@ func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 	uuid := c.Param("uuid")
 	snapshotUUID := c.Param("snapshot_uuid")
 
-	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, c.Request().Host)
+	host := c.Request().Header.Get("x-forwarded-host")
+	if host == "" {
+		host = c.Request().Host
+	}
+
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, host)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
 	}

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -164,7 +164,7 @@ func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s/config.repo", api.FullRootPath(), repoUUID, snapUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
-	req.Header.Set("Referer", refererHeader)
+	req.Header.Set("x-forward-host", refererHeader)
 
 	code, body, err := suite.serveSnapshotsRouter(req)
 	assert.Nil(t, err)

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -157,14 +157,14 @@ func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {
 	repoUUID := uuid.NewString()
 	snapUUID := uuid.NewString()
 	repoConfigFile := "file"
-	refererHeader := "example.com"
+	refererHeader := "anotherhost.example.com"
 
 	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", orgID, snapUUID, repoUUID, refererHeader).Return(repoConfigFile, nil).Once()
 
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s/config.repo", api.FullRootPath(), repoUUID, snapUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
-	req.Header.Set("x-forward-host", refererHeader)
+	req.Header.Set("x-forwarded-host", refererHeader)
 
 	code, body, err := suite.serveSnapshotsRouter(req)
 	assert.Nil(t, err)


### PR DESCRIPTION
## Summary

To properly show the gpg key url from the gateway

## Testing steps

1.  create a repo with a gpg key set, and snapshotting enabled
2.  fetch your repos list to get uuids for the repo and latest snapshots: GET http://localhost:8000/api/content-sources/v1/repositories/
3.    fetch this url: http://localhost:8000/api/content-sources/v1/repositories/60dd106b-d08e-436a-bf34-53180713d4bc/snapshots/8a68fc2d-c8eb-4046-8c56-df44603f8206/config.repo

replacing the UUIDs for the repo & snapshot UUID. Notice the URL is likely https://localhost:8000/.

4.  now fetch the url with the header:   'X-Forwarded-Host: example.com'
you should see the url change to  https://example.com/

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
