### PR TITLE
Fixes 4009: snapshot errata should be sortable

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2024,6 +2024,12 @@ const docTemplate = `{
                         "description": "A comma separated list of severities to control api response. Severity can include ` + "`" + `Important` + "`" + `, ` + "`" + `Critical` + "`" + `, ` + "`" + `Moderate` + "`" + `, ` + "`" + `Low` + "`" + `, and ` + "`" + `Unknown` + "`" + `.",
                         "name": "severity",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort the response based on specific parameters. Sort criteria can include ` + "`" + `issued_date` + "`" + `, ` + "`" + `updated_date` + "`" + `, ` + "`" + `type` + "`" + `, and ` + "`" + `severity` + "`" + `.",
+                        "name": "sort_by",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3801,6 +3801,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.6
+	github.com/content-services/tang v0.0.7
 	github.com/content-services/yummy v1.0.12
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/go-openapi/spec v0.20.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/content-services/caliri/release/v4 v4.4.6 h1:HQGFT8fAWgP6ajurAn+gt6ro
 github.com/content-services/caliri/release/v4 v4.4.6/go.mod h1:+FDRCiyWWdfd8mYmbXOjHkbInwlZXp+cqfABEcEdF7o=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.6 h1:PuJYkGNzESV25UoKArH4PG5L62BOeyMKOLR8jekJPmk=
-github.com/content-services/tang v0.0.6/go.mod h1:2qcK/XfRd4mQaBOzDfLI56ua/T2mJo7sQCdpxzjsiU0=
+github.com/content-services/tang v0.0.7 h1:6aKNuNAvsh1fCpZTjkTD/nl3HaHPf0IwNIF3hafzhUA=
+github.com/content-services/tang v0.0.7/go.mod h1:2qcK/XfRd4mQaBOzDfLI56ua/T2mJo7sQCdpxzjsiU0=
 github.com/content-services/yummy v1.0.12 h1:DeSEwMA0eRdKBr7CtDt1ohzuG9Rx/xc0yDULfUNC0MM=
 github.com/content-services/yummy v1.0.12/go.mod h1:kk8ecb2BQd8r4vxpAKsOP6pTF972bvTGiezM7ePBlEQ=
 github.com/content-services/zest/release/v2024 v2024.5.1715867131 h1:xhMNfI4wnMiyX3J3uE234lMn9iWru1kbvfSqGKNnmi8=

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -615,6 +615,7 @@ func (r *rpmDaoImpl) ListSnapshotErrata(ctx context.Context, orgId string, snaps
 	pkgs, total, err := (*config.Tang).RpmRepositoryVersionErrataList(ctx, pulpHrefs, filters, tangy.PageOptions{
 		Offset: pageOpts.Offset,
 		Limit:  pageOpts.Limit,
+		SortBy: pageOpts.SortBy,
 	})
 
 	if err != nil {

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -992,21 +992,38 @@ func (s *RpmSuite) TestListRpmsAndErrataForSnapshots() {
 		Summary: expected[0].Summary,
 	}}, ret)
 
-	expectedErrataItem := []tangy.ErrataListItem{{
-		ErrataId: "Foodidly",
-		Summary:  "there was a great foo",
-	}}
+	expectedErrataItem := []tangy.ErrataListItem{
+		{
+			ErrataId: "Foodidly",
+			Summary:  "there was a great foo",
+			Type:     "bugfix",
+		},
+		{
+			ErrataId: "Foodidly2",
+			Summary:  "there was another great foo",
+			Type:     "security",
+		},
+	}
 
-	mTangy.On("RpmRepositoryVersionErrataList", ctx, hrefs, tangy.ErrataListFilters{}, tangy.PageOptions{Offset: 101, Limit: 3}).Return(expectedErrataItem, total, nil)
+	page = api.PaginationData{Limit: 3, Offset: 101, SortBy: "type:asc"}
+	mTangy.On("RpmRepositoryVersionErrataList", ctx, hrefs, tangy.ErrataListFilters{}, tangy.PageOptions{Offset: 101, Limit: 3, SortBy: "type:asc"}).Return(expectedErrataItem, total, nil)
 	resp, totalRec, err := dao.ListSnapshotErrata(ctx, orgId, []string{snaps[0].UUID}, tangy.ErrataListFilters{}, page)
 
 	require.NoError(s.T(), err)
 
 	assert.Equal(s.T(), total, totalRec)
-	assert.Equal(s.T(), []api.SnapshotErrata{{
-		ErrataId: expectedErrataItem[0].ErrataId,
-		Summary:  expectedErrataItem[0].Summary,
-	}}, resp)
+	assert.Equal(s.T(), []api.SnapshotErrata{
+		{
+			ErrataId: expectedErrataItem[0].ErrataId,
+			Summary:  expectedErrataItem[0].Summary,
+			Type:     expectedErrataItem[0].Type,
+		},
+		{
+			ErrataId: expectedErrataItem[1].ErrataId,
+			Summary:  expectedErrataItem[1].Summary,
+			Type:     expectedErrataItem[1].Type,
+		},
+	}, resp)
 }
 
 func (s *RpmSuite) TestDetectRpms() {

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -215,7 +215,7 @@ func (rh *RpmHandler) detectRpmsPresence(c echo.Context) error {
 // @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name."
 // @Param        type query string false "A comma separated list of types to control api response. Type can include `security`, `enhancement`, `bugfix`, and `other`."
 // @Param        severity query string false "A comma separated list of severities to control api response. Severity can include `Important`, `Critical`, `Moderate`, `Low`, and `Unknown`."
-// @Param		 sort_by query string false "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`."
+// @Param        sort_by query string false "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`."
 // @Success      200 {object} api.SnapshotErrataCollectionResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -215,6 +215,7 @@ func (rh *RpmHandler) detectRpmsPresence(c echo.Context) error {
 // @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name."
 // @Param        type query string false "A comma separated list of types to control api response. Type can include `security`, `enhancement`, `bugfix`, and `other`."
 // @Param        severity query string false "A comma separated list of severities to control api response. Severity can include `Important`, `Critical`, `Moderate`, `Low`, and `Unknown`."
+// @Param		 sort_by query string false "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`."
 // @Success      200 {object} api.SnapshotErrataCollectionResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse


### PR DESCRIPTION
## Summary

- Enables sorting on issued_date, updated_date, type, and severity for snapshot errata
- Dependent on this [tang PR](https://github.com/content-services/tang/pull/9) and a new tang release

## Testing steps

- Create a repository and let it snapshot
- Make a request to list the snapshot errata and sort by issued_date, updated_date, type, and severity (asc or desc). Example request:`/snapshots/:uuid/errata?sort_by=type:desc`
- This should return a list of errata sorted by the specified field and direction
- Listing the snapshot errata with no sort_by parameter should still default to sorting by issued_date descending

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate