### PR TITLE
Fixes 4013,4008: Use custom lecho for enhanced logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/content-services/content-sources-backend
 
 go 1.20
 
+replace github.com/ziflex/lecho/v3 =>  /home/jlsherri/git/lecho
+
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
 	github.com/content-services/tang v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,9 @@ module github.com/content-services/content-sources-backend
 
 go 1.20
 
-replace github.com/ziflex/lecho/v3 =>  /home/jlsherri/git/lecho
-
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
+	github.com/content-services/lecho/v3 v3.5.2
 	github.com/content-services/tang v0.0.6
 	github.com/content-services/yummy v1.0.11
 	github.com/getkin/kin-openapi v0.124.0
@@ -28,7 +27,6 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/swag v1.16.3
-	github.com/ziflex/lecho/v3 v3.5.0
 	gorm.io/driver/postgres v1.5.4
 	gorm.io/gorm v1.25.5
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/content-services/caliri/release/v4 v4.4.5-beta.1 h1:tIXKiFi0aatf2w6rDYdjQLqHtjBQzeHYCR+F1bmfr/s=
 github.com/content-services/caliri/release/v4 v4.4.5-beta.1/go.mod h1:ziS43sIDnl+q3HmcO+PCMgLKgZb4uISpieUAc3y1l3s=
+github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
+github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
 github.com/content-services/tang v0.0.6 h1:PuJYkGNzESV25UoKArH4PG5L62BOeyMKOLR8jekJPmk=
 github.com/content-services/tang v0.0.6/go.mod h1:2qcK/XfRd4mQaBOzDfLI56ua/T2mJo7sQCdpxzjsiU0=
 github.com/content-services/yummy v1.0.11 h1:Rb9reihh9EgSSEZbFXcAfezl378YBKDmpq7zTaH8DqY=
@@ -271,8 +273,6 @@ github.com/xdg/scram v1.0.5/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49
 github.com/xdg/stringprep v1.0.3 h1:cmL5Enob4W83ti/ZHuZLuKD/xqJfus4fVPwE+/BDm+4=
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/ziflex/lecho/v3 v3.5.0 h1:Z4TBr8SbUUnfaVc8tGJf1Jhu0G9Jxjl77lPW0riXKak=
-github.com/ziflex/lecho/v3 v3.5.0/go.mod h1:+eInrytYHxVPI6NQbua9xXGerB1x0ujj9jAV33yBIko=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/pkg/middleware/extract_status.go
+++ b/pkg/middleware/extract_status.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"errors"
+
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
+	"github.com/labstack/echo/v4"
+)
+
+// ExtractStatus is a middlware that sets the response status
+//
+//	based on the error returned.  This is meant to be used
+//	with our own fork of lecho to figure out the proper logging level
+//	based on the Error contained within.
+func ExtractStatus(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var err error
+		if err = next(c); err != nil {
+			httpErr := new(ce.ErrorResponse)
+			if errors.As(err, httpErr) {
+				largest := 0
+				for _, respErr := range httpErr.Errors {
+					if respErr.Status > largest {
+						largest = respErr.Status
+					}
+				}
+				c.Response().Status = largest
+			}
+			return err
+		}
+
+		return nil
+	}
+}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -37,6 +37,7 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 		RequestLatencyLevel: zerolog.WarnLevel,
 		RequestLatencyLimit: 500 * time.Millisecond,
 	}))
+	e.Use(middleware.ExtractStatus) // Must be after lecho
 	e.Use(middleware.EnforceJSONContentType)
 
 	// Add routes

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -12,6 +12,7 @@ import (
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	echo_log "github.com/labstack/gommon/log"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/ziflex/lecho/v3"
 )
@@ -27,11 +28,14 @@ func ConfigureEcho(allRoutes bool) *echo.Echo {
 	e.Use(echo_middleware.RequestIDWithConfig(echo_middleware.RequestIDConfig{
 		TargetHeader: config.HeaderRequestId,
 	}))
+
 	e.Use(lecho.Middleware(lecho.Config{
-		Logger:          echoLogger,
-		RequestIDHeader: config.HeaderRequestId,
-		RequestIDKey:    config.RequestIdLoggingKey,
-		Skipper:         config.SkipLogging,
+		Logger:              echoLogger,
+		RequestIDHeader:     config.HeaderRequestId,
+		RequestIDKey:        config.RequestIdLoggingKey,
+		Skipper:             config.SkipLogging,
+		RequestLatencyLevel: zerolog.WarnLevel,
+		RequestLatencyLimit: 500 * time.Millisecond,
 	}))
 	e.Use(middleware.EnforceJSONContentType)
 

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -8,13 +8,13 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/instrumentation"
 	"github.com/content-services/content-sources-backend/pkg/middleware"
 	"github.com/content-services/content-sources-backend/pkg/rbac"
+	"github.com/content-services/lecho/v3"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	echo_log "github.com/labstack/gommon/log"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/ziflex/lecho/v3"
 )
 
 func ConfigureEcho(allRoutes bool) *echo.Echo {


### PR DESCRIPTION
## Summary

This uses a custom lecho fork to accomplish two things:
1.  log slow requests at a higher log level
2.  do not treat non-500 errors as needing error level logging

2.  was kinda tricky.  We need another middleware that runs around lecho to properly parse the error into the correct struct, extract the correct status, and set that on the response.  Then lecho has to re-lookup the response to get the proper status code.  I will work on contributing 1. back to lecho, but i'm not sure if the changes for 2 make sense to?

## Testing steps

to test 1:
add in a time.sleep(2*time.Second)  somewhere in a handler (like listRepositories).  Watch requests get logged at warn

to test 2:

in listRepositories add some code after the filter is parsed:

```
 if filterData.Search == "foo" {
         return ce.NewErrorResponse(500, "Error listing repositories", "ISE")
 }
```

now you can make requests to:

```
GET http://localhost:8000/api/content-sources/v1.0/repositories/?search=foo
```
to trigger an ISE.  You can try to create the same repo 2x to trigger a 400.  ISEs should still be logged at error level, but 400s should be logged at Info like normal.


## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
