### PR TITLE
Fixes 4208: add environment ID to template events/api

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3858,10 +3858,6 @@ const docTemplate = `{
                     "description": "Architecture of the template",
                     "type": "string"
                 },
-                "client_environment_id": {
-                    "description": "Environment ID used by subscription-manager \u0026 candlepin",
-                    "type": "string"
-                },
                 "date": {
                     "description": "Latest date to include snapshots for",
                     "type": "string"
@@ -3884,6 +3880,10 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "rhsm_environment_id": {
+                    "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                    "type": "string"
                 },
                 "uuid": {
                     "type": "string",

--- a/api/docs.go
+++ b/api/docs.go
@@ -3858,6 +3858,10 @@ const docTemplate = `{
                     "description": "Architecture of the template",
                     "type": "string"
                 },
+                "client_environment_id": {
+                    "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                    "type": "string"
+                },
                 "date": {
                     "description": "Latest date to include snapshots for",
                     "type": "string"

--- a/api/docs.go
+++ b/api/docs.go
@@ -3882,7 +3882,7 @@ const docTemplate = `{
                     }
                 },
                 "rhsm_environment_id": {
-                    "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                    "description": "Environment ID used by subscription-manager and candlepin",
                     "type": "string"
                 },
                 "uuid": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1065,6 +1065,10 @@
                         "description": "Architecture of the template",
                         "type": "string"
                     },
+                    "client_environment_id": {
+                        "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                        "type": "string"
+                    },
                     "date": {
                         "description": "Latest date to include snapshots for",
                         "type": "string"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1089,7 +1089,7 @@
                         "type": "array"
                     },
                     "rhsm_environment_id": {
-                        "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                        "description": "Environment ID used by subscription-manager and candlepin",
                         "type": "string"
                     },
                     "uuid": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1065,10 +1065,6 @@
                         "description": "Architecture of the template",
                         "type": "string"
                     },
-                    "client_environment_id": {
-                        "description": "Environment ID used by subscription-manager \u0026 candlepin",
-                        "type": "string"
-                    },
                     "date": {
                         "description": "Latest date to include snapshots for",
                         "type": "string"
@@ -1091,6 +1087,10 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "rhsm_environment_id": {
+                        "description": "Environment ID used by subscription-manager \u0026 candlepin",
+                        "type": "string"
                     },
                     "uuid": {
                         "readOnly": true,

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -18,15 +18,15 @@ type TemplateRequest struct {
 }
 
 type TemplateResponse struct {
-	UUID            string    `json:"uuid" readonly:"true"`
-	Name            string    `json:"name"`             // Name of the template
-	OrgID           string    `json:"org_id"`           // Organization ID of the owner
-	Description     string    `json:"description"`      // Description of the template
-	Arch            string    `json:"arch"`             // Architecture of the template
-	Version         string    `json:"version"`          // Version of the template
-	Date            time.Time `json:"date"`             // Latest date to include snapshots for
-	RepositoryUUIDS []string  `json:"repository_uuids"` // Repositories added to the template
-
+	UUID                string    `json:"uuid" readonly:"true"`
+	Name                string    `json:"name"`                  // Name of the template
+	OrgID               string    `json:"org_id"`                // Organization ID of the owner
+	Description         string    `json:"description"`           // Description of the template
+	Arch                string    `json:"arch"`                  // Architecture of the template
+	Version             string    `json:"version"`               // Version of the template
+	Date                time.Time `json:"date"`                  // Latest date to include snapshots for
+	RepositoryUUIDS     []string  `json:"repository_uuids"`      // Repositories added to the template
+	ClientEnvironmentId string    `json:"client_environment_id"` // Environment ID used by subscription-manager & candlepin
 }
 
 // We use a separate struct because name, version, arch cannot be updated

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -26,7 +26,7 @@ type TemplateResponse struct {
 	Version           string    `json:"version"`             // Version of the template
 	Date              time.Time `json:"date"`                // Latest date to include snapshots for
 	RepositoryUUIDS   []string  `json:"repository_uuids"`    // Repositories added to the template
-	RHSMEnvironmentId string    `json:"rhsm_environment_id"` // Environment ID used by subscription-manager & candlepin
+	RHSMEnvironmentID string    `json:"rhsm_environment_id"` // Environment ID used by subscription-manager and candlepin
 }
 
 // We use a separate struct because name, version, arch cannot be updated

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -18,15 +18,15 @@ type TemplateRequest struct {
 }
 
 type TemplateResponse struct {
-	UUID                string    `json:"uuid" readonly:"true"`
-	Name                string    `json:"name"`                  // Name of the template
-	OrgID               string    `json:"org_id"`                // Organization ID of the owner
-	Description         string    `json:"description"`           // Description of the template
-	Arch                string    `json:"arch"`                  // Architecture of the template
-	Version             string    `json:"version"`               // Version of the template
-	Date                time.Time `json:"date"`                  // Latest date to include snapshots for
-	RepositoryUUIDS     []string  `json:"repository_uuids"`      // Repositories added to the template
-	ClientEnvironmentId string    `json:"client_environment_id"` // Environment ID used by subscription-manager & candlepin
+	UUID              string    `json:"uuid" readonly:"true"`
+	Name              string    `json:"name"`                // Name of the template
+	OrgID             string    `json:"org_id"`              // Organization ID of the owner
+	Description       string    `json:"description"`         // Description of the template
+	Arch              string    `json:"arch"`                // Architecture of the template
+	Version           string    `json:"version"`             // Version of the template
+	Date              time.Time `json:"date"`                // Latest date to include snapshots for
+	RepositoryUUIDS   []string  `json:"repository_uuids"`    // Repositories added to the template
+	RHSMEnvironmentId string    `json:"rhsm_environment_id"` // Environment ID used by subscription-manager & candlepin
 }
 
 // We use a separate struct because name, version, arch cannot be updated

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/candlepin_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/event"
@@ -441,6 +442,7 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 
 func templatesModelToApi(model models.Template, api *api.TemplateResponse) {
 	api.UUID = model.UUID
+	api.ClientEnvironmentId = candlepin_client.GetEnvironmentID(model.UUID)
 	api.OrgID = model.OrgID
 	api.Name = model.Name
 	api.Description = model.Description

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -442,7 +442,7 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 
 func templatesModelToApi(model models.Template, api *api.TemplateResponse) {
 	api.UUID = model.UUID
-	api.RHSMEnvironmentId = candlepin_client.GetEnvironmentID(model.UUID)
+	api.RHSMEnvironmentID = candlepin_client.GetEnvironmentID(model.UUID)
 	api.OrgID = model.OrgID
 	api.Name = model.Name
 	api.Description = model.Description

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -442,7 +442,7 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 
 func templatesModelToApi(model models.Template, api *api.TemplateResponse) {
 	api.UUID = model.UUID
-	api.ClientEnvironmentId = candlepin_client.GetEnvironmentID(model.UUID)
+	api.RHSMEnvironmentId = candlepin_client.GetEnvironmentID(model.UUID)
 	api.OrgID = model.OrgID
 	api.Name = model.Name
 	api.Description = model.Description

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -52,7 +52,7 @@ func (s *TemplateSuite) TestCreate() {
 
 	respTemplate, err := templateDao.Create(context.Background(), reqTemplate)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.RHSMEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.RHSMEnvironmentID)
 	assert.Equal(s.T(), orgID, respTemplate.OrgID)
 	assert.Equal(s.T(), *reqTemplate.Description, respTemplate.Description)
 	assert.Equal(s.T(), timeNow.Round(time.Millisecond), respTemplate.Date.Round(time.Millisecond))
@@ -121,7 +121,7 @@ func (s *TemplateSuite) TestFetch() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), found.Name, resp.Name)
 	assert.Equal(s.T(), found.OrgID, resp.OrgID)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.RHSMEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.RHSMEnvironmentID)
 }
 
 func (s *TemplateSuite) TestFetchNotFound() {
@@ -162,7 +162,7 @@ func (s *TemplateSuite) TestList() {
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
 	assert.Len(s.T(), responses.Data[0].RepositoryUUIDS, 2)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].RHSMEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].RHSMEnvironmentID)
 }
 
 func (s *TemplateSuite) TestListNoTemplates() {

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/candlepin_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
@@ -51,6 +52,7 @@ func (s *TemplateSuite) TestCreate() {
 
 	respTemplate, err := templateDao.Create(context.Background(), reqTemplate)
 	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.ClientEnvironmentId)
 	assert.Equal(s.T(), orgID, respTemplate.OrgID)
 	assert.Equal(s.T(), *reqTemplate.Description, respTemplate.Description)
 	assert.Equal(s.T(), timeNow.Round(time.Millisecond), respTemplate.Date.Round(time.Millisecond))
@@ -119,6 +121,7 @@ func (s *TemplateSuite) TestFetch() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), found.Name, resp.Name)
 	assert.Equal(s.T(), found.OrgID, resp.OrgID)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.ClientEnvironmentId)
 }
 
 func (s *TemplateSuite) TestFetchNotFound() {
@@ -159,6 +162,7 @@ func (s *TemplateSuite) TestList() {
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
 	assert.Len(s.T(), responses.Data[0].RepositoryUUIDS, 2)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].ClientEnvironmentId)
 }
 
 func (s *TemplateSuite) TestListNoTemplates() {

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -52,7 +52,7 @@ func (s *TemplateSuite) TestCreate() {
 
 	respTemplate, err := templateDao.Create(context.Background(), reqTemplate)
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.ClientEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.RHSMEnvironmentId)
 	assert.Equal(s.T(), orgID, respTemplate.OrgID)
 	assert.Equal(s.T(), *reqTemplate.Description, respTemplate.Description)
 	assert.Equal(s.T(), timeNow.Round(time.Millisecond), respTemplate.Date.Round(time.Millisecond))
@@ -121,7 +121,7 @@ func (s *TemplateSuite) TestFetch() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), found.Name, resp.Name)
 	assert.Equal(s.T(), found.OrgID, resp.OrgID)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.ClientEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.RHSMEnvironmentId)
 }
 
 func (s *TemplateSuite) TestFetchNotFound() {
@@ -162,7 +162,7 @@ func (s *TemplateSuite) TestList() {
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
 	assert.Len(s.T(), responses.Data[0].RepositoryUUIDS, 2)
-	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].ClientEnvironmentId)
+	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].RHSMEnvironmentId)
 }
 
 func (s *TemplateSuite) TestListNoTemplates() {


### PR DESCRIPTION
## Summary

adds a new parameter 'client_environment_id' to kafka template events & api responses

## Testing steps

in local setup:  
```
KAFKA_TOPICS=platform.content-sources.template   make kafka-topic-consume  
```

now create a content template via the api/ui and watch the result:

```
Partition:0	content-type:application/cloudevents+json	null	{"specversion":"1.0","id":"14ebf3a8-1c8b-497a-9228-92a826452d81","source":"urn:redhat:source:console:app:repositories","type":"com.redhat.console.repositories.template-created","subject":"urn:redhat:subject:console:rhel:template-created","datacontenttype":"application/json","time":"2024-05-28T18:18:07.558203259Z","data":[{"uuid":"77e526a0-0ee9-4284-8d32-3eebe4ad9e84","name":"test","org_id":"9","description":"","arch":"","version":"","date":"2024-05-02T10:04:05-04:00","repository_uuids":[],"client_environment_id":"77e526a00ee942848d323eebe4ad9e84"}],"redhatorgid":"9"}
```

notice: `"client_environment_id":"77e526a00ee942848d323eebe4ad9e84"`

for api testing,   GET /templates/   GET /templates/UUID  & POST /templates/   should all return client_environment_id as part of the response


## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
