### PR TITLE
Fixes 3656: add api to list template errata

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2688,6 +2688,93 @@ const docTemplate = `{
                 }
             }
         },
+        "/templates/{uuid}/errata": {
+            "get": {
+                "description": "List errata in a content template.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "List Template Errata",
+                "operationId": "listTemplateErrata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID.",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: ` + "`" + `100` + "`" + `.",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:` + "`" + `0` + "`" + `.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "A comma separated list of types to control api response. Type can include ` + "`" + `security` + "`" + `, ` + "`" + `enhancement` + "`" + `, ` + "`" + `bugfix` + "`" + `, and ` + "`" + `other` + "`" + `.",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "A comma separated list of severities to control api response. Severity can include ` + "`" + `Important` + "`" + `, ` + "`" + `Critical` + "`" + `, ` + "`" + `Moderate` + "`" + `, ` + "`" + `Low` + "`" + `, and ` + "`" + `Unknown` + "`" + `.",
+                        "name": "severity",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SnapshotErrataCollectionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/templates/{uuid}/rpms": {
             "get": {
                 "description": "List RPMs in a content template.",
@@ -3550,6 +3637,13 @@ const docTemplate = `{
         "api.SnapshotErrata": {
             "type": "object",
             "properties": {
+                "cves": {
+                    "description": "List of CVEs",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "description": {
                     "description": "Description of the errata",
                     "type": "string"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -766,6 +766,13 @@
             },
             "api.SnapshotErrata": {
                 "properties": {
+                    "cves": {
+                        "description": "List of CVEs",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "description": {
                         "description": "Description of the errata",
                         "type": "string"
@@ -4683,6 +4690,119 @@
                     }
                 },
                 "summary": "Fully update all attributes of a Template",
+                "tags": [
+                    "templates"
+                ]
+            }
+        },
+        "/templates/{uuid}/errata": {
+            "get": {
+                "description": "List errata in a content template.",
+                "operationId": "listTemplateErrata",
+                "parameters": [
+                    {
+                        "description": "Template ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "A comma separated list of types to control api response. Type can include `security`, `enhancement`, `bugfix`, and `other`.",
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "A comma separated list of severities to control api response. Severity can include `Important`, `Critical`, `Moderate`, `Low`, and `Unknown`.",
+                        "in": "query",
+                        "name": "severity",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.SnapshotErrataCollectionResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Template Errata",
                 "tags": [
                     "templates"
                 ]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.7
+	github.com/content-services/tang v0.0.8
 	github.com/content-services/yummy v1.0.12
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/go-openapi/spec v0.20.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/content-services/caliri/release/v4 v4.4.6 h1:HQGFT8fAWgP6ajurAn+gt6ro
 github.com/content-services/caliri/release/v4 v4.4.6/go.mod h1:+FDRCiyWWdfd8mYmbXOjHkbInwlZXp+cqfABEcEdF7o=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.7 h1:6aKNuNAvsh1fCpZTjkTD/nl3HaHPf0IwNIF3hafzhUA=
-github.com/content-services/tang v0.0.7/go.mod h1:2qcK/XfRd4mQaBOzDfLI56ua/T2mJo7sQCdpxzjsiU0=
+github.com/content-services/tang v0.0.8 h1:mOFTj95cs9O4owWRyfDETgag2Q1ZL5sgMAk9qHK2l/U=
+github.com/content-services/tang v0.0.8/go.mod h1:2qcK/XfRd4mQaBOzDfLI56ua/T2mJo7sQCdpxzjsiU0=
 github.com/content-services/yummy v1.0.12 h1:DeSEwMA0eRdKBr7CtDt1ohzuG9Rx/xc0yDULfUNC0MM=
 github.com/content-services/yummy v1.0.12/go.mod h1:kk8ecb2BQd8r4vxpAKsOP6pTF972bvTGiezM7ePBlEQ=
 github.com/content-services/zest/release/v2024 v2024.5.1716497237 h1:QdB3vCUPq8HcCsdygneHVovAE+Xlp7uOiTczkDLgRPQ=

--- a/pkg/api/rpms.go
+++ b/pkg/api/rpms.go
@@ -34,16 +34,17 @@ type SnapshotErrataListRequest struct {
 }
 
 type SnapshotErrata struct {
-	Id              string `json:"id"`
-	ErrataId        string `json:"errata_id"`        // ID of the errata
-	Title           string `json:"title"`            // Title of the errata
-	Summary         string `json:"summary"`          // Summary of the errata
-	Description     string `json:"description"`      // Description of the errata
-	IssuedDate      string `json:"issued_date"`      // IssuedDate of the errata
-	UpdateDate      string `json:"updated_date"`     // UpdateDate of the errata
-	Type            string `json:"type"`             // Type of the errata
-	Severity        string `json:"severity"`         // Severity of the errata
-	RebootSuggested bool   `json:"reboot_suggested"` // Whether a reboot is suggested
+	Id              string   `json:"id"`
+	ErrataId        string   `json:"errata_id"`        // ID of the errata
+	Title           string   `json:"title"`            // Title of the errata
+	Summary         string   `json:"summary"`          // Summary of the errata
+	Description     string   `json:"description"`      // Description of the errata
+	IssuedDate      string   `json:"issued_date"`      // IssuedDate of the errata
+	UpdateDate      string   `json:"updated_date"`     // UpdateDate of the errata
+	Type            string   `json:"type"`             // Type of the errata
+	Severity        string   `json:"severity"`         // Severity of the errata
+	RebootSuggested bool     `json:"reboot_suggested"` // Whether a reboot is suggested
+	CVEs            []string `json:"cves"`             // List of CVEs
 }
 
 type SnapshotErrataCollectionResponse struct {

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -93,6 +93,7 @@ type RpmDao interface {
 	InsertForRepository(ctx context.Context, repoUuid string, pkgs []yum.Package) (int64, error)
 	OrphanCleanup(ctx context.Context) error
 	ListTemplateRpms(ctx context.Context, orgId string, templateUUID string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error)
+	ListTemplateErrata(ctx context.Context, orgId string, templateUUID string, filters tangy.ErrataListFilters, pageOpts api.PaginationData) ([]api.SnapshotErrata, int, error)
 }
 
 //go:generate $GO_OUTPUT/mockery --name RepositoryDao --filename repositories_mock.go --inpackage

--- a/pkg/dao/rpms_mock.go
+++ b/pkg/dao/rpms_mock.go
@@ -186,6 +186,43 @@ func (_m *MockRpmDao) ListSnapshotRpms(ctx context.Context, orgId string, snapsh
 	return r0, r1, r2
 }
 
+// ListTemplateErrata provides a mock function with given fields: ctx, orgId, templateUUID, filters, pageOpts
+func (_m *MockRpmDao) ListTemplateErrata(ctx context.Context, orgId string, templateUUID string, filters tangy.ErrataListFilters, pageOpts api.PaginationData) ([]api.SnapshotErrata, int, error) {
+	ret := _m.Called(ctx, orgId, templateUUID, filters, pageOpts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListTemplateErrata")
+	}
+
+	var r0 []api.SnapshotErrata
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, tangy.ErrataListFilters, api.PaginationData) ([]api.SnapshotErrata, int, error)); ok {
+		return rf(ctx, orgId, templateUUID, filters, pageOpts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, tangy.ErrataListFilters, api.PaginationData) []api.SnapshotErrata); ok {
+		r0 = rf(ctx, orgId, templateUUID, filters, pageOpts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.SnapshotErrata)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, tangy.ErrataListFilters, api.PaginationData) int); ok {
+		r1 = rf(ctx, orgId, templateUUID, filters, pageOpts)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, tangy.ErrataListFilters, api.PaginationData) error); ok {
+		r2 = rf(ctx, orgId, templateUUID, filters, pageOpts)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // ListTemplateRpms provides a mock function with given fields: ctx, orgId, templateUUID, search, pageOpts
 func (_m *MockRpmDao) ListTemplateRpms(ctx context.Context, orgId string, templateUUID string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error) {
 	ret := _m.Called(ctx, orgId, templateUUID, search, pageOpts)


### PR DESCRIPTION
## Summary

- Adds API for listing content template errata: `/templates/:uuid/errata` (similar to the list errata endpoint for snapshots)
- Includes optional query parameters `search`, `limit`, `type`, and `severity`
- Depends on this [tang PR](https://github.com/content-services/tang/pull/10) to add in the CVEs

## Testing steps

- Add a custom repository with errata and a RH repository and let them snapshot (this will snapshot a small RH repo: `OPTIONS_REPOSITORY_IMPORT_FILTER=small go run cmd/external-repos/main.go import && go run cmd/external-repos/main.go nightly-jobs`)
- Create a template with those repositories, selecting the latest date 
- Make a request to the `/templates/:uuid/errata` endpoint with the template uuid and you should see the template's errata (should include errata from both of the snapshots in the template) in a response similar to this:
```
{
    "data": [
        {
            "id": "018fbf80-9d1e-7458-b10b-9b39b3b652a7",
            "errata_id": "RHSA-2020:3602",
            "title": "Important: Ansible security and bug fix update (2.9.13)",
            "summary": "An update for ansible is now available for Ansible Engine 2\n\nRed Hat Product Security has rated this update as having a security impact\nof Important. A Common Vulnerability Scoring System (CVSS) base score,\nwhich gives a detailed severity rating, is available for each vulnerability\nfrom the CVE link(s) in the References section.",
            "description": "Ansible is a simple model-driven configuration management, multi-node\ndeployment, and remote-task execution system. Ansible works over SSH and\ndoes not require any software or daemons to be installed on remote nodes.\nExtension modules can be written in any language and are transferred to\nmanaged machines automatically.\n\nThe following packages have been upgraded to a newer upstream version:\nansible (2.9.13)\n\nBug Fix(es):\n* CVE-2020-14365 ansible: dnf module install packages with no GPG signature\n\nSee:\nhttps://github.com/ansible/ansible/blob/v2.9.13/changelogs/CHANGELOG-v2.9.rst\nfor details on bug fixes in this release.",
            "issued_date": "2020-09-01 19:10:30",
            "updated_date": "2020-09-01 19:10:25",
            "type": "security",
            "severity": "Important",
            "reboot_suggested": false,
            "cves": [
                "CVE-2020-14365"
            ]
        },
        ...
```        

- To test that the correct snapshot's errata are shown, you can update the custom repository with a different URL and let it snapshot
- Edit the template date to include this latest snapshot and view the errata again. The errata list should reflect the latest snapshot's errata
- Edit the template to remove the custom repository and then view the errata again, you should only see the errata from the RH repository's snapshot

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
