### PR TITLE
Fixes 4195: check for multiple tags in openapi spec

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -30,7 +30,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "environments"
                 ],
                 "summary": "Search environments",
@@ -123,7 +122,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "packagegroups"
                 ],
                 "summary": "Search package groups",
@@ -907,7 +905,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "environments"
                 ],
                 "summary": "List Repositories Environments",
@@ -1039,7 +1036,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "packagegroups"
                 ],
                 "summary": "List Repositories Package Groups",
@@ -1121,7 +1117,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "rpms"
                 ],
                 "summary": "List Repositories RPMs",
@@ -1245,7 +1240,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories"
+                    "snapshots"
                 ],
                 "summary": "List snapshots of a repository",
                 "operationId": "listSnapshots",
@@ -1526,7 +1521,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "rpms"
                 ],
                 "summary": "Search RPMs",
@@ -1595,7 +1589,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "repositories",
                     "rpms"
                 ],
                 "summary": "Detect RPMs presence",
@@ -1661,7 +1654,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "snapshots",
                     "environments"
                 ],
                 "summary": "Search environments within snapshots",
@@ -1789,8 +1781,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "snapshots",
-                    "environments"
+                    "packagegroups"
                 ],
                 "summary": "Search package groups within snapshots",
                 "operationId": "searchSnapshotPackageGroups",
@@ -1858,7 +1849,6 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "snapshots",
                     "rpms"
                 ],
                 "summary": "Search RPMs within snapshots",
@@ -1983,7 +1973,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "snapshots"
+                    "rpms"
                 ],
                 "summary": "List Snapshot Errata",
                 "operationId": "listSnapshotErrata",
@@ -2076,7 +2066,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "snapshots"
+                    "rpms"
                 ],
                 "summary": "List Snapshot RPMs",
                 "operationId": "listSnapshotRpms",
@@ -2698,7 +2688,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "templates"
+                    "rpms"
                 ],
                 "summary": "List Template RPMs",
                 "operationId": "listTemplateRpms",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1317,7 +1317,6 @@
                 },
                 "summary": "Search environments",
                 "tags": [
-                    "repositories",
                     "environments"
                 ]
             }
@@ -1427,7 +1426,6 @@
                 },
                 "summary": "Search package groups",
                 "tags": [
-                    "repositories",
                     "packagegroups"
                 ]
             }
@@ -2465,7 +2463,6 @@
                 },
                 "summary": "List Repositories Environments",
                 "tags": [
-                    "repositories",
                     "environments"
                 ]
             }
@@ -2638,7 +2635,6 @@
                 },
                 "summary": "List Repositories Package Groups",
                 "tags": [
-                    "repositories",
                     "packagegroups"
                 ]
             }
@@ -2744,7 +2740,6 @@
                 },
                 "summary": "List Repositories RPMs",
                 "tags": [
-                    "repositories",
                     "rpms"
                 ]
             }
@@ -2874,7 +2869,7 @@
                 },
                 "summary": "List snapshots of a repository",
                 "tags": [
-                    "repositories"
+                    "snapshots"
                 ]
             }
         },
@@ -3248,7 +3243,6 @@
                 },
                 "summary": "Search RPMs",
                 "tags": [
-                    "repositories",
                     "rpms"
                 ]
             }
@@ -3333,7 +3327,6 @@
                 },
                 "summary": "Detect RPMs presence",
                 "tags": [
-                    "repositories",
                     "rpms"
                 ]
             }
@@ -3421,7 +3414,6 @@
                 },
                 "summary": "Search environments within snapshots",
                 "tags": [
-                    "snapshots",
                     "environments"
                 ]
             }
@@ -3583,8 +3575,7 @@
                 },
                 "summary": "Search package groups within snapshots",
                 "tags": [
-                    "snapshots",
-                    "environments"
+                    "packagegroups"
                 ]
             }
         },
@@ -3671,7 +3662,6 @@
                 },
                 "summary": "Search RPMs within snapshots",
                 "tags": [
-                    "snapshots",
                     "rpms"
                 ]
             }
@@ -3865,7 +3855,7 @@
                 },
                 "summary": "List Snapshot Errata",
                 "tags": [
-                    "snapshots"
+                    "rpms"
                 ]
             }
         },
@@ -3962,7 +3952,7 @@
                 },
                 "summary": "List Snapshot RPMs",
                 "tags": [
-                    "snapshots"
+                    "rpms"
                 ]
             }
         },
@@ -4777,7 +4767,7 @@
                 },
                 "summary": "List Template RPMs",
                 "tags": [
-                    "templates"
+                    "rpms"
                 ]
             }
         }

--- a/cmd/lint_openapi/main.go
+++ b/cmd/lint_openapi/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type OpenAPISpec struct {
+	Paths      map[string]PathItem    `json:"paths"`
+	Components map[string]interface{} `json:"components"`
+}
+
+type PathItem struct {
+	Get    Operation `json:"get,omitempty"`
+	Put    Operation `json:"put,omitempty"`
+	Post   Operation `json:"post,omitempty"`
+	Delete Operation `json:"delete,omitempty"`
+	Patch  Operation `json:"patch,omitempty"`
+}
+
+type Operation struct {
+	Tags []string `json:"tags"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		panic("Usage: ./command openapi_spec")
+	}
+
+	openapiFile := os.Args[1]
+
+	bytes, err := os.ReadFile(openapiFile)
+	if err != nil {
+		panic(err)
+	}
+
+	var document OpenAPISpec
+	err = json.Unmarshal(bytes, &document)
+	if err != nil {
+		panic(err)
+	}
+
+	hasMultipleTags := false
+
+	for path, pathItem := range document.Paths {
+		methods := map[string]Operation{
+			"get":    pathItem.Get,
+			"put":    pathItem.Put,
+			"post":   pathItem.Post,
+			"delete": pathItem.Delete,
+			"patch":  pathItem.Patch,
+		}
+		for method, operation := range methods {
+			if len(operation.Tags) > 1 {
+				fmt.Printf("Path '%s' method '%s' has multiple tags: %v\n", path, method, operation.Tags)
+				hasMultipleTags = true
+			}
+		}
+	}
+
+	if hasMultipleTags {
+		os.Exit(1)
+	}
+}

--- a/cmd/lint_openapi/main.go
+++ b/cmd/lint_openapi/main.go
@@ -24,11 +24,7 @@ type Operation struct {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		panic("Usage: ./command openapi_spec")
-	}
-
-	openapiFile := os.Args[1]
+	openapiFile := "./api/openapi.json"
 
 	bytes, err := os.ReadFile(openapiFile)
 	if err != nil {

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -27,4 +27,4 @@ openapi: install-swag ## Regenerate openapi json document and lint
 	# Convert from swagger to openapi
 	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json
 	rm ./api/swagger.json ./api/swagger.yaml
-	go run ./cmd/lint_openapi/main.go ./api/openapi.json
+	go run ./cmd/lint_openapi/main.go

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -22,8 +22,9 @@ $(SWAG):
 	}
 
 .PHONY: openapi
-openapi: install-swag ## Regenerate openapi json document
+openapi: install-swag ## Regenerate openapi json document and lint
 	$(SWAG) init --generalInfo api.go --o ./api --dir pkg/handler/ --pd pkg/api
 	# Convert from swagger to openapi
 	go run ./cmd/swagger2openapi/main.go api/swagger.json api/openapi.json
 	rm ./api/swagger.json ./api/swagger.yaml
+	go run ./cmd/lint_openapi/main.go ./api/openapi.json

--- a/pkg/handler/environments.go
+++ b/pkg/handler/environments.go
@@ -29,7 +29,7 @@ func RegisterEnvironmentRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
 // @Summary      Search environments
 // @ID           searchEnvironments
 // @Description  This enables users to search for environments in a given list of repositories.
-// @Tags         repositories,environments
+// @Tags         environments
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.ContentUnitSearchRequest  true  "request body"
@@ -60,7 +60,7 @@ func (rh *RepositoryEnvironmentHandler) searchEnvironmentByName(c echo.Context) 
 // @Summary      List Repositories Environments
 // @ID           listRepositoriesEnvironments
 // @Description  List environments in a repository.
-// @Tags         repositories,environments
+// @Tags         environments
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Repository ID."
@@ -98,7 +98,7 @@ func (rh *RepositoryEnvironmentHandler) listRepositoriesEnvironments(c echo.Cont
 // @Summary      Search environments within snapshots
 // @ID           searchSnapshotEnvironments
 // @Description  This enables users to search for environments in a given list of snapshots.
-// @Tags         snapshots,environments
+// @Tags         environments
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.SnapshotSearchRpmRequest  true  "request body"

--- a/pkg/handler/package_groups.go
+++ b/pkg/handler/package_groups.go
@@ -29,7 +29,7 @@ func RegisterPackageGroupRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
 // @Summary      Search package groups
 // @ID           searchPackageGroup
 // @Description  This enables users to search for package groups in a given list of repositories.
-// @Tags         repositories,packagegroups
+// @Tags         packagegroups
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.ContentUnitSearchRequest  true  "request body"
@@ -60,7 +60,7 @@ func (rh *RepositoryPackageGroupHandler) searchPackageGroupByName(c echo.Context
 // @Summary      List Repositories Package Groups
 // @ID           listRepositoriesPackageGroups
 // @Description  List package groups in a repository.
-// @Tags         repositories,packagegroups
+// @Tags         packagegroups
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Repository ID."
@@ -97,7 +97,7 @@ func (rh *RepositoryPackageGroupHandler) listRepositoriesPackageGroups(c echo.Co
 // @Summary      Search package groups within snapshots
 // @ID           searchSnapshotPackageGroups
 // @Description  This enables users to search for package groups in a given list of snapshots.
-// @Tags         snapshots,environments
+// @Tags         packagegroups
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.SnapshotSearchRpmRequest  true  "request body"

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -34,7 +34,7 @@ func RegisterRpmRoutes(engine *echo.Group, rDao *dao.DaoRegistry) {
 // @Summary      Search RPMs
 // @ID           searchRpm
 // @Description  This enables users to search for RPMs (Red Hat Package Manager) in a given list of repositories.
-// @Tags         repositories,rpms
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.ContentUnitSearchRequest  true  "request body"
@@ -65,7 +65,7 @@ func (rh *RpmHandler) searchRpmByName(c echo.Context) error {
 // @Summary      List Repositories RPMs
 // @ID           listRepositoriesRpms
 // @Description  List RPMs in a repository.
-// @Tags         repositories,rpms
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Repository ID."
@@ -102,7 +102,7 @@ func (rh *RpmHandler) listRepositoriesRpm(c echo.Context) error {
 // @Summary      Search RPMs within snapshots
 // @ID           searchSnapshotRpms
 // @Description  This enables users to search for RPMs (Red Hat Package Manager) in a given list of snapshots.
-// @Tags         snapshots,rpms
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.SnapshotSearchRpmRequest  true  "request body"
@@ -140,7 +140,7 @@ func (rh *RpmHandler) searchSnapshotRPMs(c echo.Context) error {
 // @Summary      List Snapshot RPMs
 // @ID           listSnapshotRpms
 // @Description  List RPMs in a repository snapshot.
-// @Tags         snapshots
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Snapshot ID."
@@ -176,7 +176,7 @@ func (rh *RpmHandler) listSnapshotRpm(c echo.Context) error {
 // @Summary      Detect RPMs presence
 // @ID           detectRpm
 // @Description  This enables users to detect presence of RPMs (Red Hat Package Manager) in a given list of repositories.
-// @Tags         repositories,rpms
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param        body  body   api.DetectRpmsRequest  true  "request body"
@@ -206,7 +206,7 @@ func (rh *RpmHandler) detectRpmsPresence(c echo.Context) error {
 // @Summary      List Snapshot Errata
 // @ID           listSnapshotErrata
 // @Description  List errata in a repository snapshot.
-// @Tags         snapshots
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param        uuid path string true "Snapshot ID."
@@ -252,7 +252,7 @@ func (rh *RpmHandler) listSnapshotErrata(c echo.Context) error {
 // @Summary      List Template RPMs
 // @ID           listTemplateRpms
 // @Description  List RPMs in a content template.
-// @Tags         templates
+// @Tags         rpms
 // @Accept       json
 // @Produce      json
 // @Param		 uuid	path string true "Template ID."

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -36,7 +36,7 @@ func RegisterSnapshotRoutes(group *echo.Group, daoReg *dao.DaoRegistry) {
 // @Summary      List snapshots of a repository
 // @ID           listSnapshots
 // @Description  List snapshots of a repository.
-// @Tags         repositories
+// @Tags         snapshots
 // @Accept       json
 // @Produce      json
 // @Param  uuid  path  string    true  "Repository ID."


### PR DESCRIPTION
## Summary

Adds a linter to check for multiple tags in the openapi spec when running `make openapi`. Each tag is associated with the resulting data. For example, for listing repository package groups, the tag would be `packagegroups`.

## Testing steps

- If there are any cases of multiple tags in the openapi spec, `make openapi` should fail and tell you which endpoint has more than one tag
- `make openapi` should not fail if each endpoint has only one tag
- For QE, some endpoints will be moved around (for example, if an endpoint was originally found under the `repositories_api` and it lists repository rpms, it would now only be found under the `rpms_api`) 

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
