### PR TITLE
Build: Add rhel 9.4 repos

### DIFF
--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -90,6 +90,12 @@
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.3/x86_64/baseos/os"
     },
     {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os"
+    },
+    {
         "base_url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64"
     },
     {
@@ -190,5 +196,11 @@
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.3/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os"
     }
 ]


### PR DESCRIPTION
## Summary

adds the 9.4 repos  which will fail introspection currently, but should work soon

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
