### PR TITLE
Refs 3897: fix sentry name

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -196,7 +196,7 @@ objects:
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
-                    name: content-sources-sentry
+                    name: content-sources-glitchtip
                     key: dsn
                     optional: true
               - name: CLIENTS_PULP_SERVER

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -501,6 +501,8 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
 	}
 
+	log.Logger.Error().Msg("this is a test")
+
 	response, err := rh.DaoRegistry.RepositoryConfig.WithContext(c.Request().Context()).Fetch(orgID, uuid)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())


### PR DESCRIPTION
## Summary

I'm pretty sure this is the reason we're not getting alerts for service errors. I noticed in the logs that sentry was being configured for the task worker, but not for the service. The name for the task worker is "content-sources-glitchtip". Both pods were working fine in ephemeral if I used an env variable.

I included an error log to verify if this works. If it does, I'll remove the error log in a followup.

## Testing steps
Just merge and see I think

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
