### PR TITLE
Fixes 4281: remove 8-stream from public repos

### DIFF
--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1487,6 +1487,11 @@ func (suite *RepositoryConfigSuite) TestSavePublicUrls() {
 	var count int64
 	repoUrls := []string{
 		"https://somepublicRepo.example.com/",
+		"https://anotherpublicRepo.example.com",
+	}
+
+	repoUrlsCleaned := []string{
+		"https://somepublicRepo.example.com/",
 		"https://anotherpublicRepo.example.com/",
 	}
 
@@ -1496,7 +1501,7 @@ func (suite *RepositoryConfigSuite) TestSavePublicUrls() {
 	repos := []models.Repository{}
 	err = tx.
 		Model(&models.Repository{}).
-		Where("url in (?)", repoUrls).
+		Where("url in (?)", repoUrlsCleaned).
 		Count(&count).
 		Find(&repos).
 		Error
@@ -1508,7 +1513,7 @@ func (suite *RepositoryConfigSuite) TestSavePublicUrls() {
 	assert.NoError(t, err)
 	err = tx.
 		Model(&models.Repository{}).
-		Where("url in (?)", repoUrls).
+		Where("url in (?)", repoUrlsCleaned).
 		Count(&count).
 		Find(&repos).
 		Error
@@ -1516,7 +1521,7 @@ func (suite *RepositoryConfigSuite) TestSavePublicUrls() {
 	assert.Equal(t, int64(len(repos)), count)
 
 	// Remove one url and check that it was changed back to false
-	noLongerPublic := repoUrls[0]
+	noLongerPublic := repoUrlsCleaned[0]
 	repoUrls = repoUrls[1:2] // remove the first item
 	err = GetRepositoryConfigDao(suite.tx, suite.mockPulpClient).SavePublicRepos(context.Background(), repoUrls)
 	assert.NoError(t, err)
@@ -1527,7 +1532,7 @@ func (suite *RepositoryConfigSuite) TestSavePublicUrls() {
 	assert.False(t, repo.Public)
 
 	repo = models.Repository{}
-	err = tx.Model(&models.Repository{}).Where("url = ?", repoUrls[0]).Find(&repo).Error
+	err = tx.Model(&models.Repository{}).Where("url = ?", repoUrlsCleaned[1]).Find(&repo).Error
 	require.NoError(t, err)
 	assert.True(t, repo.Public)
 }

--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -1,14 +1,5 @@
 [
     {
-        "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
-    },
-    {
-        "base_url": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
-    },
-    {
-        "base_url": "http://mirror.centos.org/centos/8-stream/extras/x86_64/os/"
-    },
-    {
         "base_url": "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
     },
     {
@@ -106,15 +97,6 @@
     },
     {
         "base_url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable"
-    },
-    {
-        "base_url": "http://mirror.centos.org/centos/8-stream/AppStream/aarch64/os/"
-    },
-    {
-        "base_url": "http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/"
-    },
-    {
-        "base_url": "http://mirror.centos.org/centos/8-stream/extras/aarch64/os/"
     },
     {
         "base_url": "http://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/"


### PR DESCRIPTION
## Summary

and make repos removed from the external_repos.json file no longer public

## Testing steps

1. on main run `make repos-import`
2. connect to the db and query 8-stream public repos:
```
make db-cli-connect
# select public, url from repositories  where url ilike '%8-stream%';
```
3.  Check out this PR, re-run `make repos-import`
4. re-query the query and make sure the 8-stream repos are no longer public
5. query the 9-stream repos and make sure they are still public
```
# select public, url from repositories  where url ilike '%9-stream%';
```

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
