### PR TITLE
Fixes 4256: snapshot every hour

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -577,7 +577,7 @@ parameters:
   - name: IMAGE
     value: quay.io/cloudservices/content-sources-backend
   - name: NIGHTLY_CRON_JOB
-    value: "0 0/24 * * *"
+    value: "0 0/1 * * *"
   - name: IMAGE_TAG
     required: true
   - name: CPU_LIMIT

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -470,6 +470,7 @@ objects:
             command:
               - /external-repos
               - nightly-jobs
+              - "24"
             env:
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
@@ -576,7 +577,7 @@ parameters:
   - name: IMAGE
     value: quay.io/cloudservices/content-sources-backend
   - name: NIGHTLY_CRON_JOB
-    value: "0 0/8 * * *"
+    value: "0 0/24 * * *"
   - name: IMAGE_TAG
     required: true
   - name: CPU_LIMIT

--- a/pkg/tasks/update_repository.go
+++ b/pkg/tasks/update_repository.go
@@ -14,7 +14,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
-	"github.com/rs/zerolog/log"
 )
 
 type UpdateRepositoryPayload struct {
@@ -99,7 +98,6 @@ func (ur *UpdateRepository) Run() error {
 // UpdateCPContent updates the content in candlepin (name & GPG Key)
 func (ur *UpdateRepository) UpdateCPContent(content caliri.ContentDTO) error {
 	expected := GenContentDto(ur.repoConfig)
-	log.Logger.Error().Msgf("NAAAAAAME: %v", expected.Name)
 	err := ur.cpClient.UpdateContent(ur.ctx, ur.orgID, ur.repoConfig.UUID, expected)
 	if err != nil {
 		return fmt.Errorf("could not update repository for gpg key update: %w", err)

--- a/pkg/tasks/update_repository.go
+++ b/pkg/tasks/update_repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	"github.com/rs/zerolog/log"
 )
 
 type UpdateRepositoryPayload struct {
@@ -98,6 +99,7 @@ func (ur *UpdateRepository) Run() error {
 // UpdateCPContent updates the content in candlepin (name & GPG Key)
 func (ur *UpdateRepository) UpdateCPContent(content caliri.ContentDTO) error {
 	expected := GenContentDto(ur.repoConfig)
+	log.Logger.Error().Msgf("NAAAAAAME: %v", expected.Name)
 	err := ur.cpClient.UpdateContent(ur.ctx, ur.orgID, ur.repoConfig.UUID, expected)
 	if err != nil {
 		return fmt.Errorf("could not update repository for gpg key update: %w", err)


### PR DESCRIPTION
## Summary
start snapshotting every hour.  On each hourly run:
* Snapshot at least # of repos/24 on each run:
  * snapshots all repos that have not been snapshotted in the last 24 hours
  * if this amount is less than # of repos/24, then grab more repos to snapshot up to that number prioritizing those that have been snapshotted last.

## Testing steps

* on a fresh db:  make repos-import
* `go run cmd/external-repos/main.go nightly-jobs`
* wait until all repos are done snapshotting
* create one or more custom repos

from a `make db-cli-connect` console run:

```
select count(queued_at), max(name), tasks.repository_uuid from tasks inner join repository_configurations rc on rc.repository_uuid = tasks.repository_uuid  where type = 'snapshot'  group by tasks.repository_uuid ;
```
this will show you the number of snapshot tasks per repository.  

Then run:

 `go run cmd/external-repos/main.go nightly-jobs  5`

re-run the query, and on every cmd run you should see (# of repos/5) + 1 snapshots run.  You shouldn't see any counts go more than 1 more than any other repository  (they should all slowly go to '2' and then once they are all '2' you will see some go to '3' tasks)

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
