### PR TITLE
Refs 4133: add types filter to admin tasks list

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -57,6 +57,7 @@ type AdminTaskFilterData struct {
 	Status    string `json:"status"` // Comma separated list of statuses to optionally filter on.
 	OrgId     string `json:"org_id"`
 	AccountId string `json:"account_id"`
+	Typename  string `json:"type"`
 }
 
 func RootPrefix() string {

--- a/pkg/dao/admin_tasks.go
+++ b/pkg/dao/admin_tasks.go
@@ -76,6 +76,11 @@ func (a adminTaskInfoDaoImpl) List(
 		filteredDB = filteredDB.Where("status IN ?", statuses)
 	}
 
+	if filterData.Typename != "" {
+		typenames := strings.Split(filterData.Typename, ",")
+		filteredDB = filteredDB.Where("type IN ?", typenames)
+	}
+
 	sortMap := map[string]string{
 		"org_id":      "tasks.org_id",
 		"account_id":  "account_id",

--- a/pkg/dao/admin_tasks_test.go
+++ b/pkg/dao/admin_tasks_test.go
@@ -467,6 +467,34 @@ func (suite *AdminTaskSuite) TestFilterAccountID() {
 	assert.Equal(t, 1, len(response.Data))
 }
 
+func (suite *AdminTaskSuite) TestFilterType() {
+	suite.createTask()
+	t := suite.T()
+
+	var total int64
+	pageData := api.PaginationData{
+		Limit:  100,
+		Offset: 0,
+	}
+	filterData := api.AdminTaskFilterData{
+		Typename: "another test task type",
+	}
+	var err error
+
+	response, total, err := suite.dao.List(context.Background(), pageData, filterData)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.Equal(t, 0, len(response.Data))
+
+	filterData = api.AdminTaskFilterData{
+		Typename: "test task type",
+	}
+	response, total, err = suite.dao.List(context.Background(), pageData, filterData)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, 1, len(response.Data))
+}
+
 func (suite *AdminTaskSuite) TestSort() {
 	t := suite.T()
 	orgId1 := seeds.RandomOrgId()

--- a/pkg/handler/admin_tasks.go
+++ b/pkg/handler/admin_tasks.go
@@ -71,6 +71,7 @@ func ParseAdminTaskFilters(c echo.Context) api.AdminTaskFilterData {
 		String("account_id", &filterData.AccountId).
 		String("org_id", &filterData.OrgId).
 		String("status", &filterData.Status).
+		String("type", &filterData.Typename).
 		BindError()
 
 	if err != nil {


### PR DESCRIPTION
## Summary
Adds ability to filter admin tasks by type

## Testing steps
1. Either test using frontend PR or make a request like `GET /admin/tasks/?type=introspect,snapshot`
2. Make sure you've created/deleted some repos and templates so you have a few task types to filter.
3. These are all the task types: https://github.com/content-services/content-sources-backend/blob/main/pkg/config/tasks.go#L4-L9
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
