### PR TITLE
Fixes 4055: treat filter/page param parse as info

### DIFF
--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -245,23 +245,19 @@ func (t templateDaoImpl) List(ctx context.Context, orgID string, paginationData 
 	order := convertSortByToSQL(paginationData.SortBy, sortMap, "name asc")
 
 	// Get count
-	filteredDB.
+	if filteredDB.
 		Model(&templates).
-		Count(&totalTemplates)
-
-	if filteredDB.Error != nil {
-		return api.TemplateCollectionResponse{}, totalTemplates, filteredDB.Error
+		Count(&totalTemplates).Error != nil {
+		return api.TemplateCollectionResponse{}, totalTemplates, t.DBToApiError(filteredDB.Error)
 	}
 
-	filteredDB.
+	if filteredDB.
 		Preload("RepositoryConfigurations").
 		Order(order).
 		Limit(paginationData.Limit).
 		Offset(paginationData.Offset).
-		Find(&templates)
-
-	if filteredDB.Error != nil {
-		return api.TemplateCollectionResponse{}, totalTemplates, filteredDB.Error
+		Find(&templates).Error != nil {
+		return api.TemplateCollectionResponse{}, totalTemplates, t.DBToApiError(filteredDB.Error)
 	}
 
 	responses := templatesConvertToResponses(templates)

--- a/pkg/handler/admin_tasks.go
+++ b/pkg/handler/admin_tasks.go
@@ -74,7 +74,7 @@ func ParseAdminTaskFilters(c echo.Context) api.AdminTaskFilterData {
 		BindError()
 
 	if err != nil {
-		log.Error().Err(err).Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("Error parsing filters")
 	}
 
 	return filterData

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -190,13 +190,13 @@ func ParsePagination(c echo.Context) api.PaginationData {
 		BindError()
 
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to bind pagination.")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("Failed to bind pagination.")
 	}
 
 	if pageData.SortBy == DefaultSortBy {
 		err = c.Request().ParseForm()
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to bind pagination.")
+			log.Ctx(c.Request().Context()).Info().Msg("Failed to bind pagination.")
 		}
 		q := c.Request().Form
 		pageData.SortBy = strings.Join(q["sort_by[]"], ",")
@@ -237,7 +237,7 @@ func ParseFilters(c echo.Context) api.FilterData {
 		BindError()
 
 	if err != nil {
-		log.Error().Err(err).Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Msg("Error parsing filters")
 	}
 
 	return filterData


### PR DESCRIPTION
## Summary

Changes filter/pagination parsing errors as info level logging instead of error

## Testing steps

perform a request:
GET http://localhost:8000/api/content-sources/v1.0/templates/?limit=a

watch your server, it should show logging at INFO

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
