### PR TITLE
Build: switch to zest v2024 and new pulp-ubi

### DIFF
--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       timeout: 3s
 
   migration_service:
-    image: "quay.io/cloudservices/pulp-rpm-ubi:latest"
+    image: "quay.io/cloudservices/pulp-ubi:latest"
     depends_on:
       postgres:
         condition: service_healthy
@@ -32,7 +32,7 @@ services:
       - "pulp:/var/lib/pulp"      
 
   set_init_password_service:
-    image:  "quay.io/cloudservices/pulp-rpm-ubi:latest"
+    image:  "quay.io/cloudservices/pulp-ubi:latest"
     command: set_init_password.sh
     depends_on:
       migration_service:
@@ -53,7 +53,7 @@ services:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
 
   pulp_api:
-    image: "quay.io/cloudservices/pulp-rpm-ubi:latest"
+    image: "quay.io/cloudservices/pulp-ubi:latest"
     deploy:
       replicas: 1
     command: [ 'pulp-api' ]
@@ -74,7 +74,7 @@ services:
     restart: always
 
   pulp_content:
-    image: "quay.io/cloudservices/pulp-rpm-ubi:latest"
+    image: "quay.io/cloudservices/pulp-ubi:latest"
     deploy:
       replicas: 1
     command: [ 'pulp-content' ]
@@ -109,7 +109,7 @@ services:
     restart: always
 
   pulp_worker:
-    image: "quay.io/cloudservices/pulp-rpm-ubi:latest"
+    image: "quay.io/cloudservices/pulp-ubi:latest"
     deploy:
       replicas: 1
     command: [ 'pulp-worker' ]

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.31.0
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.14.0
 	github.com/cloudevents/sdk-go/v2 v2.14.0
-	github.com/content-services/zest/release/v2023 v2023.12.1703173361
+	github.com/content-services/zest/release/v2024 v2024.1.1705669831
 	github.com/getsentry/sentry-go v0.26.0
 	github.com/jackc/pgconn v1.14.1
 	github.com/jackc/pgx/v4 v4.18.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/content-services/tang v0.0.1 h1:3d+qxpnKZfmLU1ESOOp+kwrWt9gxH2a+Y265p
 github.com/content-services/tang v0.0.1/go.mod h1:sduORj8RJTosdat4n10MRCQknm1JtygqijLtOJTCYLI=
 github.com/content-services/yummy v1.0.10 h1:8cyg/43DDmlcVqXEFrYzhmEcwgbWgJ7UMBg3fbZvFzc=
 github.com/content-services/yummy v1.0.10/go.mod h1:OC2EOi+lc6p6NJTJy7z8Hu8Hx1MBy+NuBRigfCJ/ivA=
-github.com/content-services/zest/release/v2023 v2023.12.1703173361 h1:yLP81i6FPNX1b0uJvBz19RyOu5kr/wuEwMgwI4ihBU0=
-github.com/content-services/zest/release/v2023 v2023.12.1703173361/go.mod h1:9pesd98rUBOqg1z2UL65NA1+zZQRcFJY3VIdimAJxL8=
+github.com/content-services/zest/release/v2024 v2024.1.1705669831 h1:KzH9RIxlx6H7Ckjt2HYa5uggtilL7CiogdWGZw3Xlxg=
+github.com/content-services/zest/release/v2024 v2024.1.1705669831/go.mod h1:UwNlzoIpFWKjR3yPnm+l4GtShPYLhWy9Rt+jmFM5W/U=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/pkg/api/admin_task.go
+++ b/pkg/api/admin_task.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 )
 
 // AdminTaskInfoResponse holds data returned by a admin tasks API response

--- a/pkg/dao/admin_tasks_test.go
+++ b/pkg/dao/admin_tasks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
 	mockExt "github.com/content-services/content-sources-backend/pkg/test/mocks/mock_external"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/google/uuid"
 	uuid2 "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/pkg/pulp_client/client.go
+++ b/pkg/pulp_client/client.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/cache"
 	"github.com/content-services/content-sources-backend/pkg/config"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 )
 
 type pulpDaoImpl struct {

--- a/pkg/pulp_client/content_guard.go
+++ b/pkg/pulp_client/content_guard.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/openlyinc/pointy"
 )
 

--- a/pkg/pulp_client/domains.go
+++ b/pkg/pulp_client/domains.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -3,7 +3,7 @@ package pulp_client
 import (
 	"context"
 
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 )
 
 //go:generate mockery  --name PulpGlobalClient --filename pulp_global_client_mock.go --inpackage

--- a/pkg/pulp_client/orphans.go
+++ b/pkg/pulp_client/orphans.go
@@ -1,6 +1,6 @@
 package pulp_client
 
-import zest "github.com/content-services/zest/release/v2023"
+import zest "github.com/content-services/zest/release/v2024"
 
 // GetTask Fetch a pulp task
 func (r pulpDaoImpl) OrphanCleanup() (string, error) {

--- a/pkg/pulp_client/pulp_client_mock.go
+++ b/pkg/pulp_client/pulp_client_mock.go
@@ -5,7 +5,7 @@ package pulp_client
 import (
 	context "context"
 
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/pkg/pulp_client/pulp_global_client_mock.go
+++ b/pkg/pulp_client/pulp_global_client_mock.go
@@ -3,7 +3,7 @@
 package pulp_client
 
 import (
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/pkg/pulp_client/rpm_distributions.go
+++ b/pkg/pulp_client/rpm_distributions.go
@@ -1,6 +1,6 @@
 package pulp_client
 
-import zest "github.com/content-services/zest/release/v2023"
+import zest "github.com/content-services/zest/release/v2024"
 
 // CreateRpmDistribution Creates a Distribution
 func (r *pulpDaoImpl) CreateRpmDistribution(publicationHref string, name string, basePath string, contentGuardHref *string) (*string, error) {

--- a/pkg/pulp_client/rpm_publication.go
+++ b/pkg/pulp_client/rpm_publication.go
@@ -1,6 +1,6 @@
 package pulp_client
 
-import zest "github.com/content-services/zest/release/v2023"
+import zest "github.com/content-services/zest/release/v2024"
 
 // CreateRpmPublication Creates a Publication
 func (r *pulpDaoImpl) CreateRpmPublication(versionHref string) (*string, error) {

--- a/pkg/pulp_client/rpm_remote.go
+++ b/pkg/pulp_client/rpm_remote.go
@@ -2,7 +2,7 @@ package pulp_client
 
 import (
 	"github.com/content-services/content-sources-backend/pkg/config"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/pulp_client/rpm_repositories.go
+++ b/pkg/pulp_client/rpm_repositories.go
@@ -1,7 +1,7 @@
 package pulp_client
 
 import (
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 )
 
 // Creates a repository, rpmRemotePulpRef is optional

--- a/pkg/pulp_client/rpm_repository_version.go
+++ b/pkg/pulp_client/rpm_repository_version.go
@@ -1,7 +1,7 @@
 package pulp_client
 
 import (
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/openlyinc/pointy"
 )
 

--- a/pkg/pulp_client/status.go
+++ b/pkg/pulp_client/status.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/content-services/content-sources-backend/pkg/cache"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/rs/zerolog"
 )
 

--- a/pkg/pulp_client/task.go
+++ b/pkg/pulp_client/task.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"time"
 
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/exp/slices"

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -11,7 +11,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 )
 
 type DeleteRepositorySnapshotsPayload struct {

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"

--- a/pkg/tasks/repository_snapshot.go
+++ b/pkg/tasks/repository_snapshot.go
@@ -17,7 +17,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
 	"github.com/rs/zerolog"

--- a/pkg/tasks/repository_snapshot_test.go
+++ b/pkg/tasks/repository_snapshot_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	zest "github.com/content-services/zest/release/v2023"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
 	"github.com/rs/zerolog/log"


### PR DESCRIPTION
## Summary

Switches to new zest build that is built with pulp-ubi.

## Testing steps

``` 
make compose-clean
make compose-up
go get -u  github.com/content-services/zest/release/v2024
make run
```

then try to curl the repositories listing:  GET http://localhost:8000/api/content-sources/v1.0/repositories/


## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
