### PR TITLE
Fixes 3940: handle pending snapshot task

### DIFF
--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -2101,6 +2101,18 @@ func (suite *RepositoryConfigSuite) TestCombineStatus() {
 			Expected: "Pending",
 		},
 		{
+			Name: "Introspection successful, snapshot is pending, and repo has no previous snapshots",
+			RepoConfig: &models.RepositoryConfiguration{
+				Snapshot:         true,
+				LastSnapshotTask: &models.TaskInfo{Status: config.TaskStatusPending},
+				LastSnapshotUUID: "",
+			},
+			Repo: &models.Repository{
+				LastIntrospectionStatus: config.StatusValid,
+			},
+			Expected: "Pending",
+		},
+		{
 			Name: "Introspection pending, last snapshot successful, and repo has no previous snapshots",
 			RepoConfig: &models.RepositoryConfiguration{
 				Snapshot:         true,
@@ -2188,6 +2200,18 @@ func (suite *RepositoryConfigSuite) TestCombineStatus() {
 			RepoConfig: &models.RepositoryConfiguration{
 				Snapshot:         true,
 				LastSnapshotTask: &models.TaskInfo{Status: config.TaskStatusRunning},
+				LastSnapshotUUID: uuid.NewString(),
+			},
+			Repo: &models.Repository{
+				LastIntrospectionStatus: config.StatusValid,
+			},
+			Expected: "Pending",
+		},
+		{
+			Name: "Introspection successful, snapshot is pending, and repo has previous snapshots",
+			RepoConfig: &models.RepositoryConfiguration{
+				Snapshot:         true,
+				LastSnapshotTask: &models.TaskInfo{Status: config.TaskStatusPending},
 				LastSnapshotUUID: uuid.NewString(),
 			},
 			Repo: &models.Repository{


### PR DESCRIPTION
## Summary

Fixes case where repository status is "Unknown" if a snapshot task never reaches a running state 

## Testing steps

- When a snapshot task is `pending` or `running`, the status in the repository response should show `Pending` and the UI should show it's `In progress`
- These `Pending` repositories should be displayed when filtering on status `Pending`
- I tested this by adding a repository and snapshotting, then manually changing the snapshot task status to `pending` in the db and verifying that the status shown in the repository status is `Pending`, but there is probably a better way to simulate this case
- EDIT: see [Ryan's comment](https://github.com/content-services/content-sources-backend/pull/634#issuecomment-2051854053) for a better way to test this

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
