### PR TITLE
Fixes 3664: support listing/fetching RH tasks

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -90,6 +90,7 @@ func main() {
 			log.Error().Err(err).Msg("error queueing introspection tasks")
 		}
 		if config.Get().Features.Snapshots.Enabled {
+			waitForPulp()
 			err = enqueueSnapshotRepos(nil)
 			if err != nil {
 				log.Error().Err(err).Msg("error queueing snapshot tasks")

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -123,12 +123,18 @@ func saveToDB(db *gorm.DB) error {
 }
 
 func waitForPulp() {
+	failedOnce := false
 	for {
 		client := pulp_client.GetPulpClientWithDomain(context.Background(), pulp_client.DefaultDomain)
 		_, err := client.GetRpmRemoteList()
 		if err == nil {
+			if failedOnce {
+				log.Warn().Msg("Pulp user has been created, sleeping for role creation to happen")
+				time.Sleep(20 * time.Second)
+			}
 			return
 		}
+		failedOnce = true
 		log.Warn().Err(err).Msg("Pulp isn't up yet, waiting 5s.")
 		time.Sleep(5 * time.Second)
 	}

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -45,7 +45,7 @@ func (t taskInfoDaoImpl) Fetch(orgID string, id string) (api.TaskInfoResponse, e
 	result := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid AND rc.org_id = ?", orgID).
-		Where("t.id = ? AND t.org_id = ?", UuidifyString(id), orgID).First(&taskInfo)
+		Where("t.id = ? AND t.org_id in (?)", UuidifyString(id), []string{config.RedHatOrg, orgID}).First(&taskInfo)
 
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
@@ -70,8 +70,8 @@ func (t taskInfoDaoImpl) List(
 
 	filteredDB := t.db.Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
-		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid  AND rc.org_id = ?", orgID).
-		Where("t.org_id = ?", orgID)
+		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid  AND rc.org_id in (?)", []string{config.RedHatOrg, orgID}).
+		Where("t.org_id in (?)", []string{config.RedHatOrg, orgID})
 
 	if filterData.Status != "" {
 		filteredDB = filteredDB.Where("t.status = ?", filterData.Status)


### PR DESCRIPTION
## Summary

allows all orgs to fetch tasks for RH repos

## Testing steps

Ensure a RH repo has been snapshotted, List tasks:

GET /api/content-sources/v1.0/tasks/

and then fetch one's UUID:

GET /api/content-sources/v1.0/tasks/UUID/

Bonus points if you try to cancel a RH task:

POST /api/content-sources/v1.0/tasks/uuid/cancel/

(you shouldn't be able to)

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
