### PR TITLE
Fixes 4093: Override candlepin environment paths

### DIFF
--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -163,6 +163,32 @@ func (_m *MockCandlepinClient) DemoteContentFromEnvironment(ctx context.Context,
 	return r0
 }
 
+// FetchContentPathOverrides provides a mock function with given fields: ctx, environmentId
+func (_m *MockCandlepinClient) FetchContentPathOverrides(ctx context.Context, environmentId string) ([]caliri.ContentOverrideDTO, error) {
+	ret := _m.Called(ctx, environmentId)
+
+	var r0 []caliri.ContentOverrideDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]caliri.ContentOverrideDTO, error)); ok {
+		return rf(ctx, environmentId)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []caliri.ContentOverrideDTO); ok {
+		r0 = rf(ctx, environmentId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]caliri.ContentOverrideDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, environmentId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchEnvironment provides a mock function with given fields: ctx, envID
 func (_m *MockCandlepinClient) FetchEnvironment(ctx context.Context, envID string) (*caliri.EnvironmentDTO, error) {
 	ret := _m.Called(ctx, envID)
@@ -288,6 +314,20 @@ func (_m *MockCandlepinClient) ListContents(ctx context.Context, ownerKey string
 	}
 
 	return r0, r1, r2
+}
+
+// OverrideContentPaths provides a mock function with given fields: ctx, environmentId, contentLabelToUrl
+func (_m *MockCandlepinClient) OverrideContentPaths(ctx context.Context, environmentId string, contentLabelToUrl map[string]string) error {
+	ret := _m.Called(ctx, environmentId, contentLabelToUrl)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, map[string]string) error); ok {
+		r0 = rf(ctx, environmentId, contentLabelToUrl)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // PromoteContentToEnvironment provides a mock function with given fields: ctx, envID, contentIDs

--- a/pkg/candlepin_client/content.go
+++ b/pkg/candlepin_client/content.go
@@ -8,6 +8,9 @@ import (
 	caliri "github.com/content-services/caliri/release/v4"
 )
 
+const OverrideNameBaseUrl = "baseurl"
+const OverrideNameCaCert = "sslcacert"
+
 func GetContentID(repoConfigUUID string) string {
 	return strings.Replace(repoConfigUUID, "-", "", -1)
 }

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -31,4 +31,6 @@ type CandlepinClient interface {
 	PromoteContentToEnvironment(ctx context.Context, envID string, contentIDs []string) error
 	DemoteContentFromEnvironment(ctx context.Context, envID string, contentIDs []string) error
 	FetchEnvironment(ctx context.Context, envID string) (*caliri.EnvironmentDTO, error)
+	OverrideContentPaths(ctx context.Context, environmentId string, contentLabelToUrl map[string]string) error
+	FetchContentPathOverrides(ctx context.Context, environmentId string) ([]caliri.ContentOverrideDTO, error)
 }

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -31,6 +31,7 @@ type CandlepinClient interface {
 	PromoteContentToEnvironment(ctx context.Context, envID string, contentIDs []string) error
 	DemoteContentFromEnvironment(ctx context.Context, envID string, contentIDs []string) error
 	FetchEnvironment(ctx context.Context, envID string) (*caliri.EnvironmentDTO, error)
-	OverrideContentPaths(ctx context.Context, environmentId string, contentLabelToUrl map[string]string) error
+	UpdateContentOverrides(ctx context.Context, environmentId string, dtos []caliri.ContentOverrideDTO) error
 	FetchContentPathOverrides(ctx context.Context, environmentId string) ([]caliri.ContentOverrideDTO, error)
+	RemoveContentOverrides(ctx context.Context, environmentId string, toRemove []caliri.ContentOverrideDTO) error
 }

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -546,7 +546,7 @@ func (t *UpdateTemplateContent) getOverrideDTOs(contentPath string) ([]caliri.Co
 		}
 
 		mapping = append(mapping, caliri.ContentOverrideDTO{
-			Name:         pointy.Pointer("sslcacert"),
+			Name:         pointy.Pointer(candlepin_client.OverrideNameCaCert),
 			ContentLabel: &repo.Label,
 			Value:        pointy.Pointer(" "), // use a single space because candlepin doesn't allow "" or null
 		})
@@ -558,7 +558,7 @@ func (t *UpdateTemplateContent) getOverrideDTOs(contentPath string) ([]caliri.Co
 				return mapping, err
 			}
 			mapping = append(mapping, caliri.ContentOverrideDTO{
-				Name:         pointy.Pointer("baseurl"),
+				Name:         pointy.Pointer(candlepin_client.OverrideNameBaseUrl),
 				ContentLabel: &repo.Label,
 				Value:        &path,
 			})

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -506,7 +506,7 @@ func (t *UpdateTemplateContent) demoteContent(reposRemoved []string, envID strin
 // Returns list of custom content to be created, a list of custom content IDs, a list of red hat content IDs, and an error.
 func (t *UpdateTemplateContent) getContentList() ([]caliri.ContentDTO, []string, []string, error) {
 	uuids := strings.Join(t.payload.RepoConfigUUIDs, ",")
-	customRepos, _, err := t.daoReg.RepositoryConfig.List(t.ctx, t.orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: config.OriginExternal})
+	repoConfigs, _, err := t.daoReg.RepositoryConfig.List(t.ctx, t.orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: config.OriginExternal})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -523,7 +523,7 @@ func (t *UpdateTemplateContent) getContentList() ([]caliri.ContentDTO, []string,
 
 	rhContentIDs := getRedHatContentIDs(cpContentLabels, cpContentIDs, rhRepos.Data)
 
-	contentToCreate, customContentIDs := createContentItems(customRepos.Data)
+	contentToCreate, customContentIDs := createContentItems(repoConfigs.Data)
 
 	return contentToCreate, customContentIDs, rhContentIDs, nil
 }

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -263,7 +263,7 @@ func (s *UpdateTemplateContentSuite) AssertOverrides(ctx context.Context, envId 
 		for j := 0; j < len(expected); j++ {
 			expectedDTO := expected[j]
 			if *existingDto.Name == *expectedDTO.Name && *existingDto.ContentLabel == *expectedDTO.ContentLabel {
-				if *existingDto.Name == "baseurl" && pathForUrl(s.T(), *existingDto.Value) == pathForUrl(s.T(), *expectedDTO.Value) {
+				if *existingDto.Name == candlepin_client.OverrideNameBaseUrl && pathForUrl(s.T(), *existingDto.Value) == pathForUrl(s.T(), *expectedDTO.Value) {
 					found = true
 					break
 				} else if *existingDto.Value == *expectedDTO.Value {


### PR DESCRIPTION
for custom repos

## Summary

Adds overriding of custom content baseurls 

## Testing steps

Follow the directions here: https://github.com/content-services/content-sources-backend/blob/main/docs/register_client.md

At the end you should have a client configured to use a  custom repository and a red hat repository.  You should now be able to 'dnf install' a package from the custom repo

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
