### PR TITLE
Fixes 4431: detect env fetch 404 and use env type

### DIFF
--- a/pkg/candlepin_client/environment.go
+++ b/pkg/candlepin_client/environment.go
@@ -8,6 +8,8 @@ import (
 	"github.com/openlyinc/pointy"
 )
 
+const ENVIRONMENT_TYPE = "content-template"
+
 func GetEnvironmentID(templateUUID string) string {
 	return strings.Replace(templateUUID, "-", "", -1)
 }
@@ -42,7 +44,7 @@ func (c *cpClientImpl) CreateEnvironment(ctx context.Context, orgID string, name
 	}
 
 	envId := GetEnvironmentID(templateUUID)
-	env, httpResp, err := client.OwnerAPI.CreateEnvironment(ctx, OwnerKey(orgID)).EnvironmentDTO(caliri.EnvironmentDTO{Id: &envId, Name: &name, ContentPrefix: &prefix}).Execute()
+	env, httpResp, err := client.OwnerAPI.CreateEnvironment(ctx, OwnerKey(orgID)).EnvironmentDTO(caliri.EnvironmentDTO{Id: &envId, Name: &name, ContentPrefix: &prefix, Type: pointy.Pointer(ENVIRONMENT_TYPE)}).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -63,6 +65,9 @@ func (c *cpClientImpl) FetchEnvironment(ctx context.Context, templateID string) 
 		defer httpResp.Body.Close()
 	}
 	if err != nil {
+		if httpResp.StatusCode == 404 {
+			return nil, nil
+		}
 		return nil, errorWithResponseBody("couldn't fetch environment", httpResp, err)
 	}
 	return resp, nil

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -444,7 +444,7 @@ func (t *UpdateTemplateContent) RunCandlepin() error {
 
 func (t *UpdateTemplateContent) fetchOrCreateEnvironment(prefix string) (*caliri.EnvironmentDTO, error) {
 	env, err := t.cpClient.FetchEnvironment(t.ctx, t.payload.TemplateUUID)
-	if err != nil && !strings.Contains(err.Error(), "couldn't fetch environment: 404:") {
+	if err != nil {
 		return nil, err
 	}
 	if env != nil {

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -255,9 +255,9 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.NoError(s.T(), err)
 
 	// Verify environment has been deleted
-	_, err = s.cpClient.FetchEnvironment(ctx, environmentID)
-	assert.Error(s.T(), err)
-	assert.Contains(s.T(), err.Error(), "404")
+	env, err := s.cpClient.FetchEnvironment(ctx, environmentID)
+	assert.Nil(s.T(), err)
+	assert.Nil(s.T(), env)
 
 	// Verify template has been deleted
 	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID)


### PR DESCRIPTION
## Summary

Within the stage the 404 error is not the same as in dev,  `couldn't fetch environment: 404 Not Found:`  instead of `couldn't fetch environment: 404:`   So instead we should just check the response code.  

Also we should be setting an environment type, which can be an arbitrary string, set here to 'content-template'.

## Testing steps

Create a content template as normal, verify no errors

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
