### PR TITLE
Refs 4160: update label constraint migration to change label

### DIFF
--- a/db/migrations/20240513101357_add_label_constraint_to_repository_configuration.up.sql
+++ b/db/migrations/20240513101357_add_label_constraint_to_repository_configuration.up.sql
@@ -12,6 +12,11 @@ SET label = CONCAT(rc.label, '_', substr(md5(random()::text), 1, 10))
 FROM (SELECT count(*) , label FROM repository_configurations GROUP BY label HAVING count(*) > 1)
     AS rc2 WHERE rc.label = rc2.label AND rc.org_id != '-1';
 
+UPDATE repository_configurations as rc
+SET label = 'rhel-9-for-aarch64-appstream-rpms'
+FROM repositories as r
+WHERE rc.repository_uuid = r.uuid AND r.url = 'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/';
+
 CREATE UNIQUE INDEX IF NOT EXISTS repo_config_label_deleted_org_id_unique
 ON repository_configurations(label, org_id)
 WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Summary
This label was duplicated before being fixed in #671 

The label needs to be updated as part of the migration, or the migration will fail.

## Testing steps
1. Assuming your local DB has the latest migration (label uniqueness constraint), run `go run cmd/dbmigrate/main.go down --steps 1`
2. Update the redhat_repos.json to revert the change made in #671.
3. Run `make repos-import`
4. Run `go run cmd/dbmigration/main.go up` to run the uniqueness constraint migration.
5. The migration should not fail, and the label for this repository in repository_configurations should be correct.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
