### PR TITLE
Refs 3565: add pulp connectivity metric

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/handler"
 	m "github.com/content-services/content-sources-backend/pkg/instrumentation"
 	custom_collector "github.com/content-services/content-sources-backend/pkg/instrumentation/custom"
+	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/router"
 	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
@@ -183,7 +184,7 @@ func instrumentation(ctx context.Context, wg *sync.WaitGroup, metrics *m.Metrics
 
 	// Custom go routine
 	custom_ctx, custom_cancel := context.WithCancelCause(ctx)
-	custom := custom_collector.NewCollector(custom_ctx, metrics, db.DB)
+	custom := custom_collector.NewCollector(custom_ctx, metrics, db.DB, pulp_client.GetGlobalPulpClient())
 	go func() {
 		defer wg.Done()
 		log.Logger.Info().Msgf("Starting custom metrics go routine")

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -11,6 +11,7 @@ import (
 // TODO Update metric names according to: https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 const (
 	NameSpace                                      = "content_sources"
+	PulpConnectivity                               = "PulpConnectivity"
 	HttpStatusHistogram                            = "http_status_histogram"
 	RepositoriesTotal                              = "repositories_total"
 	RepositoryConfigsTotal                         = "repository_configs_total"
@@ -31,6 +32,7 @@ type Metrics struct {
 	HttpStatusHistogram prometheus.HistogramVec
 
 	// Custom metrics
+	PulpConnectivity                               prometheus.Gauge
 	RepositoriesTotal                              prometheus.Gauge
 	RepositoryConfigsTotal                         prometheus.Gauge
 	PublicRepositories36HourIntrospectionTotal     prometheus.GaugeVec
@@ -52,6 +54,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 	}
 	metrics := &Metrics{
 		reg: reg,
+		PulpConnectivity: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      PulpConnectivity,
+			Help:      "Status of pulp connection",
+		}),
 		HttpStatusHistogram: *promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: NameSpace,
 			Name:      HttpStatusHistogram,


### PR DESCRIPTION
## Summary

adds a metric to represent the status of the pulp connection.  

## Testing steps

curl localhost:9000/metrics 

look for:
```
# HELP content_sources_PulpConnectivity Status of pulp connection
# TYPE content_sources_PulpConnectivity gauge
content_sources_PulpConnectivity 1
```

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
