### PR TITLE
Fixes 2940: add snapshot rpm list api

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1962,7 +1962,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.RepositoryRpmCollectionResponse"
+                            "$ref": "#/definitions/api.SnapshotRpmCollectionResponse"
                         }
                     },
                     "400": {
@@ -3305,6 +3305,55 @@ const docTemplate = `{
                 },
                 "uuid": {
                     "type": "string"
+                }
+            }
+        },
+        "api.SnapshotRpm": {
+            "type": "object",
+            "properties": {
+                "arch": {
+                    "description": "The architecture of the rpm",
+                    "type": "string"
+                },
+                "epoch": {
+                    "description": "The epoch of the rpm",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The rpm package name",
+                    "type": "string"
+                },
+                "release": {
+                    "description": "The release of the rpm",
+                    "type": "string"
+                },
+                "summary": {
+                    "description": "The summary of the rpm",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The version of the  rpm",
+                    "type": "string"
+                }
+            }
+        },
+        "api.SnapshotRpmCollectionResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "List of rpms",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SnapshotRpm"
+                    }
+                },
+                "links": {
+                    "description": "Links to other pages of results",
+                    "$ref": "#/definitions/api.Links"
+                },
+                "meta": {
+                    "description": "Metadata about the request",
+                    "$ref": "#/definitions/api.ResponseMetadata"
                 }
             }
         },

--- a/api/docs.go
+++ b/api/docs.go
@@ -3083,7 +3083,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "arch": {
-                    "description": "The Architecture of the rpm",
+                    "description": "The architecture of the rpm",
                     "type": "string"
                 },
                 "checksum": {

--- a/api/docs.go
+++ b/api/docs.go
@@ -1917,6 +1917,83 @@ const docTemplate = `{
                 }
             }
         },
+        "/snapshots/{uuid}/rpms": {
+            "get": {
+                "description": "List RPMs in a repository snapshot.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories",
+                    "rpms",
+                    "snapshots"
+                ],
+                "summary": "List Snapshot RPMs",
+                "operationId": "listSnapshotRpms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Snapshot ID.",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: ` + "`" + `100` + "`" + `.",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:` + "`" + `0` + "`" + `.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.RepositoryRpmCollectionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tasks/": {
             "get": {
                 "description": "Get the list of tasks.",

--- a/api/docs.go
+++ b/api/docs.go
@@ -1927,8 +1927,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
-                    "rpms",
                     "snapshots"
                 ],
                 "summary": "List Snapshot RPMs",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3494,6 +3494,105 @@
                 ]
             }
         },
+        "/snapshots/{uuid}/rpms": {
+            "get": {
+                "description": "List RPMs in a repository snapshot.",
+                "operationId": "listSnapshotRpms",
+                "parameters": [
+                    {
+                        "description": "Snapshot ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryRpmCollectionResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Snapshot RPMs",
+                "tags": [
+                    "repositories",
+                    "rpms",
+                    "snapshots"
+                ]
+            }
+        },
         "/tasks/": {
             "get": {
                 "description": "Get the list of tasks.",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3587,8 +3587,6 @@
                 },
                 "summary": "List Snapshot RPMs",
                 "tags": [
-                    "repositories",
-                    "rpms",
                     "snapshots"
                 ]
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -749,6 +749,53 @@
                 },
                 "type": "object"
             },
+            "api.SnapshotRpm": {
+                "properties": {
+                    "arch": {
+                        "description": "The architecture of the rpm",
+                        "type": "string"
+                    },
+                    "epoch": {
+                        "description": "The epoch of the rpm",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "The rpm package name",
+                        "type": "string"
+                    },
+                    "release": {
+                        "description": "The release of the rpm",
+                        "type": "string"
+                    },
+                    "summary": {
+                        "description": "The summary of the rpm",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "The version of the  rpm",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.SnapshotRpmCollectionResponse": {
+                "properties": {
+                    "data": {
+                        "description": "List of rpms",
+                        "items": {
+                            "$ref": "#/components/schemas/api.SnapshotRpm"
+                        },
+                        "type": "array"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/api.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/api.ResponseMetadata"
+                    }
+                },
+                "type": "object"
+            },
             "api.SnapshotSearchRpmRequest": {
                 "properties": {
                     "limit": {
@@ -3538,7 +3585,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/api.RepositoryRpmCollectionResponse"
+                                    "$ref": "#/components/schemas/api.SnapshotRpmCollectionResponse"
                                 }
                             }
                         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -528,7 +528,7 @@
             "api.RepositoryRpm": {
                 "properties": {
                     "arch": {
-                        "description": "The Architecture of the rpm",
+                        "description": "The architecture of the rpm",
                         "type": "string"
                     },
                     "checksum": {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/content-services/content-sources-backend
 
 go 1.20
 
+replace (
+	github.com/content-services/tang => /home/jlsherri/git/tang
+)
+
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0-proton
 	github.com/content-services/tang v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,9 @@ module github.com/content-services/content-sources-backend
 
 go 1.20
 
-replace (
-	github.com/content-services/tang => /home/jlsherri/git/tang
-)
-
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0-proton
-	github.com/content-services/tang v0.0.3
+	github.com/content-services/tang v0.0.4
 	github.com/content-services/yummy v1.0.11
 	github.com/getkin/kin-openapi v0.123.0
 	github.com/go-openapi/spec v0.20.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/content-services/caliri/release/v4 v4.4.5-beta.1 h1:tIXKiFi0aatf2w6rDYdjQLqHtjBQzeHYCR+F1bmfr/s=
 github.com/content-services/caliri/release/v4 v4.4.5-beta.1/go.mod h1:ziS43sIDnl+q3HmcO+PCMgLKgZb4uISpieUAc3y1l3s=
-github.com/content-services/tang v0.0.3 h1:tbhm+sTYEh0BzQFD5h3J2jc3ImDSuhSTjdod2fJEoRQ=
-github.com/content-services/tang v0.0.3/go.mod h1:92WTS+mPTjoMgHYBx+d3Ea6vRavyXP2tH4XnDs3twF4=
+github.com/content-services/tang v0.0.4 h1:EC+KV0/p5OgPwK3aZY+XbxaH83Z6skqou4UBoB7RxGY=
+github.com/content-services/tang v0.0.4/go.mod h1:92WTS+mPTjoMgHYBx+d3Ea6vRavyXP2tH4XnDs3twF4=
 github.com/content-services/yummy v1.0.11 h1:Rb9reihh9EgSSEZbFXcAfezl378YBKDmpq7zTaH8DqY=
 github.com/content-services/yummy v1.0.11/go.mod h1:owka4bLsGyIlCHEIl2zhACC2Z4P7NCTrORn+bBbLcDQ=
 github.com/content-services/zest/release/v2024 v2024.3.1709674773 h1:kr7NX4UZhF9ZrJEhRgsZ5Kw5vwV03r6uSTRl42Wv4yc=

--- a/pkg/api/rpms.go
+++ b/pkg/api/rpms.go
@@ -3,7 +3,7 @@ package api
 type RepositoryRpm struct {
 	UUID     string `json:"uuid"`     // Identifier of the rpm
 	Name     string `json:"name"`     // The rpm package name
-	Arch     string `json:"arch"`     // The Architecture of the rpm
+	Arch     string `json:"arch"`     // The architecture of the rpm
 	Version  string `json:"version"`  // The version of the  rpm
 	Release  string `json:"release"`  // The release of the rpm
 	Epoch    int32  `json:"epoch"`    // The epoch of the rpm
@@ -13,7 +13,7 @@ type RepositoryRpm struct {
 
 type SnapshotRpm struct {
 	Name    string `json:"name"`    // The rpm package name
-	Arch    string `json:"arch"`    // The Architecture of the rpm
+	Arch    string `json:"arch"`    // The architecture of the rpm
 	Version string `json:"version"` // The version of the  rpm
 	Release string `json:"release"` // The release of the rpm
 	Epoch   string `json:"epoch"`   // The epoch of the rpm

--- a/pkg/api/rpms.go
+++ b/pkg/api/rpms.go
@@ -11,8 +11,23 @@ type RepositoryRpm struct {
 	Checksum string `json:"checksum"` // The checksum of the rpm
 }
 
+type SnapshotRpm struct {
+	Name    string `json:"name"`    // The rpm package name
+	Arch    string `json:"arch"`    // The Architecture of the rpm
+	Version string `json:"version"` // The version of the  rpm
+	Release string `json:"release"` // The release of the rpm
+	Epoch   string `json:"epoch"`   // The epoch of the rpm
+	Summary string `json:"summary"` // The summary of the rpm
+}
+
 type RepositoryRpmCollectionResponse struct {
 	Data  []RepositoryRpm  `json:"data"`  // List of rpms
+	Meta  ResponseMetadata `json:"meta"`  // Metadata about the request
+	Links Links            `json:"links"` // Links to other pages of results
+}
+
+type SnapshotRpmCollectionResponse struct {
+	Data  []SnapshotRpm    `json:"data"`  // List of rpms
 	Meta  ResponseMetadata `json:"meta"`  // Metadata about the request
 	Links Links            `json:"links"` // Links to other pages of results
 }
@@ -48,6 +63,10 @@ type SearchRpmResponse struct {
 // meta Metadata about the request.
 // links Links to other pages of results.
 func (r *RepositoryRpmCollectionResponse) SetMetadata(meta ResponseMetadata, links Links) {
+	r.Meta = meta
+	r.Links = links
+}
+func (r *SnapshotRpmCollectionResponse) SetMetadata(meta ResponseMetadata, links Links) {
 	r.Meta = meta
 	r.Links = links
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -78,6 +78,7 @@ type RpmDao interface {
 	List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryRpmCollectionResponse, int64, error)
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchRpmResponse, error)
 	SearchSnapshotRpms(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchRpmResponse, error)
+	ListSnapshotRpms(ctx context.Context, orgId string, snapshotUUIDs []string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error)
 	InsertForRepository(repoUuid string, pkgs []yum.Package) (int64, error)
 	OrphanCleanup() error
 }

--- a/pkg/dao/rpms_mock.go
+++ b/pkg/dao/rpms_mock.go
@@ -72,6 +72,39 @@ func (_m *MockRpmDao) List(orgID string, uuidRepo string, limit int, offset int,
 	return r0, r1, r2
 }
 
+// ListSnapshotRpms provides a mock function with given fields: ctx, orgId, snapshotUUIDs, search, pageOpts
+func (_m *MockRpmDao) ListSnapshotRpms(ctx context.Context, orgId string, snapshotUUIDs []string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error) {
+	ret := _m.Called(ctx, orgId, snapshotUUIDs, search, pageOpts)
+
+	var r0 []api.SnapshotRpm
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, string, api.PaginationData) ([]api.SnapshotRpm, int, error)); ok {
+		return rf(ctx, orgId, snapshotUUIDs, search, pageOpts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, string, api.PaginationData) []api.SnapshotRpm); ok {
+		r0 = rf(ctx, orgId, snapshotUUIDs, search, pageOpts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.SnapshotRpm)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, []string, string, api.PaginationData) int); ok {
+		r1 = rf(ctx, orgId, snapshotUUIDs, search, pageOpts)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string, []string, string, api.PaginationData) error); ok {
+		r2 = rf(ctx, orgId, snapshotUUIDs, search, pageOpts)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // OrphanCleanup provides a mock function with given fields:
 func (_m *MockRpmDao) OrphanCleanup() error {
 	ret := _m.Called()

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -980,8 +980,6 @@ func (s *RpmSuite) TestListRpmsForSnapshots() {
 	res = s.tx.Model(models.Snapshot{}).Where("repository_configuration_uuid = ?", repoConfig.UUID).Update("version_href", hrefs[0])
 	require.NoError(s.T(), res.Error)
 
-	// pkgs, total, err := (*config.Tang).RpmRepositoryVersionPackageList(ctx, pulpHrefs, tangy.RpmListFilters{Name: search}, tangy.PageOptions{
-
 	total := 5
 	search := "wake"
 	page := api.PaginationData{Limit: 3, Offset: 101}

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -136,7 +136,7 @@ func (rh *RpmHandler) searchSnapshotRPMs(c echo.Context) error {
 // @Summary      List Snapshot RPMs
 // @ID           listSnapshotRpms
 // @Description  List RPMs in a repository snapshot.
-// @Tags         repositories,rpms,snapshots
+// @Tags         snapshots
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Snapshot ID."

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -143,7 +143,7 @@ func (rh *RpmHandler) searchSnapshotRPMs(c echo.Context) error {
 // @Param		 limit query int false "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`."
 // @Param		 offset query int false "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`."
 // @Param		 search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name."
-// @Success      200 {object} api.RepositoryRpmCollectionResponse
+// @Success      200 {object} api.SnapshotRpmCollectionResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse

--- a/pkg/handler/rpms_test.go
+++ b/pkg/handler/rpms_test.go
@@ -542,6 +542,110 @@ func (suite *RpmSuite) TestSearchSnapshotRpmByName() {
 	}
 }
 
+func (suite *RpmSuite) TestListSnapshotRpms() {
+	t := suite.T()
+
+	config.Load()
+	config.Get().Features.Snapshots.Enabled = true
+	config.Get().Features.Snapshots.Accounts = &[]string{test_handler.MockAccountNumber}
+	defer resetFeatures()
+
+	snapID := "abcd"
+	type TestCaseExpected struct {
+		Code   int
+		Body   string
+		Search string
+		Page   api.PaginationData
+	}
+	type TestCaseGiven struct {
+		Method string
+		Param  string
+	}
+	type TestCase struct {
+		Name     string
+		Given    TestCaseGiven
+		Expected TestCaseExpected
+	}
+
+	var testCases []TestCase = []TestCase{
+		{
+			Name: "Success scenario",
+			Given: TestCaseGiven{
+				Method: http.MethodGet,
+				Param:  "",
+			},
+			Expected: TestCaseExpected{
+				Code: http.StatusOK,
+				Body: "{\"data\":[{\"name\":\"demo-1\",\"arch\":\"\",\"version\":\"\",\"release\":\"\",\"epoch\":\"\",\"summary\":\"Package demo 1\"}],\"meta\":{\"limit\":100,\"offset\":0,\"count\":1},\"links\":{\"first\":\"/api/content-sources/v1.0/snapshots/abcd/rpms?limit=100\\u0026offset=0\",\"last\":\"/api/content-sources/v1.0/snapshots/abcd/rpms?limit=100\\u0026offset=0\"}}\n",
+				Page: api.PaginationData{Limit: 100},
+			},
+		},
+		{
+			Name: "Success scenario with search and pagination",
+			Given: TestCaseGiven{
+				Method: http.MethodGet,
+				Param:  "?search=foo&limit=3&offset=1",
+			},
+			Expected: TestCaseExpected{
+				Code:   http.StatusOK,
+				Body:   "{\"data\":[{\"name\":\"demo-1\",\"arch\":\"\",\"version\":\"\",\"release\":\"\",\"epoch\":\"\",\"summary\":\"Package demo 1\"}],\"meta\":{\"limit\":100,\"offset\":0,\"count\":1},\"links\":{\"first\":\"/api/content-sources/v1.0/snapshots/abcd/rpms?limit=100\\u0026offset=0\",\"last\":\"/api/content-sources/v1.0/snapshots/abcd/rpms?limit=100\\u0026offset=0\"}}\n",
+				Page:   api.PaginationData{Limit: 3, Offset: 2},
+				Search: "foo",
+			},
+		},
+		{
+			Name: "Evoke a wrong method",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				Param:  "search=a",
+			},
+			Expected: TestCaseExpected{
+				Code: http.StatusMethodNotAllowed,
+				Body: "{\"errors\":[{\"status\":405,\"detail\":\"Method Not Allowed\"}]}\n",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+
+		path := fmt.Sprintf("%s/snapshots/%v/rpms", api.FullRootPath(), "abcd")
+		switch {
+		case testCase.Expected.Code >= 200 && testCase.Expected.Code < 300:
+			{
+				suite.dao.Rpm.On("ListSnapshotRpms", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId, []string{snapID}, testCase.Expected.Search, testCase.Expected.Page).
+					Return([]api.SnapshotRpm{
+						{
+							Name:    "demo-1",
+							Summary: "Package demo 1",
+						},
+					}, 1, nil)
+			}
+		case testCase.Expected.Code == http.StatusBadRequest:
+			{
+			}
+		case testCase.Expected.Code == http.StatusInternalServerError:
+			{
+				suite.dao.Rpm.On("ListSnapshotRpms", mock.AnythingOfType("*context.valueCtx"), test_handler.MockOrgId, []string{snapID}, testCase.Expected.Search, testCase.Expected.Page).
+					Return(nil, 0, echo.NewHTTPError(http.StatusInternalServerError, "some error"))
+			}
+		}
+
+		// Prepare request
+		req := httptest.NewRequest(testCase.Given.Method, path, strings.NewReader(""))
+		req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Execute the request
+		code, body, err := suite.serveRpmsRouter(req)
+
+		// Check results
+		assert.Equal(t, testCase.Expected.Code, code)
+		require.NoError(t, err)
+		assert.Equal(t, testCase.Expected.Body, string(body))
+	}
+}
+
 func TestRpmSuite(t *testing.T) {
 	suite.Run(t, new(RpmSuite))
 }


### PR DESCRIPTION
## Summary
adds a new snapshot rpm list api:

```// @Router       /repositories/{uuid}/rpms [get]```

## Testing steps

Create a repo and let it snapshot, then fetch the rpms:

```
GET http://localhost:8000/api/content-sources/v1.0/snapshots/0e6c9e7f-e021-4710-8021-f59cb9c56d82/rpms?search=foo&limit=1
```

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
