### PR TITLE
Fixes 3876: remove unused path param in config.repo spec

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1936,13 +1936,6 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Identifier of the repository",
-                        "name": "uuid",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
                         "description": "Identifier of the snapshot",
                         "name": "snapshot_uuid",
                         "in": "path",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3610,15 +3610,6 @@
                 "operationId": "getRepoConfigurationFile",
                 "parameters": [
                     {
-                        "description": "Identifier of the repository",
-                        "in": "path",
-                        "name": "uuid",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
                         "description": "Identifier of the snapshot",
                         "in": "path",
                         "name": "snapshot_uuid",

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -113,8 +113,7 @@ func (sh *SnapshotHandler) listSnapshotsByDate(c echo.Context) error {
 // @Tags         repositories
 // @Accept       json
 // @Produce      text/plain
-// @Param  uuid           path  string    true  "Identifier of the repository"
-// @Param  snapshot_uuid  path  string    true  "Identifier of the snapshot"
+// @Param        snapshot_uuid  path  string    true  "Identifier of the snapshot"
 // @Success      200   {string} string
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse


### PR DESCRIPTION
The path only has a single parameter, being the identifier of the snapshot.

---

Error I encountered:
```
+ /home/sanne/go/bin/go1.20.14 generate -mod=mod ./...
error generating code: error creating operation definitions: path '/snapshots/{snapshot_uuid}/config.repo' has 1 positional parameters, but spec has 2 declared
exit status 1
```
with
```
//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml content-sources.v1.json
```
---

## Summary

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
