### PR TITLE
Build: add make repos-import-rhel9

### DIFF
--- a/mk/repos.mk
+++ b/mk/repos.mk
@@ -8,5 +8,9 @@ repos-download: $(GO_OUTPUT)/external-repos  ## Download external repo urls from
 	; }
 
 .PHONY: repos-import
-repos-import: ## Import External repo urls from Image Builders into the DB.  Generates pkg/external_repos/external_repos.json
+repos-import: ## Import External repo urls
 	go run ./cmd/external-repos/main.go import
+
+.PHONY: repos-import-rhel9
+repos-import-rhel9: ## Import only rhel 9 repos
+	OPTIONS_REPOSITORY_IMPORT_FILTER=rhel9 go run ./cmd/external-repos/main.go import

--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -12,28 +12,32 @@
         "url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os",
         "content_label": "rhel-8-for-x86_64-appstream-rpms",
         "arch": "x86_64",
-        "distribution_version": "8"
+        "distribution_version": "8",
+        "selector": "rhel8"
     },
     {
         "name": "Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)",
         "content_label": "rhel-8-for-x86_64-baseos-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os",
         "arch": "x86_64",
-        "distribution_version": "8"
+        "distribution_version": "8",
+        "selector": "rhel8"
     },
     {
         "name": "Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)",
         "content_label": "rhel-9-for-x86_64-appstream-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os",
         "arch": "x86_64",
-        "distribution_version": "9"
+        "distribution_version": "9",
+        "selector": "rhel9"
     },
     {
         "name": "Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)",
         "content_label": "rhel-9-for-x86_64-baseos-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os",
         "arch": "x86_64",
-        "distribution_version": "9"
+        "distribution_version": "9",
+        "selector": "rhel9"
     },
     {
         "name": "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)",


### PR DESCRIPTION
## Summary

Support importing only a subset of repos for testing rhel9 (for example), and a handy make target.

## Testing steps

on a fresh db:  
```
make repos-import-rhel9
```

then check the red hat repos list and see only these two red hat repos

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
