### PR TITLE
Fixes 3813: correct repo label for 9 appstream

### DIFF
--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -23,7 +23,7 @@
     },
     {
         "name": "Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)",
-        "content_label": "rhel-8-for-x86_64-appstream-rpms",
+        "content_label": "rhel-9-for-x86_64-appstream-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os",
         "arch": "x86_64",
         "distribution_version": "9"


### PR DESCRIPTION
## Summary
fixes a repo label
## Testing steps

on main:  ```make repos-import```
```
make db-cli-connect
 select label from repository_configurations where name = 'Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)';
```

switch to the branch
```make repos-import```

```
make db-cli-connect
 select label from repository_configurations where name = 'Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)';
```
You should see the updated label

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
