### PR TITLE
Fixes 3444: append /api/ to all pulp hrefs in db

### DIFF
--- a/cmd/cleanup_versions/main.go
+++ b/cmd/cleanup_versions/main.go
@@ -24,10 +24,24 @@ func main() {
 		log.Fatal().Msg("Requires arguments: --force")
 	}
 
-	result := db.DB.Exec("DELETE FROM snapshots")
+	query :=
+		`		
+			UPDATE snapshots
+			SET version_href = CONCAT('/api', version_href)
+			WHERE version_href NOT LIKE '/api%';
+			
+			UPDATE snapshots
+			SET publication_href = CONCAT('/api', publication_href)
+			WHERE publication_href NOT LIKE '/api%';
+
+			UPDATE snapshots
+			SET distribution_href = CONCAT('/api', distribution_href)
+			WHERE distribution_href NOT LIKE '/api%';
+		`
+	result := db.DB.Exec(query)
 	if result.Error != nil {
-		log.Fatal().Err(result.Error).Msg("Could not delete snapshots.")
+		log.Fatal().Err(result.Error).Msg("Could not update hrefs.")
 	} else {
-		log.Warn().Msgf("Deleted %v snapshots", result.RowsAffected)
+		log.Warn().Msgf("Updated %v hrefs", result.RowsAffected)
 	}
 }

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -374,7 +374,7 @@ objects:
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
                 value: ${OPTIONS_ENABLE_NOTIFICATIONS}
-        - name: cleanup-snapshots-2024-01-11
+        - name: update-hrefs
           podSpec:
             securityContext:
               runAsNonRoot: true

--- a/deployments/jobs.yaml
+++ b/deployments/jobs.yaml
@@ -8,11 +8,11 @@ objects:
   metadata:
     labels:
       app: content-sources-backend 
-    name: cleanup-snapshots-2024-01-11
+    name: update-hrefs-2024-02-07
   spec:
     appName: content-sources-backend 
     jobs:
-      - cleanup-snapshots-2024-01-11
+      - update-hrefs
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:


### PR DESCRIPTION
## Summary

Job runs on stage that updates pulp hrefs (version_href, publication_href, distribution_href) to prepend /api if not already. 

## Testing steps

- Run query on local snapshots table in db. Shouldn't update any rows if hrefs are already prepended with /api
- *Maybe* run query on stage db?  I haven't done this yet myself though
- 
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
