### PR TITLE
Refs 3898: add error log endpoint for UI glitchtip

### DIFF
--- a/pkg/handler/api_test.go
+++ b/pkg/handler/api_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -72,6 +73,18 @@ func TestOpenapi(t *testing.T) {
 	js := json.RawMessage{}
 	err = json.Unmarshal(body, &js)
 	assert.Nil(t, err)
+}
+
+func TestUIError(t *testing.T) {
+	body := []byte(`{"error_title": "a UI error has occurred"}`)
+	req, err := http.NewRequest("POST", "/api/"+config.DefaultAppName+"/v1.0/log_error/", bytes.NewReader(body))
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	req.Header.Set("Content-Type", "application/json")
+	code, _, err := serveRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
 }
 
 func getTestContext(params string) echo.Context {


### PR DESCRIPTION
## Summary
Adds an endpoint that logs the error sent to it, so that the frontend can send errors to it, and we can get glitchtip notifications for those errors

See https://github.com/content-services/content-sources-frontend/pull/296

POST request to `/content-sources/v1/log_error`

with the body 
```
{
    "error_title": "UI error",
    "error_details": "an error has occurred [might include stack trace]"
}
```

## Testing steps
1. Send a POST request with the body above to the new endpoint
2. In the terminal, you should see an error log

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
