### PR TITLE
Build: Update to use new pulp api path

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Wait for pulp
         run: |
           docker run --network=host --rm -v ${PWD}:/local curlimages/curl  \
-            curl --retry-all-errors --fail --retry-delay 10 --retry 32 --retry-max-time 240 http://localhost:8080/pulp/default/api/v3/repositories/rpm/rpm/  -u admin:password
+            curl --retry-all-errors --fail --retry-delay 10 --retry 32 --retry-max-time 240 http://localhost:8080/api/pulp/default/api/v3/repositories/rpm/rpm/  -u admin:password
           sleep 30
       - name: integration tests
         run: |

--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       POSTGRES_SERVICE_HOST: postgres
       PULP_ADMIN_PASSWORD: password
       PULP_DOMAIN_ENABLED: "true"
+      PULP_API_ROOT: /api/pulp/
     restart: always
 
   pulp_content:
@@ -91,6 +92,8 @@ services:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
       PULP_DOMAIN_ENABLED: "true"
+      PULP_API_ROOT: /api/pulp/
+
     restart: always
 
   pulp_web:
@@ -127,6 +130,8 @@ services:
       POSTGRES_SERVICE_PORT: 5432
       POSTGRES_SERVICE_HOST: postgres
       PULP_DOMAIN_ENABLED: "true"
+      PULP_API_ROOT: /api/pulp/
+
     restart: always
   minio:
     image: quay.io/minio/minio

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.31.0
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.14.0
 	github.com/cloudevents/sdk-go/v2 v2.14.0
-	github.com/content-services/zest/release/v2024 v2024.1.1705669831
+	github.com/content-services/zest/release/v2024 v2024.1.1706018763
 	github.com/getsentry/sentry-go v0.26.0
 	github.com/jackc/pgconn v1.14.1
 	github.com/jackc/pgx/v4 v4.18.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/content-services/yummy v1.0.10 h1:8cyg/43DDmlcVqXEFrYzhmEcwgbWgJ7UMBg
 github.com/content-services/yummy v1.0.10/go.mod h1:OC2EOi+lc6p6NJTJy7z8Hu8Hx1MBy+NuBRigfCJ/ivA=
 github.com/content-services/zest/release/v2024 v2024.1.1705669831 h1:KzH9RIxlx6H7Ckjt2HYa5uggtilL7CiogdWGZw3Xlxg=
 github.com/content-services/zest/release/v2024 v2024.1.1705669831/go.mod h1:UwNlzoIpFWKjR3yPnm+l4GtShPYLhWy9Rt+jmFM5W/U=
+github.com/content-services/zest/release/v2024 v2024.1.1706018763 h1:TrFMpNk1SaTgxmdh7PggnEGmAZZoKS7oOhqSeNlkxf0=
+github.com/content-services/zest/release/v2024 v2024.1.1706018763/go.mod h1:UwNlzoIpFWKjR3yPnm+l4GtShPYLhWy9Rt+jmFM5W/U=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=


### PR DESCRIPTION
## Summary

Updates our compose files to configure pulp to use /pulp/api

## Testing steps

1.  checkout PR
2. make compose-clean compose-up
3. make run
4. create a repo with snapshotting turned on, verify the snapshot gets created properly.

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
