### PR TITLE
Fixes 4222: make repo list search case insensitive

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -348,7 +348,7 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 	if filterData.Search != "" {
 		containsSearch := "%" + filterData.Search + "%"
 		filteredDB = filteredDB.
-			Where("name LIKE ? OR url LIKE ?", containsSearch, containsSearch)
+			Where("name ILIKE ? OR url ILIKE ?", containsSearch, containsSearch)
 	}
 
 	if !config.Get().Features.NewRepositoryFiltering.Enabled && filterData.Origin == "" {


### PR DESCRIPTION
## Summary

Changes repo list search query to be case insensitive

## Testing steps

- Add a repository
- Make a request to the list repos endpoint with a search term (i.e. `/repositories/?search=everything`)
- Should return repositories with that term regardless of case
- Can also check this in the UI with the Name/URL filter

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
