### PR TITLE
Refs 3423: fix arm64 repo arch

### DIFF
--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -39,7 +39,7 @@
         "name": "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)",
         "url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os",
         "content_label": "ansible-2-for-rhel-8-aarch64-rpms",
-        "arch": "x86_64",
+        "arch": "aarch64",
         "distribution_version": "8"
     },
     {


### PR DESCRIPTION
## Summary

This fixes an incorrect arch i had added.  

## Testing steps

Check out master, run `make repos-import`   notice the "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)" repo has an arch of x86_64. 

Checkout this PR, run `make repos-import` again, notice its not correct

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
