### PR TITLE
Fixes 3861: reject cancellation of certain task types

### DIFF
--- a/pkg/config/tasks.go
+++ b/pkg/config/tasks.go
@@ -18,3 +18,5 @@ const (
 )
 
 var RequeueableTasks = []string{DeleteTemplatesTask, DeleteRepositorySnapshotsTask, UpdateTemplateContentTask}
+
+var CancellableTasks = []string{IntrospectTask, RepositorySnapshotTask}

--- a/pkg/tasks/client/client.go
+++ b/pkg/tasks/client/client.go
@@ -3,9 +3,11 @@ package client
 import (
 	"context"
 
+	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	"github.com/google/uuid"
+	"golang.org/x/exp/slices"
 )
 
 //go:generate $GO_OUTPUT/mockery  --name TaskClient --filename client_mock.go --inpackage
@@ -39,6 +41,13 @@ func (c *Client) SendCancelNotification(ctx context.Context, taskId string) erro
 	taskUUID, err := uuid.Parse(taskId)
 	if err != nil {
 		return err
+	}
+	task, err := c.queue.Status(taskUUID)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(config.CancellableTasks, task.Typename) {
+		return queue.ErrNotCancellable
 	}
 	err = c.queue.SendCancelNotification(ctx, taskUUID)
 	if err != nil {

--- a/pkg/tasks/client/client.go
+++ b/pkg/tasks/client/client.go
@@ -2,12 +2,12 @@ package client
 
 import (
 	"context"
+	"slices"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/tasks"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 )
 
 //go:generate $GO_OUTPUT/mockery  --name TaskClient --filename client_mock.go --inpackage

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -59,4 +59,5 @@ var (
 	ErrContextCanceled    = fmt.Errorf("dequeue context timed out or was canceled")
 	ErrRowsNotAffected    = fmt.Errorf("no rows were affected")
 	ErrMaxRetriesExceeded = fmt.Errorf("task has exceeded the maximum amount of retries")
+	ErrNotCancellable     = fmt.Errorf("task not cancellable")
 )


### PR DESCRIPTION
## Summary

- Adds a list of cancellable tasks to check against and rejects cancelling any tasks not included in the list. Currently includes only snapshot and introspect tasks
- Unrelated but attempting to cancel a RH task resulted in a panic due to dereferencing an error that doesn't exist so this includes that fix also

## Testing steps

- Start a few different tasks in addition to introspect and snapshot and take note of the task uuid. List of all task types [here](https://github.com/content-services/content-sources-backend/blob/main/pkg/config/tasks.go)
- Make a request to cancel any task that isn't snapshot or introspect: `POST /tasks/:uuid/cancel/`. You should get a 400
- Cancelling snapshot or introspect tasks works as before

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
