### PR TITLE
Fixes 3612: add sslclient options to yum config

### DIFF
--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -213,7 +213,9 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 		"gpgcheck=%v\n"+ // set to verify packages
 		"repo_gpgcheck=%v\n"+ // set to verify metadata
 		"enabled=1\n"+
-		"gpgkey=%v\n",
+		"gpgkey=%v\n"+
+		"sslclientcert=/etc/pki/consumer/cert.pem\n"+
+		"sslclientkey=/etc/pki/consumer/key.pem\n",
 		repoID, repoConfig.Name, contentURL, moduleHotfixes, gpgCheck, repoGpgCheck, gpgKeyField)
 
 	return fileConfig, nil


### PR DESCRIPTION
## Summary

adds  ssl options to repo config
```
sslclientcert=/etc/pki/consumer/cert.pem
sslclientkey=/etc/pki/consumer/key.pem
```

## Testing steps

snapshot a repo, copy/download the repo config, look for the piece above

## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
