### PR TITLE
Fixes 4272: template name should be editable

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4012,6 +4012,10 @@ const docTemplate = `{
                     "description": "Description of the template",
                     "type": "string"
                 },
+                "name": {
+                    "description": "Name of the template",
+                    "type": "string"
+                },
                 "repository_uuids": {
                     "description": "Repositories to add to the template",
                     "type": "array",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1136,6 +1136,10 @@
                         "description": "Description of the template",
                         "type": "string"
                     },
+                    "name": {
+                        "description": "Name of the template",
+                        "type": "string"
+                    },
                     "repository_uuids": {
                         "description": "Repositories to add to the template",
                         "items": {

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -34,9 +34,10 @@ type TemplateResponse struct {
 	UpdatedAt         time.Time `json:"updated_at"`          // Datetime template was last updated
 }
 
-// We use a separate struct because name, version, arch cannot be updated
+// We use a separate struct because version and arch cannot be updated
 type TemplateUpdateRequest struct {
 	UUID            *string    `json:"uuid" readonly:"true" swaggerignore:"true"`
+	Name            *string    `json:"name"`                                                 // Name of the template
 	Description     *string    `json:"description"`                                          // Description of the template
 	RepositoryUUIDS []string   `json:"repository_uuids"`                                     // Repositories to add to the template
 	Date            *time.Time `json:"date"`                                                 // Latest date to include snapshots for

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -449,6 +449,9 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 	if api.User != nil {
 		model.LastUpdatedBy = *api.User
 	}
+	if api.Name != nil {
+		model.Name = *api.Name
+	}
 }
 
 func templatesModelToApi(model models.Template, api *api.TemplateResponse) {

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -419,11 +419,12 @@ func (s *TemplateSuite) TestUpdate() {
 	origTempl, rcUUIDs := s.seedWithRepoConfig(orgIDTest, 2)
 
 	templateDao := templateDaoImpl{db: s.tx}
-	_, err := templateDao.Update(context.Background(), orgIDTest, origTempl.UUID, api.TemplateUpdateRequest{Description: pointy.Pointer("scratch"), RepositoryUUIDS: []string{rcUUIDs[0]}})
+	_, err := templateDao.Update(context.Background(), orgIDTest, origTempl.UUID, api.TemplateUpdateRequest{Description: pointy.Pointer("scratch"), RepositoryUUIDS: []string{rcUUIDs[0]}, Name: pointy.Pointer("test-name")})
 	require.NoError(s.T(), err)
 	found := s.fetchTemplate(origTempl.UUID)
-	// description does update
+	// description and name updated
 	assert.Equal(s.T(), "scratch", found.Description)
+	assert.Equal(s.T(), "test-name", found.Name)
 	assert.Equal(s.T(), 1, len(found.RepositoryConfigurations))
 	assert.Equal(s.T(), rcUUIDs[0], found.RepositoryConfigurations[0].UUID)
 

--- a/pkg/handler/templates_test.go
+++ b/pkg/handler/templates_test.go
@@ -422,6 +422,7 @@ func (suite *TemplatesSuite) TestPartialUpdate() {
 		Description:     pointy.Pointer("a new template"),
 		RepositoryUUIDS: []string{"repo-uuid"},
 		OrgID:           &orgID,
+		Name:            pointy.Pointer("test template"),
 	}
 
 	expected := api.TemplateResponse{
@@ -461,18 +462,20 @@ func (suite *TemplatesSuite) TestFullUpdate() {
 	template := api.TemplateUpdateRequest{
 		Description: pointy.Pointer("Some desc"),
 		Date:        &time.Time{},
+		Name:        pointy.Pointer("Some name"),
 	}
 	templateExpected := api.TemplateUpdateRequest{
 		Description: template.Description,
 		Date:        template.Date,
+		Name:        template.Name,
 	}
 	templateExpected.FillDefaults()
 
 	expected := api.TemplateResponse{
 		UUID:            "uuid",
-		Name:            "test template",
+		Name:            *templateExpected.Name,
 		OrgID:           orgID,
-		Description:     "a new template",
+		Description:     *templateExpected.Description,
 		Arch:            config.AARCH64,
 		Version:         config.El8,
 		Date:            *templateExpected.Date,

--- a/pkg/models/template.go
+++ b/pkg/models/template.go
@@ -60,9 +60,10 @@ func (t *Template) validate() error {
 
 func (t *Template) MapForUpdate() map[string]interface{} {
 	forUpdate := make(map[string]interface{})
-	// Name, version, arch cannot be updated
+	// Version and arch cannot be updated
 	forUpdate["description"] = t.Description
 	forUpdate["date"] = t.Date
 	forUpdate["last_updated_by"] = t.LastUpdatedBy
+	forUpdate["name"] = t.Name
 	return forUpdate
 }


### PR DESCRIPTION
## Summary

- Adds support for updating a template name 
- This doesn't have the candlepin integration in place yet (updating a template name will not update the environment name). Ticket for that [here](https://issues.redhat.com/browse/HMS-4290)

## Testing steps

- Add a repository, let it snapshot, then create a template
- Edit the template name. This should work via both the API and UI 

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate