### PR TITLE
Fixes 3775: handle nil response for domain updating

### DIFF
--- a/pkg/pulp_client/domains.go
+++ b/pkg/pulp_client/domains.go
@@ -63,11 +63,11 @@ func (r *pulpDaoImpl) UpdateDomainIfNeeded(name string) error {
 			StorageSettings: S3StorageConfiguration(),
 		}
 		_, resp, err := r.client.DomainsAPI.DomainsPartialUpdate(r.ctx, *domain.PulpHref).PatchedDomain(patchedDomain).Execute()
-		if resp.Body != nil {
+		if resp != nil && resp.Body != nil {
 			defer resp.Body.Close()
 		}
 		if err != nil {
-			return err
+			return errorWithResponseBody("error updating domain", resp, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

fixes this glitchtip, which occurs when updating a domain fails:

:runtime error: invalid memory address or nil pointer dereference
Module "github.com/content-services/content-sources-backend/pkg/tasks/worker", line 221, in (*worker).recoverOnPanic
Module "github.com/content-services/content-sources-backend/pkg/pulp_client", line 66, in (*pulpDaoImpl).UpdateDomainIfNeeded
Module "github.com/content-services/content-sources-backend/pkg/tasks", line 89, in (*SnapshotRepository).Run
Module "github.com/content-services/content-sources-backend/pkg/tasks", line 54, in SnapshotHandler
Module "github.com/content-services/content-sources-backend/pkg/tasks/worker", line 174, in (*worker).process

## Testing steps

tests pass
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
