### PR TITLE
Fixes 3353: Snapshot  inconsistent for API/UI

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -506,7 +506,8 @@ func (r repositoryConfigDaoImpl) Update(orgID, uuid string, repoParams api.Repos
 				return DBErrorToApi(err)
 			}
 			repoConfig.RepositoryUUID = repo.UUID
-			updatedUrl = true
+
+			updatedUrl = repoConfig.Repository.URL != *repoParams.URL
 		}
 
 		repoConfig.Repository = models.Repository{}

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -313,7 +313,7 @@ func (rh *RepositoryHandler) update(c echo.Context, fillDefaults bool) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error updating repository", err.Error())
 	}
 
-	if urlUpdated && repoParams.URL != nil && repoConfig.URL != *repoParams.URL {
+	if urlUpdated {
 		snapInProgress, err := rh.DaoRegistry.TaskInfo.IsSnapshotInProgress(orgID, repoConfig.RepositoryUUID)
 		if err != nil {
 			return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error checking if snapshot is in progress", err.Error())

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -313,7 +313,7 @@ func (rh *RepositoryHandler) update(c echo.Context, fillDefaults bool) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error updating repository", err.Error())
 	}
 
-	if repoParams.URL != nil && repoConfig.URL != *repoParams.URL {
+	if urlUpdated && repoParams.URL != nil && repoConfig.URL != *repoParams.URL {
 		snapInProgress, err := rh.DaoRegistry.TaskInfo.IsSnapshotInProgress(orgID, repoConfig.RepositoryUUID)
 		if err != nil {
 			return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error checking if snapshot is in progress", err.Error())
@@ -334,7 +334,10 @@ func (rh *RepositoryHandler) update(c echo.Context, fillDefaults bool) error {
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}
-	rh.enqueueIntrospectEvent(c, response, orgID)
+
+	if urlUpdated {
+		rh.enqueueIntrospectEvent(c, response, orgID)
+	}
 
 	return c.JSON(http.StatusOK, response)
 }

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -863,8 +863,6 @@ func (suite *ReposSuite) TestFullUpdate() {
 	}, nil)
 	suite.reg.RepositoryConfig.On("Update", test_handler.MockOrgId, uuid, expected).Return(false, nil)
 
-	mockTaskClientEnqueueIntrospect(suite.tcMock, "https://example.com", repoUuid)
-
 	body, err := json.Marshal(request)
 	if err != nil {
 		t.Error("Could not marshal JSON")
@@ -924,7 +922,7 @@ func (suite *ReposSuite) TestPartialUpdate() {
 	request := createRepoRequest("Some Name", "https://example.com")
 	expected := createRepoRequest(*request.Name, *request.URL)
 
-	suite.reg.RepositoryConfig.WithContextMock().On("Update", test_handler.MockOrgId, uuid, expected).Return(true, nil)
+	suite.reg.RepositoryConfig.WithContextMock().On("Update", test_handler.MockOrgId, uuid, expected).Return(false, nil)
 	suite.reg.RepositoryConfig.On("Fetch", test_handler.MockOrgId, uuid).Return(api.RepositoryResponse{
 		Name:           "my repo",
 		URL:            "https://example.com",
@@ -932,8 +930,6 @@ func (suite *ReposSuite) TestPartialUpdate() {
 		RepositoryUUID: repoUuid,
 		Snapshot:       false,
 	}, nil)
-
-	mockTaskClientEnqueueIntrospect(suite.tcMock, "https://example.com", repoUuid)
 
 	body, err := json.Marshal(request)
 	if err != nil {


### PR DESCRIPTION
## Summary

Snapshot create-on-edit is inconsistent between API and UI 
This was caused by the URL not being checked correctly before enqueueing snapshot/introspect tasks. 
This card corrects that issue.

## Testing steps

- From the api or UI, update a repository (patch) with the original URL in the request.  
Without this change, introspection/snapshot tasks will always be enqueued. 
With it, the tasks will correctly, be ignored, as those two tasks are contingent on a URL change.


