### PR TITLE
Refs 3600: wrap template delete calls

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -112,6 +112,10 @@ jobs:
           CLIENTS_PULP_SERVER: http://localhost:8080
           CLIENTS_PULP_USERNAME: admin
           CLIENTS_PULP_PASSWORD: password
+          CLIENTS_CANDLEPIN_SERVER: http://localhost:8181/candlepin
+          CLIENTS_CANDLEPIN_USERNAME: admin
+          CLIENTS_CANDLEPIN_PASSWORD: admin
+          CLIENTS_CANDLEPIN_DEVEL_ORG: true
       - name: start pulp
         uses: isbang/compose-action@v1.4.1
         with:

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -99,7 +99,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithoutClient() {
 
 	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID).Return([]models.Snapshot{}, nil).Once()
 	s.mockDaoRegistry.RepositoryConfig.On("Delete", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
-	s.mockCpClient.On("DeleteContent", ctx, candlepin_client.DevelOrgKey, candlepin_client.GetContentID(repoConfig.UUID)).Return(nil).Once()
+	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
 	payload := DeleteRepositorySnapshotsPayload{
@@ -134,7 +134,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithClient() {
 	s.MockPulpClient.On("GetRpmRemoteByName", ctx, repoConfig.UUID).Return(nil).Return(nil, nil).Once()
 	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(nil, nil).Once()
 
-	s.mockCpClient.On("DeleteContent", ctx, candlepin_client.DevelOrgKey, candlepin_client.GetContentID(repoConfig.UUID)).Return(nil).Once()
+	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
 	payload := DeleteRepositorySnapshotsPayload{
@@ -197,7 +197,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 	s.MockPulpClient.On("DeleteRpmRepository", ctx, *repoResp.PulpHref).Return("taskHref", nil).Once()
 	s.MockPulpClient.On("DeleteRpmRemote", ctx, *remoteResp.PulpHref).Return("taskHref", nil).Once()
 
-	s.mockCpClient.On("DeleteContent", ctx, candlepin_client.DevelOrgKey, candlepin_client.GetContentID(repoConfig.UUID)).Return(nil).Once()
+	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
 	payload := DeleteRepositorySnapshotsPayload{

--- a/pkg/tasks/delete_templates.go
+++ b/pkg/tasks/delete_templates.go
@@ -71,14 +71,18 @@ func DeleteTemplateHandler(ctx context.Context, task *models.TaskInfo, _ *queue.
 func (d *DeleteTemplates) Run() error {
 	var err error
 
-	err = d.deleteDistributions()
-	if err != nil {
-		return err
+	if config.PulpConfigured() {
+		err = d.deleteDistributions()
+		if err != nil {
+			return err
+		}
 	}
 
-	err = d.cpClient.DeleteEnvironment(d.ctx, d.payload.TemplateUUID)
-	if err != nil {
-		return err
+	if config.CandlepinConfigured() {
+		err = d.cpClient.DeleteEnvironment(d.ctx, d.payload.TemplateUUID)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = d.deleteTemplate()


### PR DESCRIPTION
## Summary

Don't call out to candlepin when deleting a template if its not configured

## Testing steps

Locally disable the candlepin server by commenting out the candlepin server url
create a template and then try to delete it

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
