### PR TITLE
Fixes 4285: add sort_by to /templates/uuid/errata

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2735,6 +2735,12 @@ const docTemplate = `{
                         "description": "A comma separated list of severities to control api response. Severity can include ` + "`" + `Important` + "`" + `, ` + "`" + `Critical` + "`" + `, ` + "`" + `Moderate` + "`" + `, ` + "`" + `Low` + "`" + `, and ` + "`" + `Unknown` + "`" + `.",
                         "name": "severity",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort the response based on specific parameters. Sort criteria can include ` + "`" + `issued_date` + "`" + `, ` + "`" + `updated_date` + "`" + `, ` + "`" + `type` + "`" + `, and ` + "`" + `severity` + "`" + `.",
+                        "name": "sort_by",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4746,6 +4746,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -755,6 +755,7 @@ func (r *rpmDaoImpl) ListTemplateErrata(ctx context.Context, orgId string, templ
 	pkgs, total, err := (*config.Tang).RpmRepositoryVersionErrataList(ctx, pulpHrefs, filters, tangy.PageOptions{
 		Offset: pageOpts.Offset,
 		Limit:  pageOpts.Limit,
+		SortBy: pageOpts.SortBy,
 	})
 
 	if err != nil {

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -298,6 +298,7 @@ func (rh *RpmHandler) listTemplateRpm(c echo.Context) error {
 // @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name."
 // @Param        type query string false "A comma separated list of types to control api response. Type can include `security`, `enhancement`, `bugfix`, and `other`."
 // @Param        severity query string false "A comma separated list of severities to control api response. Severity can include `Important`, `Critical`, `Moderate`, `Low`, and `Unknown`."
+// @Param        sort_by query string false "Sort the response based on specific parameters. Sort criteria can include `issued_date`, `updated_date`, `type`, and `severity`."
 // @Success      200 {object} api.SnapshotErrataCollectionResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse


### PR DESCRIPTION
## Summary

Adds sort_by parameter to `/templates/:uuid/errata`

## Testing steps

- Add a repository with errata, let it snapshot, and create a template
- Make a request to list the template errata with a sort_by parameter. You can sort by issued_date, updated_date, type, or severity. Example request: `/templates/:uuid/errata?sort_by=type:asc`
- Response should list template errata sorted by the column and order specified (type and severity will be sorted alphabetically)

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
