### PR TITLE
Fixes 3423: add arm64 repos

### DIFF
--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -34,5 +34,40 @@
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os",
         "arch": "x86_64",
         "distribution_version": "9"
+    },
+    {
+        "name": "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)",
+        "url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os",
+        "content_label": "ansible-2-for-rhel-8-aarch64-rpms",
+        "arch": "x86_64",
+        "distribution_version": "8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 8 for ARM 64 - AppStream (RPMs)",
+        "url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os",
+        "content_label": "rhel-8-for-aarch64-appstream-rpms",
+        "arch": "aarch64",
+        "distribution_version": "8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 8 for ARM 64 - BaseOS (RPMs)",
+        "content_label": "rhel-8-for-aarch64-baseos-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os",
+        "arch": "aarch64",
+        "distribution_version": "8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9 for ARM 64 - AppStream (RPMs)",
+        "content_label": "rhel-8-for-aarch64-appstream-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os",
+        "arch": "aarch64",
+        "distribution_version": "9"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9 for ARM 64 - BaseOS (RPMs)",
+        "content_label": "rhel-9-for-aarch64-baseos-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os",
+        "arch": "aarch64",
+        "distribution_version": "9"
     }
 ]


### PR DESCRIPTION
## Summary

adds the base arm64 repos 

## Testing steps

configure a cdn cert in the config if you have one, if you don't reach out to me to get one.
load in the repos:

`make  repos-import`
trigger the sync:

```go run cmd/external-repos/main.go nightly-jobs```

wait a while
make sure that all repos have snapshots.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
