### PR TITLE
Fixes 3346: new pattern for pulp response errors

### DIFF
--- a/pkg/pulp_client/domains.go
+++ b/pkg/pulp_client/domains.go
@@ -75,10 +75,12 @@ func (r *pulpDaoImpl) UpdateDomainIfNeeded(name string) error {
 
 func (r *pulpDaoImpl) lookupDomain(name string) (*zest.DomainResponse, error) {
 	list, resp, err := r.client.DomainsAPI.DomainsList(r.ctx, "default").Name(name).Execute()
-	if err != nil {
-		return nil, err
+	if resp != nil {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
+	if err != nil {
+		return nil, errorWithResponseBody("error listing domains", resp, err)
+	}
 	if len(list.Results) == 0 {
 		return nil, nil
 	} else if list.Results[0].PulpHref == nil {

--- a/pkg/pulp_client/orphans.go
+++ b/pkg/pulp_client/orphans.go
@@ -8,9 +8,11 @@ func (r pulpDaoImpl) OrphanCleanup() (string, error) {
 	zero := int64(0)
 	orphansCleanup.OrphanProtectionTime = *zest.NewNullableInt64(&zero)
 	resp, httpResp, err := r.client.OrphansCleanupAPI.OrphansCleanupCleanup(r.ctx, r.domainName).OrphansCleanup(orphansCleanup).Execute()
-	if err != nil {
-		return "", err
+	if httpResp != nil {
+		defer httpResp.Body.Close()
 	}
-	defer httpResp.Body.Close()
+	if err != nil {
+		return "", errorWithResponseBody("error in orphan cleanup", httpResp, err)
+	}
 	return resp.Task, nil
 }

--- a/pkg/pulp_client/rpm_publication.go
+++ b/pkg/pulp_client/rpm_publication.go
@@ -7,11 +7,12 @@ func (r *pulpDaoImpl) CreateRpmPublication(versionHref string) (*string, error) 
 	rpmRpmRepository := *zest.NewRpmRpmPublication()
 	rpmRpmRepository.RepositoryVersion = &versionHref
 	resp, httpResp, err := r.client.PublicationsRpmAPI.PublicationsRpmRpmCreate(r.ctx, r.domainName).RpmRpmPublication(rpmRpmRepository).Execute()
-
-	if err != nil {
-		return nil, err
+	if httpResp != nil {
+		defer httpResp.Body.Close()
 	}
-	defer httpResp.Body.Close()
+	if err != nil {
+		return nil, errorWithResponseBody("error creating rpm publication", httpResp, err)
+	}
 
 	taskHref := resp.GetTask()
 	return &taskHref, nil
@@ -19,10 +20,12 @@ func (r *pulpDaoImpl) CreateRpmPublication(versionHref string) (*string, error) 
 
 func (r *pulpDaoImpl) FindRpmPublicationByVersion(versionHref string) (*zest.RpmRpmPublicationResponse, error) {
 	resp, httpResp, err := r.client.PublicationsRpmAPI.PublicationsRpmRpmList(r.ctx, r.domainName).RepositoryVersion(versionHref).Execute()
-	if err != nil {
-		return nil, err
+	if httpResp != nil {
+		defer httpResp.Body.Close()
 	}
-	defer httpResp.Body.Close()
+	if err != nil {
+		return nil, errorWithResponseBody("error listing rpm publications", httpResp, err)
+	}
 
 	results := resp.GetResults()
 	if len(results) > 0 {

--- a/pkg/pulp_client/rpm_repository_version.go
+++ b/pkg/pulp_client/rpm_repository_version.go
@@ -8,10 +8,12 @@ import (
 // GetRpmRepositoryVersion Finds a repository version given its href
 func (r *pulpDaoImpl) GetRpmRepositoryVersion(href string) (*zest.RepositoryVersionResponse, error) {
 	resp, httpResp, err := r.client.RepositoriesRpmVersionsAPI.RepositoriesRpmRpmVersionsRead(r.ctx, href).Execute()
-	if err != nil {
-		return nil, err
+	if httpResp != nil {
+		defer httpResp.Body.Close()
 	}
-	defer httpResp.Body.Close()
+	if err != nil {
+		return nil, errorWithResponseBody("error reading rpm repository versions", httpResp, err)
+	}
 
 	return resp, nil
 }
@@ -19,22 +21,26 @@ func (r *pulpDaoImpl) GetRpmRepositoryVersion(href string) (*zest.RepositoryVers
 // DeleteRpmRepositoryVersion starts task to delete repository version and returns delete task's href
 func (r *pulpDaoImpl) DeleteRpmRepositoryVersion(href string) (string, error) {
 	resp, httpResp, err := r.client.RepositoriesRpmVersionsAPI.RepositoriesRpmRpmVersionsDelete(r.ctx, href).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
 	if err != nil {
 		if err.Error() == "404 Not Found" {
 			return "", nil
 		}
-		return "", err
+		return "", errorWithResponseBody("error deleting rpm repository versions", httpResp, err)
 	}
-	defer httpResp.Body.Close()
 	return resp.Task, nil
 }
 
 func (r *pulpDaoImpl) RepairRpmRepositoryVersion(href string) (string, error) {
 	resp, httpResp, err := r.client.RepositoriesRpmVersionsAPI.RepositoriesRpmRpmVersionsRepair(r.ctx, href).
 		Repair(zest.Repair{VerifyChecksums: pointy.Pointer(true)}).Execute()
-	if err != nil {
-		return "", err
+	if httpResp != nil {
+		defer httpResp.Body.Close()
 	}
-	defer httpResp.Body.Close()
+	if err != nil {
+		return "", errorWithResponseBody("error repairing rpm repository versions", httpResp, err)
+	}
 	return resp.Task, nil
 }


### PR DESCRIPTION
## Summary
Establishes new pattern for handling pulp api response errors to ensure nil check and include the response body in the error. 

## Testing steps
1. Cause a pulp error somehow. One way is to do `podman stop cs_pulp_api_1`, then try to sync a repository.
2. You should see the error message in the logs includes the body response.
3. Also look through the pulp client package and see if I missed adding this response pattern to the responses.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
