### PR TITLE
Fixes 3793: add make command for mockery

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,10 @@ $ make openapi
 
 ### Generating/Update mocks:
 
-Ensure [mockery](https://vektra.github.io/mockery/latest/installation/) is installed.
+To use mockery:
 
-Then:
-
-```sh
-$ go generate ./...
-```
+1. `make install-mockery`
+2. `make mock`
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -206,12 +206,13 @@ $ curl -H "$( ./scripts/header.sh 9999 1111 )" http://localhost:8000/api/content
 $ make openapi
 ```
 
-### Generating/Update mocks:
+### Generating new mocks:
 
-To use mockery:
+```sh
+$ make mock
+```
 
-1. `make install-mockery`
-2. `make mock`
+
 
 ### Configuration
 

--- a/mk/includes.mk
+++ b/mk/includes.mk
@@ -30,6 +30,7 @@ include mk/pkg-deps-graph.mk
 include mk/swag.mk
 include mk/lint.mk
 include mk/docker.mk
+include mk/mockery.mk
 include mk/meta-db.mk
 include mk/db.mk
 include mk/meta-kafka.mk

--- a/mk/mockery.mk
+++ b/mk/mockery.mk
@@ -1,0 +1,12 @@
+MOCKERY_VERSION := 2.36.1
+
+export GO_OUTPUT
+
+.PHONY: install-mockery
+install-mockery: ## Install mockery locally on your GO_OUTPUT (./release) directory
+	mkdir -p $(GO_OUTPUT) && \
+	curl -sSfL https://github.com/vektra/mockery/releases/download/v$(MOCKERY_VERSION)/mockery_$(MOCKERY_VERSION)_$(shell uname -s)_$(shell uname -m).tar.gz | tar -xz -C $(GO_OUTPUT) mockery
+
+.PHONY: mock
+mock: ## Regenerate mocks
+	go generate ./...

--- a/mk/mockery.mk
+++ b/mk/mockery.mk
@@ -2,11 +2,10 @@ MOCKERY_VERSION := 2.36.1
 
 export GO_OUTPUT
 
-.PHONY: install-mockery
-install-mockery: ## Install mockery locally on your GO_OUTPUT (./release) directory
+$(GO_OUTPUT)/mockery: ## Install mockery locally on your GO_OUTPUT (./release) directory
 	mkdir -p $(GO_OUTPUT) && \
 	curl -sSfL https://github.com/vektra/mockery/releases/download/v$(MOCKERY_VERSION)/mockery_$(MOCKERY_VERSION)_$(shell uname -s)_$(shell uname -m).tar.gz | tar -xz -C $(GO_OUTPUT) mockery
 
 .PHONY: mock
-mock: ## Regenerate mocks
+mock: $(GO_OUTPUT)/mockery ## Install mockery if it isn't already in ./release directory and regenerate mocks
 	go generate ./...

--- a/mk/mockery.mk
+++ b/mk/mockery.mk
@@ -1,4 +1,4 @@
-MOCKERY_VERSION := 2.36.1
+MOCKERY_VERSION := $(shell curl -L https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
 
 export GO_OUTPUT
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,7 +12,7 @@ import (
 
 var NotFound = errors.New("not found in cache")
 
-//go:generate mockery --name Cache --filename cache_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name Cache --filename cache_mock.go --inpackage
 type Cache interface {
 	GetAccessList(ctx context.Context) (rbac.AccessList, error)
 	SetAccessList(ctx context.Context, accessList rbac.AccessList) error

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -1,6 +1,6 @@
 package candlepin_client
 
-//go:generate mockery  --name CandlepinClient --filename candlepin_client_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery  --name CandlepinClient --filename candlepin_client_mock.go --inpackage
 type CandlepinClient interface {
 	CreateOwner() error
 	ImportManifest(filename string) error

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -64,7 +64,7 @@ func SetupGormTableOrFail(db *gorm.DB) {
 	}
 }
 
-//go:generate mockery --name RepositoryConfigDao --filename repository_configs_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name RepositoryConfigDao --filename repository_configs_mock.go --inpackage
 type RepositoryConfigDao interface {
 	Create(newRepo api.RepositoryRequest) (api.RepositoryResponse, error)
 	BulkCreate(newRepositories []api.RepositoryRequest) ([]api.RepositoryResponse, []error)
@@ -85,7 +85,7 @@ type RepositoryConfigDao interface {
 	FetchWithoutOrgID(uuid string) (api.RepositoryResponse, error)
 }
 
-//go:generate mockery --name RpmDao --filename rpms_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name RpmDao --filename rpms_mock.go --inpackage
 type RpmDao interface {
 	List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryRpmCollectionResponse, int64, error)
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchRpmResponse, error)
@@ -97,7 +97,7 @@ type RpmDao interface {
 	OrphanCleanup() error
 }
 
-//go:generate mockery --name RepositoryDao --filename repositories_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name RepositoryDao --filename repositories_mock.go --inpackage
 type RepositoryDao interface {
 	FetchForUrl(url string) (Repository, error)
 	ListForIntrospection(urls *[]string, force bool) ([]Repository, error)
@@ -107,7 +107,7 @@ type RepositoryDao interface {
 	OrphanCleanup() error
 }
 
-//go:generate mockery --name SnapshotDao --filename snapshots_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name SnapshotDao --filename snapshots_mock.go --inpackage
 type SnapshotDao interface {
 	Create(snap *models.Snapshot) error
 	List(orgID string, repoConfigUuid string, paginationData api.PaginationData, filterData api.FilterData) (api.SnapshotCollectionResponse, int64, error)
@@ -122,7 +122,7 @@ type SnapshotDao interface {
 	FetchSnapshotsModelByDateAndRepository(orgID string, request api.ListSnapshotByDateRequest) ([]models.Snapshot, error)
 }
 
-//go:generate mockery --name MetricsDao --filename metrics_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name MetricsDao --filename metrics_mock.go --inpackage
 type MetricsDao interface {
 	RepositoriesCount() int
 	RepositoryConfigsCount() int
@@ -131,7 +131,7 @@ type MetricsDao interface {
 	OrganizationTotal() int64
 }
 
-//go:generate mockery --name TaskInfoDao --filename task_info_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name TaskInfoDao --filename task_info_mock.go --inpackage
 type TaskInfoDao interface {
 	Fetch(OrgID string, id string) (api.TaskInfoResponse, error)
 	List(OrgID string, pageData api.PaginationData, filterData api.TaskInfoFilterData) (api.TaskInfoCollectionResponse, int64, error)
@@ -144,13 +144,13 @@ type AdminTaskDao interface {
 	List(pageData api.PaginationData, filterData api.AdminTaskFilterData) (api.AdminTaskInfoCollectionResponse, int64, error)
 }
 
-//go:generate mockery --name DomainDao --filename domain_dao_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name DomainDao --filename domain_dao_mock.go --inpackage
 type DomainDao interface {
 	FetchOrCreateDomain(orgId string) (string, error)
 	Fetch(orgId string) (string, error)
 }
 
-//go:generate mockery --name PackageGroupDao --filename package_groups_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name PackageGroupDao --filename package_groups_mock.go --inpackage
 type PackageGroupDao interface {
 	List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryPackageGroupCollectionResponse, int64, error)
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchPackageGroupResponse, error)
@@ -159,7 +159,7 @@ type PackageGroupDao interface {
 	SearchSnapshotPackageGroups(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchPackageGroupResponse, error)
 }
 
-//go:generate mockery --name EnvironmentDao --filename environments_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name EnvironmentDao --filename environments_mock.go --inpackage
 type EnvironmentDao interface {
 	List(orgID string, uuidRepo string, limit int, offset int, search string, sortBy string) (api.RepositoryEnvironmentCollectionResponse, int64, error)
 	Search(orgID string, request api.ContentUnitSearchRequest) ([]api.SearchEnvironmentResponse, error)
@@ -168,7 +168,7 @@ type EnvironmentDao interface {
 	SearchSnapshotEnvironments(ctx context.Context, orgId string, request api.SnapshotSearchRpmRequest) ([]api.SearchEnvironmentResponse, error)
 }
 
-//go:generate mockery --name TemplateDao --filename templates_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery --name TemplateDao --filename templates_mock.go --inpackage
 type TemplateDao interface {
 	Create(templateRequest api.TemplateRequest) (api.TemplateResponse, error)
 	Fetch(orgID string, uuid string) (api.TemplateResponse, error)

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -6,7 +6,7 @@ import (
 	zest "github.com/content-services/zest/release/v2024"
 )
 
-//go:generate mockery  --name PulpGlobalClient --filename pulp_global_client_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery  --name PulpGlobalClient --filename pulp_global_client_mock.go --inpackage
 type PulpGlobalClient interface {
 	// Domains
 	LookupOrCreateDomain(name string) (string, error)
@@ -20,7 +20,7 @@ type PulpGlobalClient interface {
 	GetContentPath() (string, error)
 }
 
-//go:generate mockery  --name PulpClient --filename pulp_client_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery  --name PulpClient --filename pulp_client_mock.go --inpackage
 type PulpClient interface {
 	// Remotes
 	CreateRpmRemote(name string, url string, clientCert *string, clientKey *string, caCert *string) (*zest.RpmRpmRemoteResponse, error)

--- a/pkg/tasks/client/client.go
+++ b/pkg/tasks/client/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-//go:generate mockery  --name TaskClient --filename client_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery  --name TaskClient --filename client_mock.go --inpackage
 type TaskClient interface {
 	Enqueue(task queue.Task) (uuid.UUID, error)
 	SendCancelNotification(ctx context.Context, taskId string) error

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -23,7 +23,7 @@ type Task struct {
 	RequestID      string
 }
 
-//go:generate mockery  --name Queue --filename queue_mock.go --inpackage
+//go:generate $GO_OUTPUT/mockery  --name Queue --filename queue_mock.go --inpackage
 type Queue interface {
 	// Enqueue Enqueues a job
 	Enqueue(task *Task) (uuid.UUID, error)


### PR DESCRIPTION
## Summary

Adds make command to install mockery and regenerate mocks

## Testing steps

- Run `make mock`. This should install the latest version of mockery if it isn't already installed in the release directory and regenerate the mocks we have

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
