### PR TITLE
Refs IQE-2748: Revert old sel testing image backend

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -147,7 +147,7 @@ parameters:
 - name: IQE_TEST_IMPORTANCE
   value: ''
 - name: IQE_SEL_IMAGE
-  value: 'quay.io/cloudservices/selenium-standalone-chrome:4.18.1-20240224'
+  value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
 - name: IQE_BROWSERLOG
   value: "1"
 - name: IQE_NETLOG


### PR DESCRIPTION
New sel image is failing the test pipeline because it does not have a controlled shutdown command, making the pod stuck and resulting into timeout.