### PR TITLE
Build: move pulp to a ordinary dependency

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -15,7 +15,6 @@ objects:
         iqePlugin: content-sources
       dependencies:
         - rbac
-      optionalDependencies:
         - pulp
       # https://consoledot.pages.redhat.com/clowder/dev/providers/kafka.html
       kafkaTopics:


### PR DESCRIPTION
## Summary
Since with the default configuration in ephemeral, we do require pulp currently

## Testing steps

deployment passes

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
