### PR TITLE
Fixes 3939: create/update RH repos as public

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -866,10 +866,11 @@ func (r repositoryConfigDaoImpl) InternalOnly_RefreshRedHatRepo(request api.Repo
 	newRepoConfig.OrgID = config.RedHatOrg
 	newRepoConfig.Label = label
 	newRepo.Origin = config.OriginRedHat
+	newRepo.Public = true // Ensure all RH repos can be searched
 
 	result := r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "url"}},
-		DoUpdates: clause.AssignmentColumns([]string{"origin"})}).Create(&newRepo)
+		DoUpdates: clause.AssignmentColumns([]string{"origin", "public"})}).Create(&newRepo)
 	if result.Error != nil {
 		return nil, result.Error
 	}


### PR DESCRIPTION
## Summary
Create all red hat repos as 'public' so they can be searched just like public repos.

## Testing steps
In master, revert this change:
https://github.com/content-services/content-sources-backend/commit/542f8f32f1c2770609b5bb2c77b62c78ff72a069
then run:
```make compose-clean compose-up repos-import```

Now, verify that some RH repos are not public:

```
make db-cli-connect
# select origin, url, public from repositories;
```

now check out this PR and re-run ```make repos-import``` and rerun the query:

```
make db-cli-connect
# select origin, url, public from repositories;
```

all RH repos should now have public  set to true.

For QE, this will be hard to fully test outside of stage, as the new deployments have all the RH repos in external_repos.json, so they will be public on new deployments.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
