### PR TITLE
Fixes 3937: use clowder rds ca for tangy db (#629)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -340,6 +340,7 @@ func Load() {
 			path, err := clowder.LoadedConfig.RdsCa()
 			if err == nil {
 				v.Set("database.ca_cert_path", path)
+				v.Set("clients.pulp.database.ca_cert_path", path)
 			} else {
 				log.Error().Err(err).Msg("Cannot read RDS CA cert")
 			}


### PR DESCRIPTION
## Summary
Set the ca cert for the tangy connection if clowder is present
## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
