### PR TITLE
Build: restart pulp migration on error

### DIFF
--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       postgres:
         condition: service_healthy
     command: pulpcore-manager migrate --noinput
+    restart: on-failure
     volumes:
       - "./assets/settings.py:/etc/pulp/settings.py:z"
       - "./assets/certs:/etc/pulp/certs:z"


### PR DESCRIPTION
## Summary

There seems to be a race condition where podman thinks postgres is 'up' but its not.  So restart the pulp migration if it errors.

## Testing steps

```
make compose-clean compose-up
```

try to create a repo for snapshotting

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
