### PR TITLE
Build: increase deployment timeout to 900

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -12,6 +12,7 @@ IQE_PLUGINS="content-sources"  # name of the IQE plugin for this app.
 IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
 IQE_FILTER_EXPRESSION="not introspection"  # This is the value passed to pytest -k
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
+DEPLOY_TIMEOUT="900"  # 15min
 
 COMPONENTS_W_RESOURCES="pulp"
 


### PR DESCRIPTION
## Summary

In smoke tests I see `DEPLOY_TIMEOUT:-"600` coming from appsre:

`$ bonfire deploy ${APP_NAME} ${DEPLOY_ARGS} --source=appsre --ref-env ${IQE_REF_ENV} --namespace ${NAMESPACE} --timeout ${DEPLOY_TIMEOUT:-"600"} ${FRONTEND_ARG}`

but deploy time seem too short:
`2024-02-12 20:48:10 [   ERROR] [          thread-358] [clowdjobinvocation/create-contentsources-user] timed out waiting for resource to be ready, details:   clowdjobinvocation/create-contentsources-user not ready, status conditions:`

Frontend already has `export DEPLOY_TIMEOUT="900"  # 15min` so I will try that for backend.

## Testing steps
pr checks pass

