### PR TITLE
Fixes 3832: update date type in /snapshots/for_date

### DIFF
--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -15,8 +15,8 @@ type SnapshotResponse struct {
 }
 
 type ListSnapshotByDateRequest struct {
-	RepositoryUUIDS []string `json:"repository_uuids"` // Repository UUIDs to find snapshots for
-	Date            string   `json:"date"`             // Exact date to search by.
+	RepositoryUUIDS []string  `json:"repository_uuids"` // Repository UUIDs to find snapshots for
+	Date            time.Time `json:"date"`             // Exact date to search by.
 }
 
 type ListSnapshotByDateResponse struct {

--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -15,8 +16,35 @@ type SnapshotResponse struct {
 }
 
 type ListSnapshotByDateRequest struct {
-	RepositoryUUIDS []string  `json:"repository_uuids"` // Repository UUIDs to find snapshots for
-	Date            time.Time `json:"date"`             // Exact date to search by.
+	RepositoryUUIDS []string `json:"repository_uuids"` // Repository UUIDs to find snapshots for
+	Date            Date     `json:"date"`             // Exact date to search by.
+}
+
+type Date time.Time
+
+func (d Date) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(d).Format(time.RFC3339))
+}
+
+func (d *Date) UnmarshalJSON(b []byte) error {
+	// try parsing as YYYY-MM-DD first
+	t, err := time.Parse(`"2006-01-02"`, string(b))
+	if err == nil {
+		*d = Date(t)
+		return nil
+	}
+
+	// if parsing as YYYY-MM-DD fails, try parsing as RFC3339
+	var t2 time.Time
+	if err := json.Unmarshal(b, &t2); err != nil {
+		return err
+	}
+	*d = Date(t2)
+	return nil
+}
+
+func (d *Date) Format(layout string) string {
+	return time.Time(*d).Format(layout)
 }
 
 type ListSnapshotByDateResponse struct {

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -287,7 +287,8 @@ func (sDao *snapshotDaoImpl) FetchSnapshotByVersionHref(ctx context.Context, rep
 
 func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) ([]models.Snapshot, error) {
 	snaps := []models.Snapshot{}
-	date, _ := time.Parse(time.DateOnly, request.Date)
+	dateString := request.Date.Format(time.DateOnly)
+	date, _ := time.Parse(time.DateOnly, dateString)
 	date = date.AddDate(0, 0, 1) // Set the date to 24 hours later, inclusive of the current day
 
 	query := sDao.db.WithContext(ctx).Raw(`
@@ -338,8 +339,8 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 // FetchSnapshotsByDateAndRepository returns a list of snapshots by date.
 func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) (api.ListSnapshotByDateResponse, error) {
 	var snaps []models.Snapshot
-	layout := "2006-01-02"
-	date, _ := time.Parse(layout, request.Date)
+	dateString := request.Date.Format(time.DateOnly)
+	date, _ := time.Parse(time.DateOnly, dateString)
 	date = date.AddDate(0, 0, 1) // Set the date to 24 hours later, inclusive of the current day
 
 	snaps, err := sDao.FetchSnapshotsModelByDateAndRepository(ctx, orgID, request)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -3,7 +3,6 @@ package dao
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -427,7 +426,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 
 	request := api.ListSnapshotByDateRequest{}
 
-	request.Date = strings.Split(second.Base.CreatedAt.String(), " ")[0]
+	request.Date = second.Base.CreatedAt
 
 	request.RepositoryUUIDS = []string{repoConfig.UUID}
 
@@ -462,7 +461,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 	target3 := s.createSnapshotAtSpecifiedTime(redhatRepo, baseTime.Add(-time.Hour*100)) // Closest to Target Date
 
 	request := api.ListSnapshotByDateRequest{}
-	request.Date = strings.Split(target1.Base.CreatedAt.String(), " ")[0]
+	request.Date = target1.Base.CreatedAt
 
 	// Intentionally not found ID
 	randomUUID, _ := uuid.NewUUID()

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -426,7 +426,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 
 	request := api.ListSnapshotByDateRequest{}
 
-	request.Date = second.Base.CreatedAt
+	request.Date = api.Date(second.Base.CreatedAt)
 
 	request.RepositoryUUIDS = []string{repoConfig.UUID}
 
@@ -461,7 +461,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 	target3 := s.createSnapshotAtSpecifiedTime(redhatRepo, baseTime.Add(-time.Hour*100)) // Closest to Target Date
 
 	request := api.ListSnapshotByDateRequest{}
-	request.Date = target1.Base.CreatedAt
+	request.Date = api.Date(target1.Base.CreatedAt)
 
 	// Intentionally not found ID
 	randomUUID, _ := uuid.NewUUID()

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
@@ -18,10 +23,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 type SnapshotSuite struct {

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -63,7 +64,7 @@ func (suite *SnapshotSuite) serveSnapshotsRouter(req *http.Request) (int, []byte
 func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	t := suite.T()
 	repoUUID := "abcadaba"
-	request := api.ListSnapshotByDateRequest{Date: "2023-01-22", RepositoryUUIDS: []string{repoUUID}}
+	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: []string{repoUUID}}
 	response := api.ListSnapshotByDateResponse{Data: []api.SnapshotForDate{{RepositoryUUID: repoUUID}}}
 
 	suite.reg.Snapshot.On("FetchSnapshotsByDateAndRepository", test.MockCtx(), test_handler.MockOrgId, request).Return(response, nil)
@@ -84,7 +85,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	t := suite.T()
 	RepositoryUUIDS := []string{}
 
-	request := api.ListSnapshotByDateRequest{Date: "2023-01-22", RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
@@ -105,7 +106,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 		RepositoryUUIDS = append(RepositoryUUIDS, seeds.RandomOrgId())
 	}
 
-	request := api.ListSnapshotByDateRequest{Date: "2023-01-22", RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -4,12 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
-
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
@@ -24,6 +18,10 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 type SnapshotSuite struct {
@@ -64,7 +62,7 @@ func (suite *SnapshotSuite) serveSnapshotsRouter(req *http.Request) (int, []byte
 func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	t := suite.T()
 	repoUUID := "abcadaba"
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: []string{repoUUID}}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: []string{repoUUID}}
 	response := api.ListSnapshotByDateResponse{Data: []api.SnapshotForDate{{RepositoryUUID: repoUUID}}}
 
 	suite.reg.Snapshot.On("FetchSnapshotsByDateAndRepository", test.MockCtx(), test_handler.MockOrgId, request).Return(response, nil)
@@ -85,7 +83,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	t := suite.T()
 	RepositoryUUIDS := []string{}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
@@ -106,7 +104,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 		RepositoryUUIDS = append(RepositoryUUIDS, seeds.RandomOrgId())
 	}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -64,7 +64,7 @@ func (suite *SnapshotSuite) serveSnapshotsRouter(req *http.Request) (int, []byte
 func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	t := suite.T()
 	repoUUID := "abcadaba"
-	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: []string{repoUUID}}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: []string{repoUUID}}
 	response := api.ListSnapshotByDateResponse{Data: []api.SnapshotForDate{{RepositoryUUID: repoUUID}}}
 
 	suite.reg.Snapshot.On("FetchSnapshotsByDateAndRepository", test.MockCtx(), test_handler.MockOrgId, request).Return(response, nil)
@@ -85,7 +85,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	t := suite.T()
 	RepositoryUUIDS := []string{}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 		RepositoryUUIDS = append(RepositoryUUIDS, seeds.RandomOrgId())
 	}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Now().Truncate(time.Second), RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)

--- a/pkg/tasks/update_template_distributions.go
+++ b/pkg/tasks/update_template_distributions.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -91,8 +90,7 @@ func (t *UpdateTemplateDistributions) Run() error {
 		return err
 	}
 
-	date := template.Date.Format(time.DateOnly)
-	l := api.ListSnapshotByDateRequest{Date: date, RepositoryUUIDS: allRepos}
+	l := api.ListSnapshotByDateRequest{Date: template.Date, RepositoryUUIDS: allRepos}
 	snapshots, err := t.daoReg.Snapshot.FetchSnapshotsModelByDateAndRepository(t.ctx, t.orgId, l)
 	if err != nil {
 		return err

--- a/pkg/tasks/update_template_distributions.go
+++ b/pkg/tasks/update_template_distributions.go
@@ -90,7 +90,7 @@ func (t *UpdateTemplateDistributions) Run() error {
 		return err
 	}
 
-	l := api.ListSnapshotByDateRequest{Date: template.Date, RepositoryUUIDS: allRepos}
+	l := api.ListSnapshotByDateRequest{Date: api.Date(template.Date), RepositoryUUIDS: allRepos}
 	snapshots, err := t.daoReg.Snapshot.FetchSnapshotsModelByDateAndRepository(t.ctx, t.orgId, l)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Updates the date in the request to /snapshots/for_date to be an alias of type time.Time
- Date can be formatted like either YYYY-MM-DD or 2024-05-02T00:00:00-04:00
- Frontend change for this as well to ensure template creation doesn't fail on the Set up date step, PR [here](https://github.com/content-services/content-sources-frontend/pull/256). <-- this is not needed anymore for this PR since both formats work, but will be once we remove support for YYYY-MM-DD in a following PR

## Testing steps

- Test the /snapshots/for_date endpoint with a request like this, this should work:
```
{
  "date": "2024-04-28T00:00:00-04:00",
  "repository_uuids": ["1510694a-1bfa-479a-b596-4377261f3135"]
}
```
- This should also work:
```
{
  "date": "2024-04-28",
  "repository_uuids": ["1510694a-1bfa-479a-b596-4377261f3135"]
}
```

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
