### PR TITLE
Refs 4035: set QE_ENV="ephemeral"

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -11,6 +11,7 @@ DOCKERFILE="build/Dockerfile"
 IQE_PLUGINS="content-sources"  # name of the IQE plugin for this app.
 IQE_MARKER_EXPRESSION="api"  # This is the value passed to pytest -m
 IQE_FILTER_EXPRESSION="not (introspection or rbac)"  # This is the value passed to pytest -k
+IQE_ENV="ephemeral"
 IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
 DEPLOY_TIMEOUT="900"  # 15min
 


### PR DESCRIPTION
## Summary

Recent errors in pr_checks (which use clowder venv):
`HTTP response body: Bad Request: x-rh-identity header has an invalid or missing org_id`

possibly related to authentication changes, e.g. certs required, but clowder and ephemeral users are not configured for cert auth, they are user name and password only.

Lets try if ephemeral's use of caddy containers solves that problem.

## Testing steps

pr check runs OK

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
