### PR TITLE
Fixes 4292: filtering templates by repo uuids lists dups

### DIFF
--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -245,11 +245,13 @@ func (t templateDaoImpl) List(ctx context.Context, orgID string, paginationData 
 	// Get count
 	if filteredDB.
 		Model(&templates).
+		Distinct("uuid").
 		Count(&totalTemplates).Error != nil {
 		return api.TemplateCollectionResponse{}, totalTemplates, t.DBToApiError(filteredDB.Error)
 	}
 
 	if filteredDB.
+		Distinct("templates.*").
 		Preload("RepositoryConfigurations").
 		Order(order).
 		Limit(paginationData.Limit).

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -265,12 +265,14 @@ func (s *TemplateSuite) TestListFilters() {
 
 	// Test Filter by RepositoryUUIDs
 	template, rcUUIDs := s.seedWithRepoConfig(orgIDTest, 2)
-	filterData = api.TemplateFilterData{RepositoryUUIDs: []string{rcUUIDs[0]}}
+	filterData = api.TemplateFilterData{RepositoryUUIDs: []string{rcUUIDs[0], rcUUIDs[1]}}
 	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
 	assert.True(s.T(), template.UUID == responses.Data[0].UUID || template.UUID == responses.Data[1].UUID)
+	assert.True(s.T(), rcUUIDs[0] == responses.Data[0].RepositoryUUIDS[0] || rcUUIDs[0] == responses.Data[1].RepositoryUUIDS[0])
+	assert.True(s.T(), rcUUIDs[1] == responses.Data[0].RepositoryUUIDS[1] || rcUUIDs[1] == responses.Data[1].RepositoryUUIDS[1])
 }
 
 func (s *TemplateSuite) TestListFilterSearch() {


### PR DESCRIPTION
## Summary

Fixes a bug where filtering templates by multiple repo uuids lists duplicate templates

## Testing steps

- Add 2 repositories, let them snapshot, and create a template with both of those repositories
- Make a request to list templates filtering by those 2 repo uuids (`templates/?repository_uuids=f572ddd9-2aaa-4503-bd87-9be723574f33,3a379621-e5af-40ad-a7a6-1b0c59934194`)
- You should see that template listed once and count should be 1:
```
{
    "data": [
        {
            "uuid": "8f52f555-eef5-4b06-96ce-c0afdd260dd6",
            "name": "template1",
            "org_id": "17684632",
            "description": "",
            "arch": "x86_64",
            "version": "8",
            "date": "2024-06-17T00:00:00-04:00",
            "repository_uuids": [
                "f572ddd9-2aaa-4503-bd87-9be723574f33",
                "3a379621-e5af-40ad-a7a6-1b0c59934194",
            ],
            "rhsm_environment_id": "8f52f555eef54b0696cec0afdd260dd6",
            "created_by": "bryttaniehouse",
            "last_updated_by": "bryttaniehouse",
            "created_at": "2024-06-17T11:40:12.335712-04:00",
            "updated_at": "2024-06-17T11:40:12.335712-04:00"
        }
    ],
    "meta": {
        "limit": 100,
        "offset": 0,
        "count": 1
    },
```

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
