### PR TITLE
Fixes 2983: add api for searching snap comps groups

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -383,7 +383,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "A comma separated list of uuids to control api response.",
+                        "description": "A comma separated list of UUIDs to control api response.",
                         "name": "uuid",
                         "in": "query"
                     },
@@ -1710,6 +1710,144 @@ const docTemplate = `{
                 }
             }
         },
+        "/snapshots/environments/names": {
+            "post": {
+                "description": "This enables users to search for environments in a given list of snapshots.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "snapshots",
+                    "environments"
+                ],
+                "summary": "Search environments within snapshots",
+                "operationId": "searchSnapshotEnvironments",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SnapshotSearchRpmRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.SearchEnvironmentResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/snapshots/package_groups/names": {
+            "post": {
+                "description": "This enables users to search for package groups in a given list of snapshots.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "snapshots",
+                    "environments"
+                ],
+                "summary": "Search package groups within snapshots",
+                "operationId": "searchSnapshotPackageGroups",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SnapshotSearchRpmRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.SearchPackageGroupResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/snapshots/rpms/names": {
             "post": {
                 "description": "This enables users to search for RPMs (Red Hat Package Manager) in a given list of snapshots.",
@@ -2429,7 +2567,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "repository_uuids": {
-                    "description": "Repository uuids to find snapshots for",
+                    "description": "Repository UUIDs to find snapshots for",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -2990,6 +3128,10 @@ const docTemplate = `{
                 "environment_name": {
                     "description": "Environment found",
                     "type": "string"
+                },
+                "id": {
+                    "description": "ID of the environment found",
+                    "type": "string"
                 }
             }
         },
@@ -3000,8 +3142,12 @@ const docTemplate = `{
                     "description": "Description of the package group found",
                     "type": "string"
                 },
+                "id": {
+                    "description": "Package group ID",
+                    "type": "string"
+                },
                 "package_group_name": {
-                    "description": "Package group found",
+                    "description": "Name of package group found",
                     "type": "string"
                 },
                 "package_list": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -101,7 +101,7 @@
                         "type": "string"
                     },
                     "repository_uuids": {
-                        "description": "Repository uuids to find snapshots for",
+                        "description": "Repository UUIDs to find snapshots for",
                         "items": {
                             "type": "string"
                         },
@@ -645,6 +645,10 @@
                     "environment_name": {
                         "description": "Environment found",
                         "type": "string"
+                    },
+                    "id": {
+                        "description": "ID of the environment found",
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -655,8 +659,12 @@
                         "description": "Description of the package group found",
                         "type": "string"
                     },
+                    "id": {
+                        "description": "Package group ID",
+                        "type": "string"
+                    },
                     "package_group_name": {
-                        "description": "Package group found",
+                        "description": "Name of package group found",
                         "type": "string"
                     },
                     "package_list": {
@@ -1489,7 +1497,7 @@
                         }
                     },
                     {
-                        "description": "A comma separated list of uuids to control api response.",
+                        "description": "A comma separated list of UUIDs to control api response.",
                         "in": "query",
                         "name": "uuid",
                         "schema": {
@@ -3219,6 +3227,182 @@
                 "tags": [
                     "repositories",
                     "rpms"
+                ]
+            }
+        },
+        "/snapshots/environments/names": {
+            "post": {
+                "description": "This enables users to search for environments in a given list of snapshots.",
+                "operationId": "searchSnapshotEnvironments",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.SnapshotSearchRpmRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.SearchEnvironmentResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Search environments within snapshots",
+                "tags": [
+                    "snapshots",
+                    "environments"
+                ]
+            }
+        },
+        "/snapshots/package_groups/names": {
+            "post": {
+                "description": "This enables users to search for package groups in a given list of snapshots.",
+                "operationId": "searchSnapshotPackageGroups",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.SnapshotSearchRpmRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.SearchPackageGroupResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Search package groups within snapshots",
+                "tags": [
+                    "snapshots",
+                    "environments"
                 ]
             }
         },

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0
-	github.com/content-services/tang v0.0.1
+	github.com/content-services/tang v0.0.3
 	github.com/content-services/yummy v1.0.10
 	github.com/getkin/kin-openapi v0.122.0
 	github.com/go-openapi/spec v0.20.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/cloudevents/sdk-go/v2 v2.14.0 h1:Nrob4FwVgi5L4tV9lhjzZcjYqFVyJzsA56Cw
 github.com/cloudevents/sdk-go/v2 v2.14.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/content-services/tang v0.0.1 h1:3d+qxpnKZfmLU1ESOOp+kwrWt9gxH2a+Y265p5/VUW0=
-github.com/content-services/tang v0.0.1/go.mod h1:sduORj8RJTosdat4n10MRCQknm1JtygqijLtOJTCYLI=
+github.com/content-services/tang v0.0.3 h1:tbhm+sTYEh0BzQFD5h3J2jc3ImDSuhSTjdod2fJEoRQ=
+github.com/content-services/tang v0.0.3/go.mod h1:92WTS+mPTjoMgHYBx+d3Ea6vRavyXP2tH4XnDs3twF4=
 github.com/content-services/yummy v1.0.10 h1:8cyg/43DDmlcVqXEFrYzhmEcwgbWgJ7UMBg3fbZvFzc=
 github.com/content-services/yummy v1.0.10/go.mod h1:OC2EOi+lc6p6NJTJy7z8Hu8Hx1MBy+NuBRigfCJ/ivA=
 github.com/content-services/zest/release/v2024 v2024.1.1706018763 h1:TrFMpNk1SaTgxmdh7PggnEGmAZZoKS7oOhqSeNlkxf0=

--- a/pkg/api/repository_environments.go
+++ b/pkg/api/repository_environments.go
@@ -16,6 +16,7 @@ type RepositoryEnvironmentCollectionResponse struct {
 type SearchEnvironmentResponse struct {
 	EnvironmentName string `json:"environment_name"` // Environment found
 	Description     string `json:"description"`      // Description of the environment found
+	ID              string `json:"id"`               // ID of the environment found
 }
 
 // SetMetadata Map metadata to the collection.

--- a/pkg/api/repository_package_groups.go
+++ b/pkg/api/repository_package_groups.go
@@ -17,7 +17,8 @@ type RepositoryPackageGroupCollectionResponse struct {
 }
 
 type SearchPackageGroupResponse struct {
-	PackageGroupName string         `json:"package_group_name"`            // Package group found
+	PackageGroupName string         `json:"package_group_name"`            // Name of package group found
+	ID               string         `json:"id"`                            // Package group ID
 	Description      string         `json:"description"`                   // Description of the package group found
 	PackageList      pq.StringArray `json:"package_list" gorm:"type:text"` // Package list of the package group found
 }

--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -15,7 +15,7 @@ type SnapshotResponse struct {
 }
 
 type ListSnapshotByDateRequest struct {
-	RepositoryUUIDS []string `json:"repository_uuids"` // Repository uuids to find snapshots for
+	RepositoryUUIDS []string `json:"repository_uuids"` // Repository UUIDs to find snapshots for
 	Date            string   `json:"date"`             // Exact date to search by.
 }
 

--- a/pkg/dao/environments_mock.go
+++ b/pkg/dao/environments_mock.go
@@ -3,7 +3,10 @@
 package dao
 
 import (
+	context "context"
+
 	api "github.com/content-services/content-sources-backend/pkg/api"
+
 	mock "github.com/stretchr/testify/mock"
 
 	yum "github.com/content-services/yummy/pkg/yum"
@@ -102,6 +105,32 @@ func (_m *MockEnvironmentDao) Search(orgID string, request api.ContentUnitSearch
 
 	if rf, ok := ret.Get(1).(func(string, api.ContentUnitSearchRequest) error); ok {
 		r1 = rf(orgID, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SearchSnapshotEnvironments provides a mock function with given fields: ctx, orgId, request
+func (_m *MockEnvironmentDao) SearchSnapshotEnvironments(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchEnvironmentResponse, error) {
+	ret := _m.Called(ctx, orgId, request)
+
+	var r0 []api.SearchEnvironmentResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, api.SnapshotSearchRpmRequest) ([]api.SearchEnvironmentResponse, error)); ok {
+		return rf(ctx, orgId, request)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, api.SnapshotSearchRpmRequest) []api.SearchEnvironmentResponse); ok {
+		r0 = rf(ctx, orgId, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.SearchEnvironmentResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, api.SnapshotSearchRpmRequest) error); ok {
+		r1 = rf(ctx, orgId, request)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -140,6 +140,7 @@ type PackageGroupDao interface {
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchPackageGroupResponse, error)
 	InsertForRepository(repoUuid string, pkgGroups []yum.PackageGroup) (int64, error)
 	OrphanCleanup() error
+	SearchSnapshotPackageGroups(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error)
 }
 
 //go:generate mockery --name EnvironmentDao --filename environments_mock.go --inpackage
@@ -148,6 +149,7 @@ type EnvironmentDao interface {
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchEnvironmentResponse, error)
 	InsertForRepository(repoUuid string, environments []yum.Environment) (int64, error)
 	OrphanCleanup() error
+	SearchSnapshotEnvironments(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchEnvironmentResponse, error)
 }
 
 //go:generate mockery --name TemplateDao --filename templates_mock.go --inpackage

--- a/pkg/dao/package_groups_mock.go
+++ b/pkg/dao/package_groups_mock.go
@@ -3,7 +3,10 @@
 package dao
 
 import (
+	context "context"
+
 	api "github.com/content-services/content-sources-backend/pkg/api"
+
 	mock "github.com/stretchr/testify/mock"
 
 	yum "github.com/content-services/yummy/pkg/yum"
@@ -102,6 +105,32 @@ func (_m *MockPackageGroupDao) Search(orgID string, request api.ContentUnitSearc
 
 	if rf, ok := ret.Get(1).(func(string, api.ContentUnitSearchRequest) error); ok {
 		r1 = rf(orgID, request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SearchSnapshotPackageGroups provides a mock function with given fields: ctx, orgId, request
+func (_m *MockPackageGroupDao) SearchSnapshotPackageGroups(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error) {
+	ret := _m.Called(ctx, orgId, request)
+
+	var r0 []api.SearchPackageGroupResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error)); ok {
+		return rf(ctx, orgId, request)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, api.SnapshotSearchRpmRequest) []api.SearchPackageGroupResponse); ok {
+		r0 = rf(ctx, orgId, request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.SearchPackageGroupResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, api.SnapshotSearchRpmRequest) error); ok {
+		r1 = rf(ctx, orgId, request)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -392,7 +392,7 @@ func (r *rpmDaoImpl) SearchSnapshotRpms(ctx context.Context, orgId string, reque
 	pulpHrefs := []string{}
 	res := readableSnapshots(r.db, orgId).Where("snapshots.UUID in ?", UuidifyStrings(request.UUIDs)).Pluck("version_href", &pulpHrefs)
 	if res.Error != nil {
-		return response, fmt.Errorf("failed to query the db for snapshots %w", res.Error)
+		return response, fmt.Errorf("failed to query the db for snapshots: %w", res.Error)
 	}
 	if config.Tang == nil {
 		return response, fmt.Errorf("no tang configuration present")
@@ -404,7 +404,7 @@ func (r *rpmDaoImpl) SearchSnapshotRpms(ctx context.Context, orgId string, reque
 
 	pkgs, err := (*config.Tang).RpmRepositoryVersionPackageSearch(ctx, pulpHrefs, request.Search, *request.Limit)
 	if err != nil {
-		return response, fmt.Errorf("error querying packages in snapshots %w", err)
+		return response, fmt.Errorf("error querying packages in snapshots: %w", err)
 	}
 	for _, pkg := range pkgs {
 		response = append(response, api.SearchRpmResponse{

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -901,11 +901,11 @@ func TestFilteredConvert(t *testing.T) {
 	assert.Equal(t, expected[0].Summary, givenYumPackages[0].Summary)
 }
 
-func (s *RpmSuite) mockTangy() (*tangy.MockTangy, *tangy.Tangy) {
+func mockTangy(t *testing.T) (*tangy.MockTangy, *tangy.Tangy) {
 	originalTangy := config.Tang
 	var mockTangy *tangy.MockTangy
 	var realTangy tangy.Tangy
-	mockTangy = tangy.NewMockTangy(s.T())
+	mockTangy = tangy.NewMockTangy(t)
 	realTangy = mockTangy
 	config.Tang = &realTangy
 	return mockTangy, originalTangy
@@ -913,7 +913,7 @@ func (s *RpmSuite) mockTangy() (*tangy.MockTangy, *tangy.Tangy) {
 
 func (s *RpmSuite) TestSearchRpmsForSnapshots() {
 	orgId := seeds.RandomOrgId()
-	mTangy, origTangy := s.mockTangy()
+	mTangy, origTangy := mockTangy(s.T())
 	defer func() { config.Tang = origTangy }()
 	ctx := context.Background()
 

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -77,8 +77,8 @@ func RegisterRoutes(engine *echo.Echo) {
 		RegisterAdminTaskRoutes(group, daoReg)
 		RegisterFeaturesRoutes(group)
 		RegisterPublicRepositoriesRoutes(group, daoReg)
-		RegisterRepositoryPackageGroupRoutes(group, daoReg)
-		RegisterRepositoryEnvironmentRoutes(group, daoReg)
+		RegisterPackageGroupRoutes(group, daoReg)
+		RegisterEnvironmentRoutes(group, daoReg)
 		RegisterTemplateRoutes(group, daoReg, &taskClient)
 	}
 

--- a/pkg/handler/features_test.go
+++ b/pkg/handler/features_test.go
@@ -63,6 +63,9 @@ type FeatureTestCase struct {
 
 func TestFeatures(t *testing.T) {
 	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.AdminTasks.Enabled = true
+	defer resetFeatures()
+
 	path := fmt.Sprintf("%s/features/", api.FullRootPath())
 	req, _ := http.NewRequest("GET", path, nil)
 	user := identity.Identity{

--- a/pkg/handler/package_groups.go
+++ b/pkg/handler/package_groups.go
@@ -8,19 +8,21 @@ import (
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/rbac"
 	"github.com/labstack/echo/v4"
+	"github.com/openlyinc/pointy"
 )
 
 type RepositoryPackageGroupHandler struct {
 	Dao dao.DaoRegistry
 }
 
-func RegisterRepositoryPackageGroupRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
+func RegisterPackageGroupRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
 	rh := RepositoryPackageGroupHandler{
 		Dao: *rDao,
 	}
 
 	addRoute(engine, http.MethodGet, "/repositories/:uuid/package_groups", rh.listRepositoriesPackageGroups, rbac.RbacVerbRead)
 	addRoute(engine, http.MethodPost, "/package_groups/names", rh.searchPackageGroupByName, rbac.RbacVerbRead)
+	addRoute(engine, http.MethodPost, "/snapshots/package_groups/names", rh.searchSnapshotPackageGroups, rbac.RbacVerbRead)
 }
 
 // searchPackageGroupByName godoc
@@ -89,4 +91,43 @@ func (rh *RepositoryPackageGroupHandler) listRepositoriesPackageGroups(c echo.Co
 	}
 
 	return c.JSON(200, setCollectionResponseMetadata(&apiResponse, c, total))
+}
+
+// searchSnapshotPackageGroups godoc
+// @Summary      Search package groups within snapshots
+// @ID           searchSnapshotPackageGroups
+// @Description  This enables users to search for package groups in a given list of snapshots.
+// @Tags         snapshots,environments
+// @Accept       json
+// @Produce      json
+// @Param        body  body   api.SnapshotSearchRpmRequest  true  "request body"
+// @Success      200 {object} []api.SearchPackageGroupResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      401 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      415 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /snapshots/package_groups/names [post]
+func (rh *RepositoryPackageGroupHandler) searchSnapshotPackageGroups(c echo.Context) error {
+	_, orgId := getAccountIdOrgId(c)
+	dataInput := api.SnapshotSearchRpmRequest{}
+
+	var err error
+	err = CheckSnapshotAccessible(c.Request().Context())
+	if err != nil {
+		return err
+	}
+
+	if err = c.Bind(&dataInput); err != nil {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
+	}
+	if dataInput.Limit == nil || *dataInput.Limit > api.SearchRpmRequestLimitDefault {
+		dataInput.Limit = pointy.Pointer(api.SearchRpmRequestLimitDefault)
+	}
+
+	resp, err := rh.Dao.PackageGroup.SearchSnapshotPackageGroups(c.Request().Context(), orgId, dataInput)
+	if err != nil {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching package groups", err.Error())
+	}
+	return c.JSON(200, resp)
 }

--- a/pkg/handler/package_groups_test.go
+++ b/pkg/handler/package_groups_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -61,7 +62,7 @@ func (suite *PackageGroupSuite) servePackageGroupsRouter(req *http.Request) (int
 	rh := RepositoryPackageGroupHandler{
 		Dao: *suite.dao.ToDaoRegistry(),
 	}
-	RegisterRepositoryPackageGroupRoutes(pathPrefix, &rh.Dao)
+	RegisterPackageGroupRoutes(pathPrefix, &rh.Dao)
 
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
@@ -82,7 +83,7 @@ func (suite *PackageGroupSuite) TestRegisterRepositoryPackageGroupRoutes() {
 		Dao: *suite.dao.ToDaoRegistry(),
 	}
 	assert.NotPanics(t, func() {
-		RegisterRepositoryPackageGroupRoutes(pathPrefix, &rh.Dao)
+		RegisterPackageGroupRoutes(pathPrefix, &rh.Dao)
 	})
 }
 
@@ -341,7 +342,7 @@ func (suite *PackageGroupSuite) TestSearchPackageGroupByName() {
 			},
 			Expected: TestCaseExpected{
 				Code: http.StatusOK,
-				Body: "[{\"package_group_name\":\"demo-1\",\"description\":\"Package group demo 1\",\"package_list\":[\"Package 1\"]},{\"package_group_name\":\"demo-2\",\"description\":\"Package group demo 2\",\"package_list\":[\"Package 2\"]},{\"package_group_name\":\"demo-3\",\"description\":\"Package group demo 3\",\"package_list\":[\"Package 3\"]}]\n",
+				Body: "[{\"package_group_name\":\"demo-1\",\"id\":\"demo-1\",\"description\":\"Package group demo 1\",\"package_list\":[\"Package 1\"]},{\"package_group_name\":\"demo-2\",\"id\":\"demo-2\",\"description\":\"Package group demo 2\",\"package_list\":[\"Package 2\"]},{\"package_group_name\":\"demo-3\",\"id\":\"demo-3\",\"description\":\"Package group demo 3\",\"package_list\":[\"Package 3\"]}]\n",
 			},
 		},
 		{
@@ -382,16 +383,19 @@ func (suite *PackageGroupSuite) TestSearchPackageGroupByName() {
 					Return([]api.SearchPackageGroupResponse{
 						{
 							PackageGroupName: "demo-1",
+							ID:               "demo-1",
 							Description:      "Package group demo 1",
 							PackageList:      []string{"Package 1"},
 						},
 						{
 							PackageGroupName: "demo-2",
+							ID:               "demo-2",
 							Description:      "Package group demo 2",
 							PackageList:      []string{"Package 2"},
 						},
 						{
 							PackageGroupName: "demo-3",
+							ID:               "demo-3",
 							Description:      "Package group demo 3",
 							PackageList:      []string{"Package 3"},
 						},
@@ -407,6 +411,132 @@ func (suite *PackageGroupSuite) TestSearchPackageGroupByName() {
 				bodyRequest.Limit = pointy.Int(api.ContentUnitSearchRequestLimitDefault)
 				require.NoError(t, err)
 				suite.dao.PackageGroup.On("Search", test_handler.MockOrgId, bodyRequest).
+					Return(nil, echo.NewHTTPError(http.StatusInternalServerError, "must contain at least 1 URL or 1 UUID"))
+			}
+		}
+
+		var bodyRequest io.Reader
+		if testCase.Given.Body == "" {
+			bodyRequest = nil
+		} else {
+			bodyRequest = strings.NewReader(testCase.Given.Body)
+		}
+
+		// Prepare request
+		req := httptest.NewRequest(testCase.Given.Method, path, bodyRequest)
+		req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Execute the request
+		code, body, err := suite.servePackageGroupsRouter(req)
+
+		// Check results
+		assert.Equal(t, testCase.Expected.Code, code)
+		require.NoError(t, err)
+		assert.Equal(t, testCase.Expected.Body, string(body))
+	}
+}
+
+func (suite *PackageGroupSuite) TestSearchSnapshotPackageGroupByName() {
+	t := suite.T()
+
+	config.Load()
+	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.Snapshots.Accounts = &[]string{test_handler.MockAccountNumber}
+	defer resetFeatures()
+
+	type TestCaseExpected struct {
+		Code int
+		Body string
+	}
+	type TestCaseGiven struct {
+		Method string
+		Body   string
+	}
+	type TestCase struct {
+		Name     string
+		Given    TestCaseGiven
+		Expected TestCaseExpected
+	}
+
+	var testCases []TestCase = []TestCase{
+		{
+			Name: "Success scenario",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				Body:   `{"uuids":["abcde"],"search":"demo","limit":50}`,
+			},
+			Expected: TestCaseExpected{
+				Code: http.StatusOK,
+				Body: "[{\"package_group_name\":\"demo-1\",\"id\":\"demo-1\",\"description\":\"Package group demo 1\",\"package_list\":[\"Package 1\"]},{\"package_group_name\":\"demo-2\",\"id\":\"demo-2\",\"description\":\"Package group demo 2\",\"package_list\":[\"Package 2\"]},{\"package_group_name\":\"demo-3\",\"id\":\"demo-3\",\"description\":\"Package group demo 3\",\"package_list\":[\"Package 3\"]}]\n",
+			},
+		},
+		{
+			Name: "Evoke a StatusBadRequest response",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				Body:   "{",
+			},
+			Expected: TestCaseExpected{
+				Code: http.StatusBadRequest,
+				Body: "{\"errors\":[{\"status\":400,\"title\":\"Error binding parameters\",\"detail\":\"code=400, message=unexpected EOF, internal=unexpected EOF\"}]}\n",
+			},
+		},
+		{
+			Name: "Evoke a StatusInternalServerError response",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				Body:   `{"search":"demo"}`,
+			},
+			Expected: TestCaseExpected{
+				Code: http.StatusInternalServerError,
+				Body: "{\"errors\":[{\"status\":500,\"title\":\"Error searching package groups\",\"detail\":\"code=500, message=must contain at least 1 URL or 1 UUID\"}]}\n",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+
+		path := fmt.Sprintf("%s/snapshots/package_groups/names", api.FullRootPath())
+		switch {
+		case testCase.Expected.Code >= 200 && testCase.Expected.Code < 300:
+			{
+				var bodyRequest api.SnapshotSearchRpmRequest
+				err := json.Unmarshal([]byte(testCase.Given.Body), &bodyRequest)
+				require.NoError(t, err)
+				suite.dao.PackageGroup.On("SearchSnapshotPackageGroups", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId, bodyRequest).
+					Return([]api.SearchPackageGroupResponse{
+						{
+							PackageGroupName: "demo-1",
+							ID:               "demo-1",
+							Description:      "Package group demo 1",
+							PackageList:      []string{"Package 1"},
+						},
+						{
+							PackageGroupName: "demo-2",
+							ID:               "demo-2",
+							Description:      "Package group demo 2",
+							PackageList:      []string{"Package 2"},
+						},
+						{
+							PackageGroupName: "demo-3",
+							ID:               "demo-3",
+							Description:      "Package group demo 3",
+							PackageList:      []string{"Package 3"},
+						},
+					}, nil)
+			}
+		case testCase.Expected.Code == http.StatusBadRequest:
+			{
+			}
+		case testCase.Expected.Code == http.StatusInternalServerError:
+			{
+				var bodyRequest api.SnapshotSearchRpmRequest
+				err := json.Unmarshal([]byte(testCase.Given.Body), &bodyRequest)
+				bodyRequest.Limit = pointy.Int(api.ContentUnitSearchRequestLimitDefault)
+				require.NoError(t, err)
+				suite.dao.PackageGroup.On("SearchSnapshotPackageGroups", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId, bodyRequest).
 					Return(nil, echo.NewHTTPError(http.StatusInternalServerError, "must contain at least 1 URL or 1 UUID"))
 			}
 		}

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -93,7 +93,7 @@ func getAccountIdOrgId(c echo.Context) (string, string) {
 // @Param		 search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name or URL."
 // @Param		 name query string false "Filter repositories by name."
 // @Param		 url query string false "A comma separated list of URLs to control api response."
-// @Param		 uuid query string false "A comma separated list of uuids to control api response."
+// @Param		 uuid query string false "A comma separated list of UUIDs to control api response."
 // @Param		 sort_by query string false "Sort the response data based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`."
 // @Param        status query string false "A comma separated list of statuses to control api response. Statuses can include `pending`, `valid`, `invalid`."
 // @Param		 origin query string false "A comma separated list of origins to filter api response. Origins can include `red_hat` and `external`."

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -379,6 +379,12 @@ func (suite *ReposSuite) TestFetchNotFound() {
 
 func (suite *ReposSuite) TestCreate() {
 	t := suite.T()
+
+	config.Load()
+	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.Snapshots.Accounts = &[]string{test_handler.MockAccountNumber}
+	defer resetFeatures()
+
 	config.Get().Clients.Pulp.Server = "some-server-address" // This ensures that PulpConfigured returns true
 	repoUuid := "repoUuid"
 	expected := api.RepositoryResponse{
@@ -421,6 +427,7 @@ func (suite *ReposSuite) TestCreate() {
 
 func resetFeatures() {
 	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.AdminTasks.Enabled = true
 	config.Get().Features.Snapshots.Accounts = nil
 	config.Get().Features.Snapshots.Users = nil
 }

--- a/pkg/handler/rpms_test.go
+++ b/pkg/handler/rpms_test.go
@@ -433,7 +433,11 @@ func (suite *RpmSuite) TestSearchRpmByName() {
 func (suite *RpmSuite) TestSearchSnapshotRpmByName() {
 	t := suite.T()
 
+	config.Load()
 	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.Snapshots.Accounts = &[]string{test_handler.MockAccountNumber}
+	defer resetFeatures()
+
 	type TestCaseExpected struct {
 		Code int
 		Body string


### PR DESCRIPTION
## Summary

- ~~Built on this PR: https://github.com/content-services/content-sources-backend/pull/517. Do not merge before this PR has merged.~~
- ~~Waiting for this dependency PR to finish and merge: https://github.com/content-services/tang/pull/3~~
- Adds endpoints to search environments and package groups of snapshots, by name.
- Also fixes issue where ID metadata was not being exposed for package groups and environments. 
- Functionality is the same as the existing searching endpoints for repositories. The only difference is you must send a snapshot UUID in the request body (instead of a repository UUID or URL).

## Testing steps
1. Create a snapshot
2. These two repos are good for testing: https://rverdile.fedorapeople.org/dummy-repos/comps/. So are epel and rh repos.
3. Search package groups by name using `POST snapshots/package_groups/names`
4. Search environments by name using `POST snapshots/environments/names/`
5. Body of the request looks something like `{"uuids":["abcd"],"search":"demo","limit":50}`, where uuid is the uuid of the snapshot.

## Checklist
- [x] Revisit when dependency PRs are finished
- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
