### PR TITLE
Refs 3255: correct mistaken default config value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,7 +235,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.pulp.username", "")
 	v.SetDefault("clients.pulp.password", "")
 	v.SetDefault("clients.pulp.guard_subject_dn", "default-content-sources-dn") // Use a default, so we always create one
-	v.SetDefault("client.pulp.custom_repo_content_guards", false)
+	v.SetDefault("clients.pulp.custom_repo_content_guards", false)
 	v.SetDefault("clients.pulp.database.host", "")
 	v.SetDefault("clients.pulp.database.port", 0)
 	v.SetDefault("clients.pulp.database.user", "")


### PR DESCRIPTION
## Summary

Fixes a typo in the default value for this config settings.  If the default isn't set, the config reader doesn't actually use the value.

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
