### PR TITLE
Fixes 4346: return task for introspect and snapshot APIs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1002,8 +1002,11 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "Introspection was successfully queued"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.TaskInfoResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -1206,8 +1209,11 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "Snapshot was successfully queued"
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.TaskInfoResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2534,8 +2534,15 @@
                     "x-originalParamName": "body"
                 },
                 "responses": {
-                    "204": {
-                        "description": "Introspection was successfully queued"
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TaskInfoResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
                     },
                     "400": {
                         "content": {
@@ -2800,8 +2807,15 @@
                     }
                 ],
                 "responses": {
-                    "204": {
-                        "description": "Snapshot was successfully queued"
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TaskInfoResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
                     },
                     "400": {
                         "content": {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -436,7 +436,7 @@ func (rh *RepositoryHandler) bulkDeleteRepositories(c echo.Context) error {
 // @Description     Snapshot a repository if not already snapshotting
 // @Tags			repositories
 // @Param  			uuid            path    string                          true   "Repository ID."
-// @Success			204 "Snapshot was successfully queued"
+// @Success			200 {object} api.TaskInfoResponse
 // @Failure      	400 {object} ce.ErrorResponse
 // @Failure      	404 {object} ce.ErrorResponse
 // @Failure      	500 {object} ce.ErrorResponse
@@ -482,7 +482,7 @@ func (rh *RepositoryHandler) createSnapshot(c echo.Context) error {
 // @Tags			repositories
 // @Param  			uuid            path    string                          true   "Repository ID."
 // @Param			body            body    api.RepositoryIntrospectRequest false  "request body"
-// @Success			204 "Introspection was successfully queued"
+// @Success			200 {object} api.TaskInfoResponse
 // @Failure      	400 {object} ce.ErrorResponse
 // @Failure      	404 {object} ce.ErrorResponse
 // @Failure      	500 {object} ce.ErrorResponse


### PR DESCRIPTION
## Summary
When using repository introspect and snapshot ends points, the response will now be the task info struct.

## Testing steps
1. Use the repository introspect API to introspect a repository, it should return a 200 and a json with the task info.
2. Use the repository snapshot API to snapshot a repository, it should return a 200 and a json with the task info.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
