### PR TITLE
Fixes 3629: add org id to features config

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -124,7 +124,9 @@ features:
     enabled: true
     accounts: #["snapAccount"]
     users: #["snapUser"]
+    organizations: #["snapOrg"]
   admin_tasks:
     enabled: true
     accounts: #["adminAccount"]
     users: #["adminUser"]
+    organizations: #["adminOrg"]

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -121,10 +121,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -222,10 +226,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -318,10 +326,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: CLIENTS_RBAC_BASE_URL
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -372,10 +384,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: CLIENTS_RBAC_BASE_URL
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -426,10 +442,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: CLIENTS_RBAC_BASE_URL
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -487,10 +507,14 @@ objects:
                 value: ${FEATURES_SNAPSHOTS_ENABLED}
               - name: FEATURES_SNAPSHOTS_ACCOUNTS
                 value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
               - name: FEATURES_ADMIN_TASKS_ENABLED
                 value: ${FEATURES_ADMIN_TASKS_ENABLED}
               - name: FEATURES_ADMIN_TASKS_ACCOUNTS
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: CLIENTS_RBAC_BASE_URL
                 value: ${{CLIENTS_RBAC_BASE_URL}}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -604,10 +628,14 @@ parameters:
     description: Whether the Snapshots feature should be turned on
   - name: FEATURES_SNAPSHOTS_ACCOUNTS
     description: Comma separated list of account number that can access the feature
+  - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+    description: Comma separated list of org ids that can access the feature
   - name: FEATURES_ADMIN_TASKS_ENABLED
     description: Whether the Admin Tasks feature should be turned on
   - name: FEATURES_ADMIN_TASKS_ACCOUNTS
     description: Comma separated list of account number that can access the feature
+  - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+    description: Comma separated list of org ids that can access the feature
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
     description: Option to make testing nightly snapshotting & introspection easier
     default: 'false'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,9 +65,10 @@ type FeatureSet struct {
 }
 
 type Feature struct {
-	Enabled  bool
-	Accounts *[]string // Only allow access if in the accounts list
-	Users    *[]string // or in the users list
+	Enabled       bool
+	Accounts      *[]string // Only allow access if in the accounts list
+	Organizations *[]string // Or org id is in the list
+	Users         *[]string // or username in the users list
 }
 
 const STORAGE_TYPE_LOCAL = "local"
@@ -265,9 +266,11 @@ func setDefaults(v *viper.Viper) {
 
 	v.SetDefault("features.snapshots.enabled", false)
 	v.SetDefault("features.snapshots.accounts", nil)
+	v.SetDefault("features.snapshots.organizations", nil)
 	v.SetDefault("features.snapshots.users", nil)
 	v.SetDefault("features.admin_tasks.enabled", false)
 	v.SetDefault("features.admin_tasks.accounts", nil)
+	v.SetDefault("features.admin_tasks.organizations", nil)
 	v.SetDefault("features.admin_tasks.users", nil)
 	v.SetDefault("features.new_repo_filtering.enabled", false)
 	addEventConfigDefaults(v)

--- a/pkg/handler/features.go
+++ b/pkg/handler/features.go
@@ -57,11 +57,14 @@ func accessible(ctx context.Context, feature config.Feature) bool {
 	if !feature.Enabled {
 		return false
 	}
-	if feature.Accounts == nil && feature.Users == nil {
+	if feature.Accounts == nil && feature.Users == nil && feature.Organizations == nil {
 		return true
 	}
 	identity := identity.Get(ctx)
 	if feature.Accounts != nil && slices.Contains(*feature.Accounts, identity.Identity.AccountNumber) {
+		return true
+	}
+	if feature.Organizations != nil && slices.Contains(*feature.Organizations, identity.Identity.OrgID) {
 		return true
 	}
 	if feature.Users != nil && slices.Contains(*feature.Users, identity.Identity.User.Username) {

--- a/pkg/handler/features_test.go
+++ b/pkg/handler/features_test.go
@@ -58,6 +58,7 @@ type FeatureTestCase struct {
 	id             identity.Identity
 	allowedAccount *string
 	allowedUser    *string
+	allowedOrg     *string
 	expected       api.FeatureSet
 }
 
@@ -71,9 +72,9 @@ func TestFeatures(t *testing.T) {
 	user := identity.Identity{
 		Type:          "User",
 		AccountNumber: "acct",
-		OrgID:         "12345",
+		OrgID:         "orgId",
 		Internal: identity.Internal{
-			OrgID: "12345",
+			OrgID: "orgId",
 		},
 		User: identity.User{Username: "foo"}}
 
@@ -107,6 +108,20 @@ func TestFeatures(t *testing.T) {
 				}},
 		},
 		{
+			name:       "Allowed with OrgId",
+			id:         user,
+			allowedOrg: &user.OrgID,
+			expected: api.FeatureSet{
+				"snapshots": {
+					Enabled:    true,
+					Accessible: true,
+				},
+				"admintasks": {
+					Enabled:    true,
+					Accessible: true,
+				}},
+		},
+		{
 			name: "Not allowed ",
 			id:   user,
 			expected: api.FeatureSet{
@@ -124,6 +139,7 @@ func TestFeatures(t *testing.T) {
 	for _, testcase := range testCases {
 		config.Get().Features.Snapshots.Users = &[]string{}
 		config.Get().Features.Snapshots.Accounts = &[]string{}
+		config.Get().Features.Snapshots.Organizations = &[]string{}
 
 		if testcase.allowedUser != nil {
 			config.Get().Features.Snapshots.Users = &[]string{*testcase.allowedUser}
@@ -131,15 +147,22 @@ func TestFeatures(t *testing.T) {
 		if testcase.allowedAccount != nil {
 			config.Get().Features.Snapshots.Accounts = &[]string{*testcase.allowedAccount}
 		}
+		if testcase.allowedOrg != nil {
+			config.Get().Features.Snapshots.Organizations = &[]string{*testcase.allowedOrg}
+		}
 
 		config.Get().Features.AdminTasks.Users = &[]string{}
 		config.Get().Features.AdminTasks.Accounts = &[]string{}
+		config.Get().Features.AdminTasks.Organizations = &[]string{}
 
 		if testcase.allowedUser != nil {
 			config.Get().Features.AdminTasks.Users = &[]string{*testcase.allowedUser}
 		}
 		if testcase.allowedAccount != nil {
 			config.Get().Features.AdminTasks.Accounts = &[]string{*testcase.allowedAccount}
+		}
+		if testcase.allowedOrg != nil {
+			config.Get().Features.AdminTasks.Organizations = &[]string{*testcase.allowedOrg}
 		}
 
 		newReq := wrapReqWithIdentity(t, req, testcase.id)

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -502,6 +502,8 @@ func (suite *ReposSuite) TestCreateAlreadyExists() {
 func (suite *ReposSuite) TestBulkCreate() {
 	resetFeatures()
 	t := suite.T()
+	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.Snapshots.Accounts = &[]string{test_handler.MockAccountNumber}
 	config.Get().Clients.Pulp.Server = "some-server-address" // This ensures that PulpConfigured returns true
 	repo1 := createRepoRequest("repo_1", "https://example1.com")
 	repo1.FillDefaults()


### PR DESCRIPTION
## Summary

Adds org ids as a way to make features accessible.

## Testing steps

edit your config.yaml and edit/add:
```
features:
  snapshots:
    enabled: true #true
    accounts: 
    users: 
    organizations: ["FOO"]
```

use header.sh to test the org_id.  this should work:

```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/"       -H "Content-Type: application/json"     -d "{
          \"name\": \"needed errata\",
          \"url\": \"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/\",
          \"gpg_key\": \"\",
          \"snapshot\": true
        }"   -H "`./scripts/header.sh FOO 1 1`"
```
This should fail:
```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/"       -H "Content-Type: application/json"     -d "{
          \"name\": \"needed errata\",
          \"url\": \"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/\",
          \"gpg_key\": \"\",
          \"snapshot\": true
        }"   -H "`./scripts/header.sh NOT_FOO 1 1`"
```


## Checklist

- [x] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
