### PR TITLE
Refs 1738: set request id header on response

### DIFF
--- a/pkg/middleware/request_id.go
+++ b/pkg/middleware/request_id.go
@@ -15,9 +15,8 @@ func AddRequestId(next echo.HandlerFunc) echo.HandlerFunc {
 		reqId := c.Request().Header.Get(config.HeaderRequestId)
 		if reqId == "" {
 			reqId = uuid2.NewString()
-			c.Response().Header().Set(config.HeaderRequestId, reqId)
 		}
-
+		c.Response().Header().Set(config.HeaderRequestId, reqId)
 		c.SetRequest(c.Request().WithContext(context.WithValue(c.Request().Context(), config.ContextRequestIDKey{}, reqId)))
 		return next(c)
 	}


### PR DESCRIPTION
## Summary

The previous pr: https://github.com/content-services/content-sources-backend/pull/637  had a bug where the request_id wasn't being set on the response in all cases (when one was specified). The result is that tasks didn't get their proper request_id

## Testing steps

Run a curl request to create (and snapshot a repo):

UUID="1cf4b0b0-fc0a-11ee-8913-201e8814f721"
curl -H "x-rh-insights-request-id:$UUID"  http://localhost:8000/api/content-sources/v1/repositories/  -H "`./scripts/header.sh 1 1`"   -d '{"name":"foo", "url":"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/", "snapshot":true}'  -H "Content-Type: application/json"

And watch the server logs:

you should see a lot of:
```
 request_id=1cf4b0b0-fc0a-11ee-8913-201e8814f721
```
Both at the api level and then as the task runs

Also check the pulp workers logs:

podman logs cs_pulp_worker_1 
and you should see the same request id there:
```
pulp [1cf4b0b0-fc0a-11ee-8913-201e8814f721]: pulpcore.tasking.tasks:INFO: Task completed 018ee838-baf4
```
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
