### PR TITLE
Build: switch to official candlepin images

### DIFF
--- a/compose_files/candlepin/Dockerfile
+++ b/compose_files/candlepin/Dockerfile
@@ -1,0 +1,18 @@
+FROM quay.io/candlepin/candlepin:dev-latest
+
+USER root
+RUN echo "jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQL92Dialect" > /etc/candlepin/candlepin.conf; \
+    echo "jpa.config.hibernate.connection.driver_class=org.postgresql.Driver" >> /etc/candlepin/candlepin.conf; \
+    echo "jpa.config.hibernate.connection.url=jdbc:postgresql://cs_postgres-content_1/candlepin" >> /etc/candlepin/candlepin.conf; \
+    echo "jpa.config.hibernate.connection.username=candlepin" >> /etc/candlepin/candlepin.conf; \
+    echo "jpa.config.hibernate.connection.password=candlepin" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.auth.trusted.enable=true" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.auth.oauth.enable=true" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.auth.oauth.consumer.rspec.secret=rspec-oauth-secret" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.db.database_manage_on_startup=Manage" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.standalone=true" >> /etc/candlepin/candlepin.conf;
+
+USER tomcat
+
+
+ENTRYPOINT ["/opt/tomcat/bin/catalina.sh", "run"]

--- a/compose_files/postgres/init.d/create-multiple-dbs.sh
+++ b/compose_files/postgres/init.d/create-multiple-dbs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function create_user_and_database() {
+	local database=$1
+	echo "  Creating user and database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+            create role $database WITH LOGIN superuser password '$database';
+	    CREATE DATABASE $database;
+	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+		create_user_and_database $db
+	done
+	echo "Multiple databases created"
+fi

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -9,9 +9,11 @@ services:
       POSTGRES_USER: ${CONTENT_DATABASE_USER:-content}
       POSTGRES_PASSWORD: ${CONTENT_DATABASE_PASSWORD:-content}
       POSTGRES_DB: ${CONTENT_DATABASE_NAME:-content}
+      POSTGRES_MULTIPLE_DATABASES: candlepin
       POSTGRES_INITDB_ARGS: '--auth-host=scram-sha-256'
       POSTGRES_HOST_AUTH_METHOD: 'scram-sha-256'
     volumes:
+        - ../compose_files/postgres/init.d/:/docker-entrypoint-initdb.d
         - database:/var/lib/postgresql/data/
     healthcheck:
       test: pg_isready
@@ -19,9 +21,13 @@ services:
       retries: 10
       timeout: 3s
   candlepin:
-    image: ghcr.io/ptoscano/candlepin-unofficial:latest
+    image: quay.io/candlepin/candlepin:dev-latest
     ports:
       - 8181:8080
+    environment:
+      JPA_CONFIG_HIBERNATE_CONNECTION_URL: jdbc:postgresql://postgres-content/candlepin
+    depends_on:
+      - postgres-content
   zookeeper:
     image: localhost/kafka:latest
     build:


### PR DESCRIPTION
## Summary

switches to the candlepin:dev-latest image. 

Uses an init file to generate a 2nd db/user for the postgres container

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
