### PR TITLE
Fixes 3937: use clowder rds ca for tangy db

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -340,6 +340,7 @@ func Load() {
 			path, err := clowder.LoadedConfig.RdsCa()
 			if err == nil {
 				v.Set("database.ca_cert_path", path)
+				v.Set("clients.pulp.database.ca_cert_path", path)
 			} else {
 				log.Error().Err(err).Msg("Cannot read RDS CA cert")
 			}


### PR DESCRIPTION
## Summary

Stage/prod dbs need to use ssl, which wasn't being done because we don't have a ca cert.  Lets try using the one clowder is giving us for our db.

## Testing steps

Don't think there is an easy way  to test this
