### PR TITLE
Fixes 3668: remove err log for cache miss

### DIFF
--- a/pkg/rbac/client_wrapper.go
+++ b/pkg/rbac/client_wrapper.go
@@ -23,6 +23,7 @@ func (h *myhandler)myMiddleware(c echo.Context) error {
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/RedHatInsights/rbac-client-go"
@@ -76,7 +77,7 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 	if r.cache != nil {
 		acl, err = r.cache.GetAccessList(ctx)
 		cacheHit = err == nil
-		if err != cache.NotFound && err != nil {
+		if !errors.Is(err, cache.NotFound) && err != nil {
 			logger.Error().Err(err).Msg("cache error")
 		}
 	}


### PR DESCRIPTION
## Summary
Corrects the method used to check the cache error is "NotFound". The "NotFound" error is wrapped within the return error, and so `errors.Is(...)` must be used because it checks the wrapped errors and not just the top error.
## Testing steps
1. In your config.yaml set `redis.expiration.rbac : 1s`.
2. Enable mock rbac. First, enable rbac in your config.yaml under `clients.rbac_enabled:  true`. Then, in your run arguments add `mock_rbac` i.e. `go run cmd/content-sources/main.go api consumer mock_rbac`.
3. Hit the repositories list endpoint. Without this change, you'll get the "not found" error.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
