### PR TITLE
Refs 3372: change pulp content path cache key

### DIFF
--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-const PulpContentPathKey = "pulp-content-path"
+const PulpContentPathKey = "central-pulp-content-path"
 
 type redisCache struct {
 	client *redis.Client


### PR DESCRIPTION
## Summary

change the pulp content cache path

## Testing steps

none, test pass

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
