### PR TITLE
Refs 4256: change snapshot interval to 24 hours

### DIFF
--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -29,7 +29,7 @@ const El8 = "8"
 const El9 = "9"
 
 const FailedIntrospectionsLimit = 20
-const SnapshotInterval = 20 // In hours
+const SnapshotForceInterval = 24 // In hours
 
 type DistributionVersion struct {
 	Name  string `json:"name"`  // Human-readable form of the version

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -239,7 +239,7 @@ func (p repositoryConfigDaoImpl) InternalOnly_ListReposToSnapshot(ctx context.Co
 	var query *gorm.DB
 	pdb := p.db.WithContext(ctx)
 
-	interval := fmt.Sprintf("%v hours", config.SnapshotInterval)
+	interval := fmt.Sprintf("%v hours", config.SnapshotForceInterval)
 	if config.Get().Options.AlwaysRunCronTasks {
 		query = pdb.Where("snapshot IS TRUE")
 	} else {


### PR DESCRIPTION
## Summary

By changing it to 24 hours, we are forcing snapshotting to happen only if they haven't been snapshotted in 24 hours, not 20.  Since the job is running hourly, it won't now grab ~3 hours worth of repos

## Testing steps

None right now, I think we should merge and monitor the behavior

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
