### PR TITLE
Fixes 3654: Remove UUID from public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Create a config file from the example:
 $ cp ./configs/config.yaml.example ./configs/config.yaml
 ```
 
+### Import Public Repos
+
+```sh
+$ make repos-import
+```
+
 ### Build needed kafka container
 
 ```sh

--- a/api/docs.go
+++ b/api/docs.go
@@ -2705,10 +2705,6 @@ const docTemplate = `{
                 "url": {
                     "description": "URL of the remote yum repository",
                     "type": "string"
-                },
-                "uuid": {
-                    "description": "UUID of the repository if it exists for the user",
-                    "type": "string"
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -234,10 +234,6 @@
                     "url": {
                         "description": "URL of the remote yum repository",
                         "type": "string"
-                    },
-                    "uuid": {
-                        "description": "UUID of the repository if it exists for the user",
-                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/pkg/api/public_repositories.go
+++ b/pkg/api/public_repositories.go
@@ -2,7 +2,6 @@ package api
 
 // PublicRepositoryResponse holds data returned by the public repositories API response
 type PublicRepositoryResponse struct {
-	UUID                         string `json:"uuid"`                            // UUID of the repository if it exists for the user
 	URL                          string `json:"url"`                             // URL of the remote yum repository
 	Status                       string `json:"status"`                          // Introspection status of the repository
 	LastIntrospectionTime        string `json:"last_introspection_time"`         // Timestamp of last attempted introspection

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -224,7 +224,6 @@ func internalToModel(internal RepositoryUpdate, model *models.Repository) {
 }
 
 func repoModelToPublicRepoApi(model models.Repository, resp *api.PublicRepositoryResponse) {
-	resp.UUID = model.UUID
 	resp.URL = model.URL
 	resp.Status = model.Status
 	resp.PackageCount = model.PackageCount

--- a/pkg/handler/public_repositories_test.go
+++ b/pkg/handler/public_repositories_test.go
@@ -208,7 +208,6 @@ func createPublicRepoCollection(size, limit, offset int) api.PublicRepositoryCol
 	repos := make([]api.PublicRepositoryResponse, size)
 	for i := 0; i < size; i++ {
 		repo := api.PublicRepositoryResponse{
-			UUID:                         fmt.Sprintf("%d", i),
 			URL:                          fmt.Sprintf("http://repo-%d.com", i),
 			LastIntrospectionTime:        "2022-08-31 14:17:50.257623 -0400 EDT",
 			LastIntrospectionSuccessTime: "2022-08-31 14:17:50.257623 -0400 EDT",


### PR DESCRIPTION
## Summary

Simply removes the UUID from the public_repos response.

## Testing steps

- Get /public_repositories/ list, check that the UUID is no longer present.
