### PR TITLE
Refs 4110: return from update task if no cp

### DIFF
--- a/pkg/tasks/update_repository.go
+++ b/pkg/tasks/update_repository.go
@@ -33,6 +33,10 @@ type UpdateRepository struct {
 }
 
 func UpdateRepositoryHandler(ctx context.Context, task *models.TaskInfo, _ *queue.Queue) error {
+	if config.Get().Clients.Candlepin.Server == "" {
+		return nil
+	}
+
 	opts := UpdateRepositoryPayload{}
 	if err := json.Unmarshal(task.Payload, &opts); err != nil {
 		return fmt.Errorf("payload incorrect type for " + config.UpdateRepositoryTask)


### PR DESCRIPTION
## Summary
Return from the update task if candlepin is not configured

## Testing steps

In ephemeral try to update a repository and check the status of the task, it should be successful

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
