### PR TITLE
Fixes 2246: fix conflict on guard creation

### DIFF
--- a/pkg/pulp_client/domains.go
+++ b/pkg/pulp_client/domains.go
@@ -1,14 +1,12 @@
 package pulp_client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"reflect"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	zest "github.com/content-services/zest/release/v2024"
-	"github.com/rs/zerolog/log"
 )
 
 const DefaultDomain = "default"
@@ -121,18 +119,7 @@ func (r *pulpDaoImpl) CreateDomain(ctx context.Context, name string) (string, er
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		body := ""
-		if resp != nil && resp.Body != nil {
-			buf := new(bytes.Buffer)
-			_, err := buf.ReadFrom(resp.Body)
-			if err == nil {
-				body = buf.String()
-			} else {
-				log.Error().Err(err).Msg("Error reading body from failed domain creation.")
-			}
-		}
-		log.Warn().Err(err).Str("body", body).Msg("Error creating domain")
-		return "", err
+		return "", errorWithResponseBody("error creating domain", resp, err)
 	}
 	return *domainResp.PulpHref, nil
 }


### PR DESCRIPTION
## Summary

After reviewing the domain creation logic to handle race conditions on create, i determined the current method was best, but could use some simplification by use of errorWithResponseBody
while testing, however, i discovered that the content_Guard creation did not properly handle race conditions.

## Testing steps

1.  turn on content guard creation by setting clients -> pulp -> 'custom_repo_content_guards' to true in config.yaml
2. run the server
3. run:
```
curl -H "`./scripts/header.sh $RANDOM $RANDOM`"  http://localhost:8000/api/content-sources/v1/repositories/bulk_create/  -H "content-type: application/json"  -X POST -d '[{"name":"abc1", "url":"https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/", "snapshot": true},{"name":"abc2", "url":"https://jlsherrill.fedorapeople.org/fake-repos/signed/", "snapshot": true}, {"name":"abc3", "url":"https://jlsherrill.fedorapeople.org/fake-repos/really-empty/", "snapshot": true}, {"name":"abc4", "url":"https://jlsherrill.fedorapeople.org/fake-repos/empty/", "snapshot": true}]'
```

This will try to create 3 repos with snapshotting in a random org.  Monitor the backend logs and verify no error occurs from the tasks

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
