### PR TITLE
Refs 4420: set RootCAs, not ClientCAs

### DIFF
--- a/pkg/candlepin_client/client.go
+++ b/pkg/candlepin_client/client.go
@@ -48,11 +48,7 @@ func getHTTPClient() (http.Client, error) {
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 		}
-		if ca == "" {
-			log.Debug().Msg("CANDLEPIN_CLIENT: no ca present")
-		}
 		if ca != "" {
-			log.Debug().Msgf("CANDLEPIN_CLIENT: %v", ca)
 			pool, err := certPool(ca)
 			if err != nil {
 				return http.Client{}, err

--- a/pkg/candlepin_client/client.go
+++ b/pkg/candlepin_client/client.go
@@ -53,7 +53,7 @@ func getHTTPClient() (http.Client, error) {
 			if err != nil {
 				return http.Client{}, err
 			}
-			tlsConfig.ClientCAs = pool
+			tlsConfig.RootCAs = pool
 		}
 		transport.TLSClientConfig = tlsConfig
 	}


### PR DESCRIPTION
## Summary

## Testing steps

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
