### PR TITLE
Fixes 3492,3371: properly join repo to task

### DIFF
--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -44,7 +44,7 @@ func (t taskInfoDaoImpl) Fetch(orgID string, id string) (api.TaskInfoResponse, e
 
 	result := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
-		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid").
+		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid AND rc.org_id = ?", orgID).
 		Where("t.id = ? AND t.org_id = ?", UuidifyString(id), orgID).First(&taskInfo)
 
 	if result.Error != nil {
@@ -70,7 +70,7 @@ func (t taskInfoDaoImpl) List(
 
 	filteredDB := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
-		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid").
+		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid  AND rc.org_id = ?", orgID).
 		Where("t.org_id = ?", orgID)
 
 	if filterData.Status != "" {


### PR DESCRIPTION
## Summary

Fixes a query that didn't properly limit joined repo configs to the proper org id.

## Testing steps

Create two repos pointing to the same URL in two different orgs.
Fetch the resulting introspect task for each repo in each org
verify the repo uuid and name matches from the expected org

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
