### PR TITLE
Fixes 4294: snapshot on create for upload repo

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -393,7 +393,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "A comma separated list of statuses to control api response. Statuses can include ` + "`" + `pending` + "`" + `, ` + "`" + `valid` + "`" + `, ` + "`" + `invalid` + "`" + `, ` + "`" + `unavailable` + "`" + `.",
+                        "description": "A comma separated list of statuses to control api response. Statuses can include ` + "`" + `Pending` + "`" + `, ` + "`" + `Valid` + "`" + `, ` + "`" + `Invalid` + "`" + `, ` + "`" + `Unavailable` + "`" + `.",
                         "name": "status",
                         "in": "query"
                     },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1782,7 +1782,7 @@
                         }
                     },
                     {
-                        "description": "A comma separated list of statuses to control api response. Statuses can include `pending`, `valid`, `invalid`, `unavailable`.",
+                        "description": "A comma separated list of statuses to control api response. Statuses can include `Pending`, `Valid`, `Invalid`, `Unavailable`.",
                         "in": "query",
                         "name": "status",
                         "schema": {

--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -160,10 +160,6 @@ func (r *RepositoryCollectionResponse) SetMetadata(meta ResponseMetadata, links 
 	r.Links = links
 }
 
-func (r *RepositoryResponse) Snapshottable() bool {
-	return r.Origin != config.OriginUpload && r.Snapshot
-}
-
 func (r *RepositoryResponse) Introspectable() bool {
 	return r.Origin != config.OriginUpload
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -206,6 +206,7 @@ func (r repositoryConfigDaoImpl) bulkCreate(tx *gorm.DB, newRepositories []api.R
 			tx.RollbackTo("beforecreate")
 			continue
 		}
+		newRepoConfigs[i].Repository = newRepos[i] // Set repo on config for proper response values
 
 		// If there is at least 1 error, skip creating responses
 		if dbErr == nil {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -77,7 +77,7 @@ func getAccountIdOrgId(c echo.Context) (string, string) {
 // @Param		 url query string false "A comma separated list of URLs to control api response."
 // @Param		 uuid query string false "A comma separated list of UUIDs to control api response."
 // @Param		 sort_by query string false "Sort the response data based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`."
-// @Param        status query string false "A comma separated list of statuses to control api response. Statuses can include `pending`, `valid`, `invalid`, `unavailable`."
+// @Param        status query string false "A comma separated list of statuses to control api response. Statuses can include `Pending`, `Valid`, `Invalid`, `Unavailable`."
 // @Param		 origin query string false "A comma separated list of origins to filter api response. Origins can include `red_hat` and `external`."
 // @Param		 content_type query string false "content type of a repository to filter on (rpm)"
 // @Accept       json
@@ -141,7 +141,7 @@ func (rh *RepositoryHandler) createRepository(c echo.Context) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error creating repository", err.Error())
 	}
 
-	if response.Snapshottable() {
+	if response.Snapshot {
 		rh.enqueueSnapshotEvent(c, &response)
 	}
 	if response.Introspectable() {
@@ -197,7 +197,7 @@ func (rh *RepositoryHandler) bulkCreateRepositories(c echo.Context) error {
 
 	// Produce an event for each repository
 	for index, repo := range responses {
-		if repo.Snapshottable() {
+		if repo.Snapshot {
 			rh.enqueueSnapshotEvent(c, &responses[index])
 		}
 		if repo.Introspectable() {
@@ -534,7 +534,7 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 
 	var repoUpdate dao.RepositoryUpdate
 	count := 0
-	lastIntrospectionStatus := "Pending"
+	lastIntrospectionStatus := config.StatusPending
 	if req.ResetCount {
 		repoUpdate = dao.RepositoryUpdate{
 			UUID:                      repo.UUID,

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -38,6 +38,13 @@ func (r *Repository) BeforeCreate(tx *gorm.DB) (err error) {
 		return err
 	}
 	r.URL = CleanupURL(r.URL)
+	if r.Origin == config.OriginUpload {
+		r.LastIntrospectionStatus = config.StatusValid
+		time := time.Now()
+		r.LastIntrospectionTime = &time
+		r.LastIntrospectionSuccessTime = &time
+		r.LastIntrospectionUpdateTime = &time
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Run the snapshot task at creation of upload repositories.  
Modify the snapshot task to not create a remote and not perform a sync during the snapshot task.  Instead it will grab the latest version href from the repository in pulp (which should be empty version 0)

## Testing steps

1. create an upload repo:
```
####
POST http://localhost:8000/api/content-sources/v1.0/repositories/
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
//x-Rh-Insights-Request-Id: 9d229d34-7219-405d-ba3d-8f99cf7c36ae
Content-Type: application/json

{
  "name": "test",
  "url": "",
  "origin": "upload",
  "snapshot": true
}
```

2.  Fetch the repository (GET /repositories/?origin=upload), you should see a snapshot task be created.  Once that is done, you can fetch the snapshots for the repository (GET /repositories/UUID/snapshots)
3. From the repository data, grab the latest snapshot url, and fetch that:
```
curl http://localhost:8080/pulp/content/f5cc5c96/4d19b9f2-ecb2-41d5-8844-cea5f9a701fe/8419ed86-9e49-4ebc-a34e-0158e67d79be/
```


## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
