### PR TITLE
Fixes 3402: pass remote href on sync

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -13,6 +13,8 @@ IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
 IQE_FILTER_EXPRESSION="not test_introspection_of_persistent_user"  # This is the value passed to pytest -k
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
+COMPONENTS_W_RESOURCES="pulp"
+
 # Only deploy one small red hat repo
 EXTRA_DEPLOY_ARGS="--set-parameter content-sources-backend/OPTIONS_REPOSITORY_IMPORT_FILTER=small"
 

--- a/pkg/tasks/repository_snapshot.go
+++ b/pkg/tasks/repository_snapshot.go
@@ -107,7 +107,7 @@ func (sr *SnapshotRepository) Run() (err error) {
 		return err
 	}
 
-	versionHref, err := sr.syncRepository(repoHref)
+	versionHref, err := sr.syncRepository(repoHref, remoteHref)
 	if err != nil {
 		return err
 	}
@@ -250,9 +250,9 @@ func (sr *SnapshotRepository) UpdatePayload() error {
 	return nil
 }
 
-func (sr *SnapshotRepository) syncRepository(repoHref string) (*string, error) {
+func (sr *SnapshotRepository) syncRepository(repoHref string, remoteHref string) (*string, error) {
 	if sr.payload.SyncTaskHref == nil {
-		syncTaskHref, err := sr.pulpClient.SyncRpmRepository(repoHref, nil)
+		syncTaskHref, err := sr.pulpClient.SyncRpmRepository(repoHref, &remoteHref)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tasks/repository_snapshot_test.go
+++ b/pkg/tasks/repository_snapshot_test.go
@@ -59,7 +59,7 @@ func (s *SnapshotSuite) TestSnapshotFull() {
 	repoResp := s.mockRepoCreate(repoConfig, remoteHref, false)
 
 	taskHref := "SyncTaskHref"
-	s.MockPulpClient.On("SyncRpmRepository", *(repoResp.PulpHref), (*string)(nil)).Return(taskHref, nil)
+	s.MockPulpClient.On("SyncRpmRepository", *(repoResp.PulpHref), &remoteHref).Return(taskHref, nil)
 	s.MockPulpClient.On("LookupOrCreateDomain", domainName).Return("found", nil)
 	s.MockPulpClient.On("UpdateDomainIfNeeded", domainName).Return(nil)
 
@@ -147,7 +147,7 @@ func (s *SnapshotSuite) TestSnapshotResync() {
 	taskHref := "SyncTaskHref"
 	s.MockPulpClient.On("LookupOrCreateDomain", domainName).Return("found", nil)
 	s.MockPulpClient.On("UpdateDomainIfNeeded", domainName).Return(nil)
-	s.MockPulpClient.On("SyncRpmRepository", *(repoResp.PulpHref), (*string)(nil)).Return(taskHref, nil)
+	s.MockPulpClient.On("SyncRpmRepository", *(repoResp.PulpHref), &remoteHref).Return(taskHref, nil)
 
 	_, syncTask := s.mockSync(taskHref, false)
 


### PR DESCRIPTION
## Summary

pass the remote href when doing a sync, as pulp has an rbac bug preventing us from using the remote on the repo

## Testing steps

integration tests pass

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
