### PR TITLE
Fixes 3482: Do not run introspection tests

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -10,7 +10,7 @@ DOCKERFILE="build/Dockerfile"
 
 IQE_PLUGINS="content-sources"  # name of the IQE plugin for this app.
 IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
-IQE_FILTER_EXPRESSION="not test_introspection_of_persistent_user"  # This is the value passed to pytest -k
+IQE_FILTER_EXPRESSION="not introspection"  # This is the value passed to pytest -k
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 
 COMPONENTS_W_RESOURCES="pulp"


### PR DESCRIPTION
## Summary

We do not want to run any full introspection tests in pr checks.
There are simple checks within other CRUD tests.

  there are now two we need to skip
  so use just "introspection" to make it generic.


## Testing steps
Test pass

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
