### PR TITLE
Fixes 3766: add check for missing repos/snapshots

### DIFF
--- a/pkg/dao/environments.go
+++ b/pkg/dao/environments.go
@@ -139,7 +139,7 @@ func (r environmentDaoImpl) Search(orgID string, request api.ContentUnitSearchRe
 	uuids := request.UUIDs
 
 	// Handle whitespaces and slashes in URLs
-	urls := make([]string, 0)
+	var urls []string
 	for _, url := range request.URLs {
 		url = models.CleanupURL(url)
 		urls = append(urls, url)

--- a/pkg/dao/environments_test.go
+++ b/pkg/dao/environments_test.go
@@ -432,6 +432,24 @@ func (s *EnvironmentSuite) TestEnvironmentSearch() {
 			}
 		}
 	}
+
+	// ensure errors returned for invalid repo uuid / url
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-environment",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		URLs: []string{
+			"https://fake-url.com",
+		},
+		Search: "fake-environment",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
 }
 
 func randomEnvironmentID(size int) string {
@@ -752,4 +770,14 @@ func (s *EnvironmentSuite) TestSearchSnapshotEnvironments() {
 		Description:     expected[0].Description,
 		ID:              expected[0].ID,
 	}}, ret)
+
+	// ensure error returned for invalid snapshot uuid
+	_, err = dao.SearchSnapshotEnvironments(ctx, orgId, api.SnapshotSearchRpmRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-environment",
+		Limit:  pointy.Pointer(55),
+	})
+	assert.Error(s.T(), err)
 }

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -1,7 +1,7 @@
 package dao
 
 import (
-	"fmt"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -67,7 +67,10 @@ func convertSortByToSQL(SortBy string, SortMap map[string]string, defaultSortBy 
 
 func checkRequestUrlAndUuids(request api.ContentUnitSearchRequest) error {
 	if len(request.URLs) == 0 && len(request.UUIDs) == 0 {
-		return fmt.Errorf("must contain at least 1 URL or 1 UUID")
+		return &ce.DaoError{
+			BadValidation: true,
+			Message:       "must contain at least 1 URL or 1 UUID",
+		}
 	}
 	return nil
 }

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -1,11 +1,11 @@
 package dao
 
 import (
-	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	uuid2 "github.com/google/uuid"
 	"github.com/openlyinc/pointy"

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -111,3 +111,38 @@ func isOwnedRepository(db *gorm.DB, orgID string, repositoryConfigUUID string) (
 	}
 	return true, nil
 }
+
+func checkForValidRepoUuidsUrls(uuids []string, urls []string, db *gorm.DB) (bool, bool, string, string) {
+	for _, uuid := range uuids {
+		found := models.RepositoryConfiguration{}
+		if err := db.
+			Where("uuid = ?", uuid).
+			First(&found).
+			Error; err != nil {
+			return false, true, uuid, ""
+		}
+	}
+	for _, url := range urls {
+		found := models.Repository{}
+		if err := db.
+			Where("url = ?", url).
+			First(&found).
+			Error; err != nil {
+			return true, false, "", url
+		}
+	}
+	return true, true, "", ""
+}
+
+func checkForValidSnapshotUuids(uuids []string, db *gorm.DB) (bool, string) {
+	for _, uuid := range uuids {
+		found := models.Snapshot{}
+		if err := db.
+			Where("uuid = ?", uuid).
+			First(&found).
+			Error; err != nil {
+			return false, uuid
+		}
+	}
+	return true, ""
+}

--- a/pkg/dao/package_groups.go
+++ b/pkg/dao/package_groups.go
@@ -140,10 +140,37 @@ func (r packageGroupDaoImpl) Search(orgID string, request api.ContentUnitSearchR
 	// Set to default request limit if null or request limit max (500) if greater than max
 	request = checkRequestLimit(request)
 
-	// FIXME 103 Once the URL stored in the database does not allow
-	//           "/" tail characters, this could be removed
-	urls := handleTailChars(request)
 	uuids := request.UUIDs
+
+	// check that repository uuids exist
+	for _, uuid := range uuids {
+		found := models.RepositoryConfiguration{}
+		if err := r.db.
+			Where("uuid = ?", uuid).
+			First(&found).
+			Error; err != nil {
+			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+				BadValidation: true,
+				Message:       "Could not find repository with UUID: " + uuid,
+			}
+		}
+	}
+	// check that repository urls exist and handle tail chars
+	urls := make([]string, len(request.URLs))
+	for _, url := range request.URLs {
+		url = models.CleanupURL(url)
+		urls = append(urls, url)
+		found := models.Repository{}
+		if err := r.db.
+			Where("url = ?", url).
+			First(&found).
+			Error; err != nil {
+			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+				BadValidation: true,
+				Message:       "Could not find repository with URL: " + url,
+			}
+		}
+	}
 
 	// These commands add an aggregate function (and remove it first if it already exists)
 	// to aggregate and concatenate arrays of package lists and execute the select statement.
@@ -348,6 +375,20 @@ func (r packageGroupDaoImpl) OrphanCleanup() error {
 
 func (r packageGroupDaoImpl) SearchSnapshotPackageGroups(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error) {
 	response := []api.SearchPackageGroupResponse{}
+
+	// check that snapshot uuids exist
+	for _, uuid := range request.UUIDs {
+		found := models.Snapshot{}
+		if err := r.db.
+			Where("uuid = ?", uuid).
+			First(&found).
+			Error; err != nil {
+			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+				BadValidation: true,
+				Message:       "Could not find snapshot with UUID: " + uuid,
+			}
+		}
+	}
 
 	pulpHrefs := []string{}
 	res := readableSnapshots(r.db, orgId).Where("snapshots.UUID in ?", UuidifyStrings(request.UUIDs)).Pluck("version_href", &pulpHrefs)

--- a/pkg/dao/package_groups.go
+++ b/pkg/dao/package_groups.go
@@ -143,7 +143,7 @@ func (r packageGroupDaoImpl) Search(orgID string, request api.ContentUnitSearchR
 	uuids := request.UUIDs
 
 	// Handle whitespaces and slashes in URLs
-	urls := make([]string, 0)
+	var urls []string
 	for _, url := range request.URLs {
 		url = models.CleanupURL(url)
 		urls = append(urls, url)

--- a/pkg/dao/package_groups.go
+++ b/pkg/dao/package_groups.go
@@ -142,33 +142,25 @@ func (r packageGroupDaoImpl) Search(orgID string, request api.ContentUnitSearchR
 
 	uuids := request.UUIDs
 
-	// check that repository uuids exist
-	for _, uuid := range uuids {
-		found := models.RepositoryConfiguration{}
-		if err := r.db.
-			Where("uuid = ?", uuid).
-			First(&found).
-			Error; err != nil {
-			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
-				BadValidation: true,
-				Message:       "Could not find repository with UUID: " + uuid,
-			}
-		}
-	}
-	// check that repository urls exist and handle tail chars
-	urls := make([]string, len(request.URLs))
+	// Handle whitespaces and slashes in URLs
+	urls := make([]string, 0)
 	for _, url := range request.URLs {
 		url = models.CleanupURL(url)
 		urls = append(urls, url)
-		found := models.Repository{}
-		if err := r.db.
-			Where("url = ?", url).
-			First(&found).
-			Error; err != nil {
-			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
-				BadValidation: true,
-				Message:       "Could not find repository with URL: " + url,
-			}
+	}
+
+	// Check that repository uuids and urls exist
+	uuidsValid, urlsValid, uuid, url := checkForValidRepoUuidsUrls(uuids, urls, r.db)
+	if !uuidsValid {
+		return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+			BadValidation: true,
+			Message:       "Could not find repository with UUID: " + uuid,
+		}
+	}
+	if !urlsValid {
+		return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+			BadValidation: true,
+			Message:       "Could not find repository with URL: " + url,
 		}
 	}
 
@@ -376,17 +368,13 @@ func (r packageGroupDaoImpl) OrphanCleanup() error {
 func (r packageGroupDaoImpl) SearchSnapshotPackageGroups(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error) {
 	response := []api.SearchPackageGroupResponse{}
 
-	// check that snapshot uuids exist
-	for _, uuid := range request.UUIDs {
-		found := models.Snapshot{}
-		if err := r.db.
-			Where("uuid = ?", uuid).
-			First(&found).
-			Error; err != nil {
-			return []api.SearchPackageGroupResponse{}, &ce.DaoError{
-				BadValidation: true,
-				Message:       "Could not find snapshot with UUID: " + uuid,
-			}
+	// Check that snapshot uuids exist
+	uuids := request.UUIDs
+	uuidsValid, uuid := checkForValidSnapshotUuids(uuids, r.db)
+	if !uuidsValid {
+		return []api.SearchPackageGroupResponse{}, &ce.DaoError{
+			BadValidation: true,
+			Message:       "Could not find snapshot with UUID: " + uuid,
 		}
 	}
 

--- a/pkg/dao/package_groups_test.go
+++ b/pkg/dao/package_groups_test.go
@@ -472,6 +472,24 @@ func (s *PackageGroupSuite) TestPackageGroupSearch() {
 			}
 		}
 	}
+
+	// ensure errors returned for invalid repo uuid / url
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-package-group",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		URLs: []string{
+			"https://fake-url.com",
+		},
+		Search: "fake-package-group",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
 }
 
 func randomPackageGroupID(size int) string {
@@ -765,6 +783,16 @@ func (s *PackageGroupSuite) TestSearchSnapshotPackageGroups() {
 		Description:      expected[0].Description,
 		PackageList:      expected[0].Packages,
 	}}, ret)
+
+	// ensure error returned for invalid snapshot uuid
+	_, err = dao.SearchSnapshotPackageGroups(ctx, orgId, api.SnapshotSearchRpmRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-package-group",
+		Limit:  pointy.Pointer(55),
+	})
+	assert.Error(s.T(), err)
 }
 
 func TestFilteredConvertPackageGroups(t *testing.T) {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -160,7 +160,7 @@ func (r rpmDaoImpl) Search(orgID string, request api.ContentUnitSearchRequest) (
 	uuids := request.UUIDs
 
 	// Handle whitespaces and slashes in URLs
-	urls := make([]string, 0)
+	var urls []string
 	for _, url := range request.URLs {
 		url = models.CleanupURL(url)
 		urls = append(urls, url)
@@ -507,7 +507,7 @@ func (r *rpmDaoImpl) DetectRpms(orgID string, request api.DetectRpmsRequest) (*a
 	var foundRpmsModel []string
 
 	// handle whitespaces and slashes in URLs
-	urls := make([]string, 0)
+	var urls []string
 	for _, url := range request.URLs {
 		url = models.CleanupURL(url)
 		urls = append(urls, url)

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -484,6 +484,24 @@ func (s *RpmSuite) TestRpmSearch() {
 			}
 		}
 	}
+
+	// ensure errors returned for invalid repo uuid / url
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-package",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
+	_, err = dao.Search("fake-org", api.ContentUnitSearchRequest{
+		URLs: []string{
+			"https://fake-url.com",
+		},
+		Search: "fake-package",
+		Limit:  pointy.Pointer(50),
+	})
+	assert.Error(t, err)
 }
 
 // func (s *RpmSuite) randomPackageName(size int) string {
@@ -907,6 +925,16 @@ func (s *RpmSuite) TestSearchRpmsForSnapshots() {
 		PackageName: expected[0].Name,
 		Summary:     expected[0].Summary,
 	}}, ret)
+
+	// ensure error returned for invalid snapshot uuid
+	_, err = dao.SearchSnapshotRpms(ctx, orgId, api.SnapshotSearchRpmRequest{
+		UUIDs: []string{
+			"fake-uuid",
+		},
+		Search: "fake-package",
+		Limit:  pointy.Pointer(55),
+	})
+	assert.Error(s.T(), err)
 }
 
 func (s *RpmSuite) TestListRpmsForSnapshots() {

--- a/pkg/handler/environments.go
+++ b/pkg/handler/environments.go
@@ -50,7 +50,7 @@ func (rh *RepositoryEnvironmentHandler) searchEnvironmentByName(c echo.Context) 
 
 	apiResponse, err := rh.Dao.Environment.Search(orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching environments", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching environments", err.Error())
 	}
 
 	return c.JSON(200, apiResponse)
@@ -128,7 +128,7 @@ func (rh *RepositoryEnvironmentHandler) searchSnapshotEnvironments(c echo.Contex
 
 	resp, err := rh.Dao.Environment.SearchSnapshotEnvironments(c.Request().Context(), orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching environments", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching environments", err.Error())
 	}
 	return c.JSON(200, resp)
 }

--- a/pkg/handler/package_groups.go
+++ b/pkg/handler/package_groups.go
@@ -50,7 +50,7 @@ func (rh *RepositoryPackageGroupHandler) searchPackageGroupByName(c echo.Context
 
 	apiResponse, err := rh.Dao.PackageGroup.Search(orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching package groups", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching package groups", err.Error())
 	}
 
 	return c.JSON(200, apiResponse)
@@ -127,7 +127,7 @@ func (rh *RepositoryPackageGroupHandler) searchSnapshotPackageGroups(c echo.Cont
 
 	resp, err := rh.Dao.PackageGroup.SearchSnapshotPackageGroups(c.Request().Context(), orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching package groups", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching package groups", err.Error())
 	}
 	return c.JSON(200, resp)
 }

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -52,7 +52,7 @@ func (rh *RpmHandler) searchRpmByName(c echo.Context) error {
 
 	apiResponse, err := rh.Dao.Rpm.Search(orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching RPMs", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching RPMs", err.Error())
 	}
 
 	return c.JSON(200, apiResponse)
@@ -128,7 +128,7 @@ func (rh *RpmHandler) searchSnapshotRPMs(c echo.Context) error {
 
 	resp, err := rh.Dao.Rpm.SearchSnapshotRpms(c.Request().Context(), orgId, dataInput)
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error searching RPMs", err.Error())
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error searching RPMs", err.Error())
 	}
 	return c.JSON(200, resp)
 }


### PR DESCRIPTION
## Summary

- Returns a 400 response code if a repository / snapshot is not found for these search endpoints:
```
/rpms/names
/package_groups/names
/environments/names
/snapshots/rpms/names
/snapshots/package_groups/names
/snapshots/environments/names 
```
- Updates the error response for requests with missing urls / uuids to return a 400 instead of a 500
- Also adds a handler test for DetectRpms because I realized I forgot to do that :) 

## Testing steps

- Make a request to each endpoint with an incorrect uuid / url, each should return 400
- Requests with no uuid / url to these endpoints should also return 400

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
