### PR TITLE
Fixes 3142: fixes default expiration on redis cache

### DIFF
--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-const PulpContentPathKey = "central-pulp-content-path"
+const PulpContentPathKey = "central-pulp-content-dir"
 
 type redisCache struct {
 	client *redis.Client
@@ -35,9 +35,9 @@ func NewRedisCache() *redisCache {
 func authKey(ctx context.Context) string {
 	identity := identity.GetIdentity(ctx)
 	if identity.Identity.User == nil && identity.Identity.ServiceAccount != nil {
-		return fmt.Sprintf("auth:%v,%v", identity.Identity.ServiceAccount.Username, identity.Identity.OrgID)
+		return fmt.Sprintf("authen:%v,%v", identity.Identity.ServiceAccount.Username, identity.Identity.OrgID)
 	}
-	return fmt.Sprintf("auth:%v,%v", identity.Identity.User.Username, identity.Identity.OrgID)
+	return fmt.Sprintf("authen:%v,%v", identity.Identity.User.Username, identity.Identity.OrgID)
 }
 
 // pulpContentPathKey returns the key for PulpContentPath caching

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,7 +150,7 @@ type Redis struct {
 	Username   string
 	Password   string
 	DB         int
-	Expiration Expiration `mapstructure:"pulp_content_path"`
+	Expiration Expiration `mapstructure:"expiration"`
 }
 
 type Expiration struct {


### PR DESCRIPTION
## Summary
and resets cache keys

## Testing steps

to check the default, apply this patch:

```
diff --git a/cmd/external-repos/main.go b/cmd/external-repos/main.go
index 6eb17810..26065f99 100644
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -27,6 +27,8 @@ func main() {
        config.Load()
        config.ConfigureLogging()
 
+       fmt.Printf("FOO: %v", config.Get().Clients.Redis.Expiration.Rbac)
+
        err := db.Connect()
        if err != nil {
                log.Panic().Err(err).Msg("Failed to connect to database")
```

then when you run: 
```
 go run cmd/external-repos/main.go 
{"level":"warn","time":"2024-02-29T15:11:32-05:00","message":"Caching is disabled."}
FOO: 0s
```
With this change, you should see the default of 60s.

Also you can look in redis itself.
Before:
```
 podman run -it docker.io/library/redis   redis-cli   -h 192.168.1.104  -n 1
192.168.1.104:6379[1]> KEYS *
1) "central-pulp-content-path"
2) "auth:new,1"
192.168.1.104:6379[1]> TTL "auth:new,1"
(integer) -1
```
After:
```
192.168.1.104:6379[1]> KEYS *
1) "authen:new,1"
2) "auth:new4,1"
3) "central-pulp-content-path"
4) "auth:new,1"
192.168.1.104:6379[1]> TTL "authen:new,1"
(integer) 47
```
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
