### PR TITLE
Refs 2950: add rolling distros to default introspection repos

### DIFF
--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -18,6 +18,12 @@
         "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os"
     },
     {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"
+    },
+    {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/x86_64/appstream/os"
     },
     {
@@ -52,6 +58,12 @@
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.9/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os"
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/x86_64/appstream/os"
@@ -108,6 +120,12 @@
         "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os"
     },
     {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os"
+    },
+    {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.4/aarch64/appstream/os"
     },
     {
@@ -142,6 +160,12 @@
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8.9/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os"
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.0/aarch64/appstream/os"


### PR DESCRIPTION
Image builder switched to rolling URLs for the latest minor in order to find snapshots more easily. As a result the package search now happens against the rolling URLs.
