### PR TITLE
Refs 4414: set candlepin deploy params

### DIFF
--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       timeout: 3s
 
   migration_service:
-    image: "quay.io/cloudservices/pulp-ubi:latest"
+    image: "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     depends_on:
       postgres:
         condition: service_healthy
@@ -33,7 +33,7 @@ services:
       - "pulp:/var/lib/pulp"      
 
   set_init_password_service:
-    image:  "quay.io/cloudservices/pulp-ubi:latest"
+    image:  "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     command: set_init_password.sh
     depends_on:
       migration_service:
@@ -54,7 +54,7 @@ services:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]
 
   pulp_api:
-    image: "quay.io/cloudservices/pulp-ubi:latest"
+    image: "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     deploy:
       replicas: 1
     command: [ 'pulp-api' ]
@@ -78,7 +78,7 @@ services:
     restart: always
 
   pulp_content:
-    image: "quay.io/cloudservices/pulp-ubi:latest"
+    image: "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     deploy:
       replicas: 1
     command: [ 'pulp-content' ]
@@ -116,7 +116,7 @@ services:
     restart: always
 
   pulp_worker:
-    image: "quay.io/cloudservices/pulp-ubi:latest"
+    image: "quay.io/redhat-services-prod/pulp-services-tenant/pulp:latest"
     deploy:
       replicas: 2
     command: [ 'pulp-worker' ]

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -136,6 +136,20 @@ objects:
                 value: ${OPTIONS_REPOSITORY_IMPORT_FILTER}
               - name: TASKING_WORKER_COUNT
                 value: ${TASKING_WORKER_COUNT}
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -269,6 +283,20 @@ objects:
                     name: pulp-db
                     key: db.name
                     optional: false
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -524,6 +552,20 @@ objects:
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
                 value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
       database:
         name: content-sources
         version: 15
@@ -672,3 +714,5 @@ parameters:
   - name: TASKING_WORKER_COUNT
     default: 3
     description: Number of task workers running within a single worker process
+  - name: CLIENTS_CANDLEPIN_SERVER
+    default: ''


### PR DESCRIPTION
## Summary

Set variables needed for candlepin communication.  Cert & key come from a secret.  This won't affect ephemeral at all

## Testing steps
tests are green

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
