### PR TITLE
Refs 2422: Add pending task metrics

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -174,7 +174,7 @@ func instrumentation(ctx context.Context, wg *sync.WaitGroup, metrics *m.Metrics
 
 	go func() {
 		<-ctx.Done()
-		shutdownContext, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownContext, cancel := context.WithTimeout(context.Background(), time.Duration(config.Get().Metrics.CollectionFrequency)*time.Second)
 		if err := e.Shutdown(shutdownContext); err != nil {
 			log.Logger.Error().Msgf("error stopping instrumentation: %s", err.Error())
 		}

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -61,9 +61,10 @@ options:
   introspect_api_time_limit_sec: 0
   enable_notifications: true
   template_event_topic: "platform.content-sources.template"
-# metrics:
-#   path: "/metrics"
-#   port: 9000
+ metrics:
+   path: "/metrics"
+   port: 9000
+   collection_frequency: 60
 
 # sentry:
 #   dsn: https://public@sentry.example.com/1

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -44,6 +44,7 @@ tasking:
 
 logging:
   level: debug
+  metrics_level: debug
   console: True
 cloudwatch:
   region:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -124,8 +124,9 @@ type Database struct {
 }
 
 type Logging struct {
-	Level   string
-	Console bool
+	Level        string
+	MetricsLevel string `mapstructure:"metrics_level"`
+	Console      bool
 }
 
 type Certs struct {
@@ -181,6 +182,9 @@ type Metrics struct {
 	// Defines the metrics port that the app should be configured to listen on for
 	// metric traffic.
 	Port int `mapstructure:"port"`
+
+	// How often (in seconds) to run queries to collect some metrics
+	CollectionFrequency int `mapstructure:"collection_frequency"`
 }
 
 const (
@@ -235,9 +239,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("options.template_event_topic", "platform.content-sources.template")
 	v.SetDefault("options.repository_import_filter", "")
 	v.SetDefault("logging.level", "info")
+	v.SetDefault("logging.metrics_level", "")
 	v.SetDefault("logging.console", true)
 	v.SetDefault("metrics.path", "/metrics")
 	v.SetDefault("metrics.port", 9000)
+	v.SetDefault("metrics.collection_frequency", 60)
 	v.SetDefault("clients.rbac_enabled", true)
 	v.SetDefault("clients.rbac_base_url", "http://rbac-service:8000/api/rbac/v1")
 	v.SetDefault("clients.rbac_timeout", 30)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,10 +130,9 @@ type Logging struct {
 }
 
 type Certs struct {
-	CertPath           string `mapstructure:"cert_path"`
-	DaysTillExpiration int
-	CdnCertPair        *tls.Certificate
-	CdnCertPairString  *string
+	CertPath          string `mapstructure:"cert_path"`
+	CdnCertPair       *tls.Certificate
+	CdnCertPairString *string
 }
 
 type Cloudwatch struct {
@@ -393,10 +392,6 @@ func Load() {
 	}
 	LoadedConfig.Certs.CdnCertPairString = certString
 	LoadedConfig.Certs.CdnCertPair = cert
-	LoadedConfig.Certs.DaysTillExpiration, err = DaysTillExpiration(cert)
-	if err != nil {
-		log.Error().Err(err).Msg("Could not calculate cert expiration date")
-	}
 
 	if LoadedConfig.Clients.Redis.Host == "" {
 		log.Warn().Msg("Caching is disabled.")
@@ -461,10 +456,17 @@ func ConfigureCertificate() (*tls.Certificate, *string, error) {
 	return &cert, &certString, nil
 }
 
-// DaysTillExpiration Finds the number of days until the specified certificate expired
+func CDNCertDaysTillExpiration() (int, error) {
+	if Get().Certs.CdnCertPair == nil {
+		return 0, nil
+	}
+	return daysTillExpiration(Get().Certs.CdnCertPair)
+}
+
+// daysTillExpiration Finds the number of days until the specified certificate expired
 // tls.Certificate allows for multiple certs to be combined, so this takes the expiration date
 // that is coming the soonest
-func DaysTillExpiration(certs *tls.Certificate) (int, error) {
+func daysTillExpiration(certs *tls.Certificate) (int, error) {
 	expires := time.Time{}
 	found := false
 	if certs == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfigureCertificateFile(t *testing.T) {
 	assert.NotNil(t, cert)
 	assert.NotNil(t, strCert)
 
-	days, err := DaysTillExpiration(cert)
+	days, err := daysTillExpiration(cert)
 	assert.NoError(t, err)
 	assert.True(t, days > 0)
 }

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -108,3 +108,15 @@ func sentryWriter(dsn string) (io.Writer, error) {
 	})
 	return wr, nil
 }
+
+func MetricsLevel() zerolog.Level {
+	logLevel := Get().Logging.MetricsLevel
+	if logLevel == "" { // Default to the base logging level, if not set
+		logLevel = Get().Logging.Level
+	}
+	level, err := zerolog.ParseLevel(logLevel)
+	if err != nil {
+		log.Error().Msgf("Could not parse metrics logging level %v %v", level, err)
+	}
+	return level
+}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -125,6 +125,9 @@ type MetricsDao interface {
 	RepositoriesIntrospectionCount(ctx context.Context, hours int, public bool) IntrospectionCount
 	PublicRepositoriesFailedIntrospectionCount(ctx context.Context) int
 	OrganizationTotal(ctx context.Context) int64
+	PendingTasksAverageLatency(ctx context.Context) float64
+	PendingTasksCount(ctx context.Context) int64
+	PendingTasksOldestTask(ctx context.Context) float64
 }
 
 //go:generate mockery --name TaskInfoDao --filename task_info_mock.go --inpackage

--- a/pkg/dao/metrics_mock.go
+++ b/pkg/dao/metrics_mock.go
@@ -27,6 +27,48 @@ func (_m *MockMetricsDao) OrganizationTotal(ctx context.Context) int64 {
 	return r0
 }
 
+// PendingTasksAverageLatency provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) PendingTasksAverageLatency(ctx context.Context) float64 {
+	ret := _m.Called(ctx)
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(context.Context) float64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// PendingTasksCount provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) PendingTasksCount(ctx context.Context) int64 {
+	ret := _m.Called(ctx)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context) int64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// PendingTasksOldestTask provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) PendingTasksOldestTask(ctx context.Context) float64 {
+	ret := _m.Called(ctx)
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(context.Context) float64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
 // PublicRepositoriesFailedIntrospectionCount provides a mock function with given fields: ctx
 func (_m *MockMetricsDao) PublicRepositoriesFailedIntrospectionCount(ctx context.Context) int {
 	ret := _m.Called(ctx)

--- a/pkg/dao/rpms_mock.go
+++ b/pkg/dao/rpms_mock.go
@@ -49,10 +49,6 @@ func (_m *MockRpmDao) DetectRpms(ctx context.Context, orgID string, request api.
 func (_m *MockRpmDao) InsertForRepository(ctx context.Context, repoUuid string, pkgs []yum.Package) (int64, error) {
 	ret := _m.Called(ctx, repoUuid, pkgs)
 
-	if len(ret) == 0 {
-		panic("no return value specified for InsertForRepository")
-	}
-
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, []yum.Package) (int64, error)); ok {
@@ -76,10 +72,6 @@ func (_m *MockRpmDao) InsertForRepository(ctx context.Context, repoUuid string, 
 // List provides a mock function with given fields: ctx, orgID, uuidRepo, limit, offset, search, sortBy
 func (_m *MockRpmDao) List(ctx context.Context, orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryRpmCollectionResponse, int64, error) {
 	ret := _m.Called(ctx, orgID, uuidRepo, limit, offset, search, sortBy)
-
-	if len(ret) == 0 {
-		panic("no return value specified for List")
-	}
 
 	var r0 api.RepositoryRpmCollectionResponse
 	var r1 int64
@@ -111,10 +103,6 @@ func (_m *MockRpmDao) List(ctx context.Context, orgID string, uuidRepo string, l
 // ListSnapshotErrata provides a mock function with given fields: ctx, orgId, snapshotUUIDs, filters, pageOpts
 func (_m *MockRpmDao) ListSnapshotErrata(ctx context.Context, orgId string, snapshotUUIDs []string, filters tangy.ErrataListFilters, pageOpts api.PaginationData) ([]api.SnapshotErrata, int, error) {
 	ret := _m.Called(ctx, orgId, snapshotUUIDs, filters, pageOpts)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListSnapshotErrata")
-	}
 
 	var r0 []api.SnapshotErrata
 	var r1 int
@@ -149,10 +137,6 @@ func (_m *MockRpmDao) ListSnapshotErrata(ctx context.Context, orgId string, snap
 func (_m *MockRpmDao) ListSnapshotRpms(ctx context.Context, orgId string, snapshotUUIDs []string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error) {
 	ret := _m.Called(ctx, orgId, snapshotUUIDs, search, pageOpts)
 
-	if len(ret) == 0 {
-		panic("no return value specified for ListSnapshotRpms")
-	}
-
 	var r0 []api.SnapshotRpm
 	var r1 int
 	var r2 error
@@ -186,10 +170,6 @@ func (_m *MockRpmDao) ListSnapshotRpms(ctx context.Context, orgId string, snapsh
 func (_m *MockRpmDao) OrphanCleanup(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
-	if len(ret) == 0 {
-		panic("no return value specified for OrphanCleanup")
-	}
-
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -203,10 +183,6 @@ func (_m *MockRpmDao) OrphanCleanup(ctx context.Context) error {
 // Search provides a mock function with given fields: ctx, orgID, request
 func (_m *MockRpmDao) Search(ctx context.Context, orgID string, request api.ContentUnitSearchRequest) ([]api.SearchRpmResponse, error) {
 	ret := _m.Called(ctx, orgID, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Search")
-	}
 
 	var r0 []api.SearchRpmResponse
 	var r1 error
@@ -233,10 +209,6 @@ func (_m *MockRpmDao) Search(ctx context.Context, orgID string, request api.Cont
 // SearchSnapshotRpms provides a mock function with given fields: ctx, orgId, request
 func (_m *MockRpmDao) SearchSnapshotRpms(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchRpmResponse, error) {
 	ret := _m.Called(ctx, orgId, request)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SearchSnapshotRpms")
-	}
 
 	var r0 []api.SearchRpmResponse
 	var r1 error

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -21,6 +21,10 @@ const (
 	MessageResultTotal                             = "message_result_total"
 	OrgTotal                                       = "org_total"
 	RHCertExpiryDays                               = "rh_cert_expiry_days"
+	TaskStats                                      = "task_stats"
+	TaskStatsLabelPendingCount                     = "task_stats_pending_count"
+	TaskStatsLabelOldestWait                       = "task_stats_oldest_wait"
+	TaskStatsLabelAverageWait                      = "task_stats_average_wait"
 )
 
 type Metrics struct {
@@ -34,6 +38,7 @@ type Metrics struct {
 	CustomRepositories36HourIntrospectionTotal     prometheus.GaugeVec
 	MessageResultTotal                             prometheus.CounterVec
 	MessageLatency                                 prometheus.Histogram
+	TaskStats                                      prometheus.GaugeVec
 	OrgTotal                                       prometheus.Gauge
 	RHCertExpiryDays                               prometheus.Gauge
 	reg                                            *prometheus.Registry
@@ -77,6 +82,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      RepositoryConfigsTotal,
 			Help:      "Number of repository configurations",
 		}),
+		TaskStats: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TaskStats,
+			Help:      "Stats around Tasks",
+		}, []string{"label"}),
 		PublicRepositories36HourIntrospectionTotal: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      PublicRepositories36HourIntrospectionTotal,

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -60,12 +60,12 @@ const (
 
 	sqlRequeue = `
 		UPDATE tasks
-		SET started_at = NULL, token = NULL, status = 'pending', retries = retries + 1
+		SET started_at = NULL, token = NULL, status = 'pending', retries = retries + 1, queued_at = statement_timestamp()
 		WHERE id = $1 AND started_at IS NOT NULL AND finished_at IS NULL`
 
 	sqlRequeueFailedTasks = `
 		UPDATE tasks
-		SET started_at = NULL, finished_at = NULL, token = NULL, status = 'pending', retries = retries + 1
+		SET started_at = NULL, finished_at = NULL, token = NULL, status = 'pending', retries = retries + 1, queued_at = statement_timestamp()
 		WHERE started_at IS NOT NULL AND finished_at IS NOT NULL AND status = 'failed' AND retries < 3 AND next_retry_time <= statement_timestamp() AND type = ANY($1::text[])`
 
 	sqlInsertDependency  = `INSERT INTO task_dependencies VALUES ($1, $2)`


### PR DESCRIPTION
## Summary
    Adds new metrics:
    * Average queue time of pending task
    * Length in queue for the oldest pending task
    * Number of pending tasks
    Also:
    * Increases default metric calculations to 30 seconds from 5
    * makes interval for metric calculation configurable
    * adds log level override for metrics so you can set the rest of the app to trace while metrics are set to debugging

## Testing steps

on a new db:

```
make run
```
in another tab:
```
make repos-import
go run cmd/external-repos/main.go nightly-jobs
```
This will kick off a ton of tasks, you can monitor with:
```
 curl localhost:9000/metrics | grep task_stats
```

This will update every ~30 seconds.  

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
