### PR TITLE
Fixes 3740: clean url during manual introspect

### DIFF
--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -78,6 +78,12 @@ func (p repositoryDaoImpl) ListForIntrospection(urls *[]string, force bool) ([]R
 	var repos []Repository
 	var repo Repository
 
+	if urls != nil {
+		for i, url := range *urls {
+			(*urls)[i] = models.CleanupURL(url)
+		}
+	}
+
 	db := p.db
 	if !force && !config.Get().Options.AlwaysRunCronTasks {
 		introspectThreshold := time.Now().Add(config.IntrospectTimeInterval * -1) // Add a negative duration

--- a/pkg/dao/repositories_test.go
+++ b/pkg/dao/repositories_test.go
@@ -546,4 +546,11 @@ func (s *RepositorySuite) TestListRepositoriesForIntrospection() {
 	repos, err = dao.ListForIntrospection(&[]string{repos[0].URL}, true)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 1, len(repos))
+
+	// Remove trailing slash, and it should still be returned
+	url := repos[0].URL[0 : len(repos[0].URL)-1]
+	assert.Equal(s.T(), repos[0].URL, url+"/")
+	repos, err = dao.ListForIntrospection(&[]string{url}, true)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, len(repos))
 }


### PR DESCRIPTION
## Summary

previously we would 'cleanup' the url when you manually trigger introspection, but this was broken during a refactor

## Testing steps
```
make repos-import
 go run cmd/external-repos/main.go introspect --force https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os
```
Without this pr, the command will do nothing, with you should see:
```
5:44PM DBG Introspecting https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/
```

also during ephemeral deployments you should see the this ansible repo get introspected, without this, its always pending

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
