### PR TITLE
Refs 3565: correct pulp connectivity metric name

### DIFF
--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -11,7 +11,7 @@ import (
 // TODO Update metric names according to: https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 const (
 	NameSpace                                      = "content_sources"
-	PulpConnectivity                               = "PulpConnectivity"
+	PulpConnectivity                               = "pulp_connectivity"
 	HttpStatusHistogram                            = "http_status_histogram"
 	RepositoriesTotal                              = "repositories_total"
 	RepositoryConfigsTotal                         = "repository_configs_total"


### PR DESCRIPTION
## Summary

Accidently had it in camel case instead of snake case

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
