### PR TITLE
Fixes 4334: lower parse filters log level

### DIFF
--- a/pkg/handler/admin_tasks.go
+++ b/pkg/handler/admin_tasks.go
@@ -75,7 +75,7 @@ func ParseAdminTaskFilters(c echo.Context) api.AdminTaskFilterData {
 		BindError()
 
 	if err != nil {
-		log.Ctx(c.Request().Context()).Info().Err(err).Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("error parsing filters")
 	}
 
 	return filterData

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -237,7 +237,7 @@ func ParseFilters(c echo.Context) api.FilterData {
 		BindError()
 
 	if err != nil {
-		log.Ctx(c.Request().Context()).Info().Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("error parsing filters")
 	}
 
 	return filterData

--- a/pkg/handler/task_info.go
+++ b/pkg/handler/task_info.go
@@ -128,7 +128,7 @@ func ParseTaskInfoFilters(c echo.Context) api.TaskInfoFilterData {
 		BindError()
 
 	if err != nil {
-		log.Error().Err(err).Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("error parsing filters")
 	}
 
 	return filterData

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -229,7 +229,7 @@ func ParseTemplateFilters(c echo.Context) api.TemplateFilterData {
 		BindError()
 
 	if err != nil {
-		log.Error().Err(err).Msg("Error parsing filters")
+		log.Ctx(c.Request().Context()).Info().Err(err).Msg("error parsing filters")
 	}
 	if repositoryUUIDs != "" {
 		filterData.RepositoryUUIDs = strings.Split(repositoryUUIDs, ",")


### PR DESCRIPTION
## Summary
Changes all the parse filter error returns to log at the same level (INFO)

## Testing steps
1. Make a request to `tasks/?exclude_red_hat_org=notabool`, where the params are the wrong type
2. In the server logs, there will be an error logged at the INFO level
## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
