### PR TITLE
Refs 3255: fix escaping of bool

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -98,7 +98,7 @@ objects:
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
               - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
-                value: ${{CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}}
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
               - name: CLIENTS_PULP_GUARD_SUBJECT_DN
                 value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
               - name: CLIENTS_PULP_DOWNLOAD_POLICY
@@ -199,7 +199,7 @@ objects:
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
               - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
-                value: ${{CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}}
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
               - name: CLIENTS_PULP_GUARD_SUBJECT_DN
                 value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
               - name: CLIENTS_PULP_DOWNLOAD_POLICY
@@ -466,7 +466,7 @@ objects:
               - name: CLIENTS_PULP_SERVER
                 value: ${{CLIENTS_PULP_SERVER}}
               - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
-                value: ${{CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}}
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
               - name: CLIENTS_PULP_GUARD_SUBJECT_DN
                 value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
               - name: CLIENTS_PULP_DOWNLOAD_POLICY


### PR DESCRIPTION
## Summary

previous commit had a mistake when escaping bools

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
