### PR TITLE
Refs 3937: Revert 'use clowder rds ca for tangy db (#629)'

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -340,7 +340,6 @@ func Load() {
 			path, err := clowder.LoadedConfig.RdsCa()
 			if err == nil {
 				v.Set("database.ca_cert_path", path)
-				v.Set("clients.pulp.database.ca_cert_path", path)
 			} else {
 				log.Error().Err(err).Msg("Cannot read RDS CA cert")
 			}


### PR DESCRIPTION
## Summary
This reverts commit b2f2940fa8ef8bcb71b07fe0a2c4e151aefa7945.

After the previous change, now the api seems to be timing out

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
