### PR TITLE
Fixes 3942: valid meta_key shows no gpg key found

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1386,7 +1386,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/repository_parameters/external_gpg_key": {
+        "/repository_parameters/external_gpg_key/": {
             "post": {
                 "description": "Fetch a gpgkey from a remote repo.",
                 "consumes": [

--- a/api/docs.go
+++ b/api/docs.go
@@ -1400,6 +1400,17 @@ const docTemplate = `{
                 ],
                 "summary": "Fetch gpgkey from URL",
                 "operationId": "fetchGpgKey",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.FetchGPGKeyRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2947,6 +2958,15 @@ const docTemplate = `{
             "type": "object",
             "additionalProperties": {
                 "$ref": "#/definitions/api.Feature"
+            }
+        },
+        "api.FetchGPGKeyRequest": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "description": "The url from which to download the GPG Key.",
+                    "type": "string"
+                }
             }
         },
         "api.FetchGPGKeyResponse": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3038,7 +3038,7 @@
                 ]
             }
         },
-        "/repository_parameters/external_gpg_key": {
+        "/repository_parameters/external_gpg_key/": {
             "post": {
                 "description": "Fetch a gpgkey from a remote repo.",
                 "operationId": "fetchGpgKey",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -96,6 +96,15 @@
                 },
                 "type": "object"
             },
+            "api.FetchGPGKeyRequest": {
+                "properties": {
+                    "url": {
+                        "description": "The url from which to download the GPG Key.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "api.FetchGPGKeyResponse": {
                 "properties": {
                     "gpg_key": {
@@ -3033,6 +3042,18 @@
             "post": {
                 "description": "Fetch a gpgkey from a remote repo.",
                 "operationId": "fetchGpgKey",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.FetchGPGKeyRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
                 "responses": {
                     "200": {
                         "content": {

--- a/pkg/handler/repository_parameters.go
+++ b/pkg/handler/repository_parameters.go
@@ -43,7 +43,7 @@ func RegisterRepositoryParameterRoutes(engine *echo.Group, dao *dao.DaoRegistry)
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
-// @Router       /repository_parameters/external_gpg_key [post]
+// @Router       /repository_parameters/external_gpg_key/ [post]
 func (rh *RepositoryParameterHandler) fetchGpgKey(c echo.Context) error {
 	var gpgKeyParams api.FetchGPGKeyRequest
 

--- a/pkg/handler/repository_parameters.go
+++ b/pkg/handler/repository_parameters.go
@@ -36,6 +36,7 @@ func RegisterRepositoryParameterRoutes(engine *echo.Group, dao *dao.DaoRegistry)
 // @Tags         gpgKey
 // @Accept       json
 // @Produce      json
+// @Param        body  body     api.FetchGPGKeyRequest  true  "request body"
 // @Success      200 {object} api.FetchGPGKeyResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse


### PR DESCRIPTION
## Summary

Adds the request body to the api spec for `/repository_parameters/external_gpg_key/`. This was missing and is needed for QE to test validation of gpg keys when fetching from a remote repo.

## Testing steps

- Add a repository (QE example [here](https://issues.redhat.com/browse/HMS-3942) is using this one: https://jlsherrill.fedorapeople.org/fake-repos/signed/) 
- Fetch the gpg key from this URL: https://jlsherrill.fedorapeople.org/fake-repos/signed/GPG-KEY.gpg
```
POST /repository_parameters/external_gpg_key/

Request:
{
     "url": "https://jlsherrill.fedorapeople.org/fake-repos/signed/GPG-KEY.gpg"
}

Response:
{
    "gpg_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPhWqgBEACnFSBzQlJ1ilLhS/toT46iJqInMQFtQz...-----END PGP PUBLIC KEY BLOCK-----\n"
}    
```
- Using the gpg key from the previous response, validate the gpg key for the repository
```
POST /repository_parameters/validate/

Request:
[
  {
    "gpg_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGPhWqgBEACnFS...",
    "metadata_verification": true,
    "name": "test1",
    "url": "https://jlsherrill.fedorapeople.org/fake-repos/signed/",
    "uuid": "1c90d2e1-642b-409f-a3ee-256e1a3e6d78"
  }
]

Response:
[
    {
        "name": {
            "skipped": false,
            "valid": true,
            "error": ""
        },
        "url": {
            "skipped": false,
            "valid": true,
            "error": "",
            "http_code": 200,
            "metadata_present": true,
            "metadata_signature_present": false
        },
        "gpg_key": {
            "skipped": false,
            "valid": true,
            "error": ""
        }
    }
]
```
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
