### PR TITLE
Fixes 3720: standardize snapshot routes

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -654,68 +654,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/repositories/snapshots/for_date/": {
-            "post": {
-                "description": "Get nearest snapshot by date for a list of repositories.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "snapshots"
-                ],
-                "summary": "Get nearest snapshot by date for a list of repositories.",
-                "operationId": "listSnapshotsByDate",
-                "parameters": [
-                    {
-                        "description": "request body",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.ListSnapshotByDateRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.ListSnapshotByDateResponse"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/repositories/{uuid}": {
             "get": {
                 "description": "Get repository information.",
@@ -1354,69 +1292,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/repositories/{uuid}/snapshots/{snapshot_uuid}/config.repo": {
-            "get": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "repositories"
-                ],
-                "summary": "Get configuration file of a repository",
-                "operationId": "getRepoConfigurationFile",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Identifier of the repository",
-                        "name": "uuid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Identifier of the snapshot",
-                        "name": "snapshot_uuid",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/repository_gpg_key/{uuid}": {
             "get": {
                 "description": "Get the GPG key file for a repository.",
@@ -1779,6 +1654,68 @@ const docTemplate = `{
                 }
             }
         },
+        "/snapshots/for_date/": {
+            "post": {
+                "description": "Get nearest snapshot by date for a list of repositories.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "snapshots"
+                ],
+                "summary": "Get nearest snapshot by date for a list of repositories.",
+                "operationId": "listSnapshotsByDate",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.ListSnapshotByDateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.ListSnapshotByDateResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/snapshots/package_groups/names": {
             "post": {
                 "description": "This enables users to search for package groups in a given list of snapshots.",
@@ -1904,6 +1841,69 @@ const docTemplate = `{
                     },
                     "415": {
                         "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/snapshots/{snapshot_uuid}/config.repo": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Get configuration file of a repository",
+                "operationId": "getRepoConfigurationFile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Identifier of the repository",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Identifier of the snapshot",
+                        "name": "snapshot_uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1864,83 +1864,6 @@
                 ]
             }
         },
-        "/repositories/snapshots/for_date/": {
-            "post": {
-                "description": "Get nearest snapshot by date for a list of repositories.",
-                "operationId": "listSnapshotsByDate",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/api.ListSnapshotByDateRequest"
-                            }
-                        }
-                    },
-                    "description": "request body",
-                    "required": true,
-                    "x-originalParamName": "body"
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {
-                                        "$ref": "#/components/schemas/api.ListSnapshotByDateResponse"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unauthorized"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Internal Server Error"
-                    }
-                },
-                "summary": "Get nearest snapshot by date for a list of repositories.",
-                "tags": [
-                    "snapshots"
-                ]
-            }
-        },
         "/repositories/{uuid}": {
             "delete": {
                 "description": "This enables deleting a specific repository.",
@@ -2778,87 +2701,6 @@
                 ]
             }
         },
-        "/repositories/{uuid}/snapshots/{snapshot_uuid}/config.repo": {
-            "get": {
-                "operationId": "getRepoConfigurationFile",
-                "parameters": [
-                    {
-                        "description": "Identifier of the repository",
-                        "in": "path",
-                        "name": "uuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Identifier of the snapshot",
-                        "in": "path",
-                        "name": "snapshot_uuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "400": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Bad Request"
-                    },
-                    "401": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unauthorized"
-                    },
-                    "404": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    },
-                    "500": {
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/errors.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Internal Server Error"
-                    }
-                },
-                "summary": "Get configuration file of a repository",
-                "tags": [
-                    "repositories"
-                ]
-            }
-        },
         "/repository_gpg_key/{uuid}": {
             "get": {
                 "description": "Get the GPG key file for a repository.",
@@ -3322,6 +3164,83 @@
                 ]
             }
         },
+        "/snapshots/for_date/": {
+            "post": {
+                "description": "Get nearest snapshot by date for a list of repositories.",
+                "operationId": "listSnapshotsByDate",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.ListSnapshotByDateRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.ListSnapshotByDateResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get nearest snapshot by date for a list of repositories.",
+                "tags": [
+                    "snapshots"
+                ]
+            }
+        },
         "/snapshots/package_groups/names": {
             "post": {
                 "description": "This enables users to search for package groups in a given list of snapshots.",
@@ -3495,6 +3414,87 @@
                 "tags": [
                     "snapshots",
                     "rpms"
+                ]
+            }
+        },
+        "/snapshots/{snapshot_uuid}/config.repo": {
+            "get": {
+                "operationId": "getRepoConfigurationFile",
+                "parameters": [
+                    {
+                        "description": "Identifier of the repository",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Identifier of the snapshot",
+                        "in": "path",
+                        "name": "snapshot_uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get configuration file of a repository",
+                "tags": [
+                    "repositories"
                 ]
             }
         },

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -101,7 +101,7 @@ type SnapshotDao interface {
 	FetchLatestSnapshot(repoConfigUUID string) (api.SnapshotResponse, error)
 	FetchSnapshotsByDateAndRepository(orgID string, request api.ListSnapshotByDateRequest) ([]api.ListSnapshotByDateResponse, error)
 	FetchSnapshotByVersionHref(repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
-	GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, host string) (string, error)
+	GetRepositoryConfigurationFile(orgID, snapshotUUID, host string) (string, error)
 	WithContext(ctx context.Context) SnapshotDao
 	Fetch(uuid string) (api.SnapshotResponse, error)
 }

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -157,15 +157,15 @@ func (sDao *snapshotDaoImpl) fetch(uuid string) (models.Snapshot, error) {
 	return snapshot, nil
 }
 
-func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID, repoConfigUUID, host string) (string, error) {
+func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID, host string) (string, error) {
 	var repoID string
-	rcDao := repositoryConfigDaoImpl{db: sDao.db}
-	repoConfig, err := rcDao.fetchRepoConfig(orgID, repoConfigUUID, true)
+	snapshot, err := sDao.fetch(snapshotUUID)
 	if err != nil {
 		return "", err
 	}
 
-	snapshot, err := sDao.fetch(snapshotUUID)
+	rcDao := repositoryConfigDaoImpl{db: sDao.db}
+	repoConfig, err := rcDao.fetchRepoConfig(orgID, snapshot.RepositoryConfigurationUUID, true)
 	if err != nil {
 		return "", err
 	}
@@ -198,7 +198,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(orgID, snapshotUUID,
 		if repoConfig.IsRedHat() {
 			gpgKeyField = config.RedHatGpgKeyPath
 		} else {
-			gpgKeyField = fmt.Sprintf("https://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfigUUID) // host includes trailing slash
+			gpgKeyField = fmt.Sprintf("https://%v%v/repository_gpg_key/%v", host, api.FullRootPath(), repoConfig.UUID) // host includes trailing slash
 		}
 	}
 

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -171,23 +171,23 @@ func (_m *MockSnapshotDao) FetchSnapshotsByDateAndRepository(orgID string, reque
 	return r0, r1
 }
 
-// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, repoConfigUUID, host
-func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, repoConfigUUID string, host string) (string, error) {
-	ret := _m.Called(orgID, snapshotUUID, repoConfigUUID, host)
+// GetRepositoryConfigurationFile provides a mock function with given fields: orgID, snapshotUUID, host
+func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(orgID string, snapshotUUID string, host string) (string, error) {
+	ret := _m.Called(orgID, snapshotUUID, host)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) (string, error)); ok {
-		return rf(orgID, snapshotUUID, repoConfigUUID, host)
+	if rf, ok := ret.Get(0).(func(string, string, string) (string, error)); ok {
+		return rf(orgID, snapshotUUID, host)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string, string) string); ok {
-		r0 = rf(orgID, snapshotUUID, repoConfigUUID, host)
+	if rf, ok := ret.Get(0).(func(string, string, string) string); ok {
+		r0 = rf(orgID, snapshotUUID, host)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string, string) error); ok {
-		r1 = rf(orgID, snapshotUUID, repoConfigUUID, host)
+	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = rf(orgID, snapshotUUID, host)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -27,9 +27,9 @@ func RegisterSnapshotRoutes(group *echo.Group, daoReg *dao.DaoRegistry) {
 	}
 
 	sh := SnapshotHandler{DaoRegistry: *daoReg}
-	addRoute(group, http.MethodPost, "/repositories/snapshots/for_date/", sh.listSnapshotsByDate, rbac.RbacVerbRead)
+	addRoute(group, http.MethodPost, "/snapshots/for_date/", sh.listSnapshotsByDate, rbac.RbacVerbRead)
 	addRoute(group, http.MethodGet, "/repositories/:uuid/snapshots/", sh.listSnapshots, rbac.RbacVerbRead)
-	addRoute(group, http.MethodGet, "/repositories/:uuid/snapshots/:snapshot_uuid/config.repo", sh.getRepoConfigurationFile, rbac.RbacVerbRead)
+	addRoute(group, http.MethodGet, "/snapshots/:snapshot_uuid/config.repo", sh.getRepoConfigurationFile, rbac.RbacVerbRead)
 }
 
 // Get Snapshots godoc
@@ -72,7 +72,7 @@ func (sh *SnapshotHandler) listSnapshots(c echo.Context) error {
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
-// @Router       /repositories/snapshots/for_date/ [post]
+// @Router       /snapshots/for_date/ [post]
 func (sh *SnapshotHandler) listSnapshotsByDate(c echo.Context) error {
 	var listSnapshotByDateParams api.ListSnapshotByDateRequest
 
@@ -120,10 +120,9 @@ func (sh *SnapshotHandler) listSnapshotsByDate(c echo.Context) error {
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
-// @Router       /repositories/{uuid}/snapshots/{snapshot_uuid}/config.repo [get]
+// @Router       /snapshots/{snapshot_uuid}/config.repo [get]
 func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 	_, orgID := getAccountIdOrgId(c)
-	uuid := c.Param("uuid")
 	snapshotUUID := c.Param("snapshot_uuid")
 
 	host := c.Request().Header.Get("x-forwarded-host")
@@ -131,7 +130,7 @@ func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 		host = c.Request().Host
 	}
 
-	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, uuid, host)
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.WithContext(c.Request().Context()).GetRepositoryConfigurationFile(orgID, snapshotUUID, host)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
 	}

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -71,7 +71,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/repositories/snapshots/for_date/", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/snapshots/for_date/", bytes.NewReader(body))
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -89,7 +89,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/repositories/snapshots/for_date/", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/snapshots/for_date/", bytes.NewReader(body))
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -110,7 +110,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/repositories/snapshots/for_date/", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, api.FullRootPath()+"/snapshots/for_date/", bytes.NewReader(body))
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -154,14 +154,13 @@ func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {
 	t := suite.T()
 
 	orgID := test_handler.MockOrgId
-	repoUUID := uuid.NewString()
 	snapUUID := uuid.NewString()
 	repoConfigFile := "file"
 	refererHeader := "anotherhost.example.com"
 
-	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", orgID, snapUUID, repoUUID, refererHeader).Return(repoConfigFile, nil).Once()
+	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", orgID, snapUUID, refererHeader).Return(repoConfigFile, nil).Once()
 
-	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s/config.repo", api.FullRootPath(), repoUUID, snapUUID)
+	path := fmt.Sprintf("%s/snapshots/%s/config.repo", api.FullRootPath(), snapUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
 	req.Header.Set("x-forwarded-host", refererHeader)


### PR DESCRIPTION
## Summary

This changes 3 apis:

/repositories/snapshots/for_date/
/repositories/{uuid}/snapshots/{snapshot_uuid}/config.repo

to
/snapshots/for_date
/snapshots/{snapshot_uuid}/config.repo


## Testing steps

make requests to the new 2 apis

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
