### PR TITLE
Fixes 4160: fix incorrect red hat repo label

### DIFF
--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -76,7 +76,7 @@
     },
     {
         "name": "Red Hat Enterprise Linux 9 for ARM 64 - AppStream (RPMs)",
-        "content_label": "rhel-8-for-aarch64-appstream-rpms",
+        "content_label": "rhel-9-for-aarch64-appstream-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os",
         "arch": "aarch64",
         "distribution_version": "9"


### PR DESCRIPTION
## Summary
Duplicate/incorrect label was causing `make repos-import` to fail

## Testing steps
1. Run `make repos-import`
2. Should not fail

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
