### PR TITLE
Fixes 4420: add ca support to candlepin client

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -150,6 +150,12 @@ objects:
                     name: content-sources-candlepin
                     key: key
                     optional: true
+              - name: CLIENTS_CANDLEPIN_CA_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: ca
+                    optional: true
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -296,6 +302,12 @@ objects:
                   secretKeyRef:
                     name: content-sources-candlepin
                     key: key
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CA_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: ca
                     optional: true
             resources:
               limits:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,7 @@ type Candlepin struct {
 	Password   string
 	ClientCert string `mapstructure:"client_cert"`
 	ClientKey  string `mapstructure:"client_key"`
+	CACert     string `mapstructure:"ca_cert"`
 	DevelOrg   bool   `mapstructure:"devel_org"` // For use only in dev envs
 }
 
@@ -257,6 +258,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.candlepin.password", "")
 	v.SetDefault("clients.candlepin.client_cert", "")
 	v.SetDefault("clients.candlepin.client_key", "")
+	v.SetDefault("clients.candlepin.ca_cert", "")
 	v.SetDefault("clients.candlepin.devel_org", false)
 
 	v.SetDefault("clients.pulp.server", "")


### PR DESCRIPTION
## Summary

support a custom ca cert in teh candlepin connection

## Testing steps

I would just do a code review on this.  I was able to see this work using custom certs, but it was a very manual process of loading files from the filesystem into the config (since the config takes the file contents, not file names).   We should see it fix the current issue in stage quickly

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
