### PR TITLE
Fixes 3919: Add additional red hat repos

### DIFF
--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -36,6 +36,20 @@
         "distribution_version": "9"
     },
     {
+        "name": "Red Hat CodeReady Linux Builder for RHEL 9 x86_64 (RPMs)",
+        "content_label": "codeready-builder-for-rhel-9-x86_64-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/codeready-builder/os",
+        "arch": "x86_64",
+        "distribution_version": "9"
+    },
+    {
+        "name": "Red Hat CodeReady Linux Builder for RHEL 8 x86_64 (RPMs)",
+        "content_label": "codeready-builder-for-rhel-8-x86_64-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os",
+        "arch": "x86_64",
+        "distribution_version": "8"
+    },
+    {
         "name": "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)",
         "url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os",
         "content_label": "ansible-2-for-rhel-8-aarch64-rpms",
@@ -69,5 +83,19 @@
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os",
         "arch": "aarch64",
         "distribution_version": "9"
+    },
+    {
+        "name": "Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)",
+        "content_label": "codeready-builder-for-rhel-9-aarch64-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os",
+        "arch": "aarch64",
+        "distribution_version": "9"
+    },
+    {
+        "name": "Red Hat CodeReady Linux Builder for RHEL 8 ARM 64 (RPMs)",
+        "content_label": "codeready-builder-for-rhel-8-aarch64-rpms",
+        "url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os",
+        "arch": "aarch64",
+        "distribution_version": "8"
     }
 ]


### PR DESCRIPTION
## Summary

Adds some more rhel 8 and rhel 9 repository for snapahostting

## Testing steps

make repos-import
go run cmd/external-repos/main.go nightly-jobs

wait a while for it to sync all the repos.  Navigate in the UI to red hat repos and make sure they were snapshotted.

For QE:  i'd just check a deployment and see that the new rhel repos are there (if anything)

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
