### PR TITLE
Fixes 4312: support use_latest in update_template_content

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -153,6 +153,11 @@ jobs:
           CLIENTS_PULP_SERVER: http://localhost:8080
           CLIENTS_PULP_USERNAME: admin
           CLIENTS_PULP_PASSWORD: password
+          CLIENTS_PULP_DATABASE_HOST: localhost
+          CLIENTS_PULP_DATABASE_PORT: 5432
+          CLIENTS_PULP_DATABASE_USER: pulp
+          CLIENTS_PULP_DATABASE_PASSWORD: password
+          CLIENTS_PULP_DATABASE_NAME: pulp
           CLIENTS_CANDLEPIN_SERVER: http://localhost:8181/candlepin
           CLIENTS_CANDLEPIN_USERNAME: admin
           CLIENTS_CANDLEPIN_PASSWORD: admin

--- a/pkg/config/tang.go
+++ b/pkg/config/tang.go
@@ -8,7 +8,6 @@ import (
 var Tang *tangy.Tangy
 
 func ConfigureTang() error {
-	log.Info().Msgf("LOGHERE: pulp server: %v, snapshots: %v", Get().Clients.Pulp.Server, Get().Features.Snapshots.Enabled)
 	if Get().Clients.Pulp.Server == "" || !Get().Features.Snapshots.Enabled {
 		return nil
 	}
@@ -28,12 +27,12 @@ func ConfigureTang() error {
 		LogLevel: Get().Logging.Level,
 		Enabled:  true,
 	}
+
 	t, err := tangy.New(tDb, tLogger)
-	log.Info().Msgf("LOGHERE: new tang: %v", t)
 	if err != nil {
 		return err
 	}
+
 	Tang = &t
-	log.Info().Msgf("LOGHERE: tang: %v", Tang)
 	return nil
 }

--- a/pkg/config/tang.go
+++ b/pkg/config/tang.go
@@ -8,6 +8,7 @@ import (
 var Tang *tangy.Tangy
 
 func ConfigureTang() error {
+	log.Info().Msgf("LOGHERE: pulp server: %v, snapshots: %v", Get().Clients.Pulp.Server, Get().Features.Snapshots.Enabled)
 	if Get().Clients.Pulp.Server == "" || !Get().Features.Snapshots.Enabled {
 		return nil
 	}
@@ -28,9 +29,11 @@ func ConfigureTang() error {
 		Enabled:  true,
 	}
 	t, err := tangy.New(tDb, tLogger)
+	log.Info().Msgf("LOGHERE: new tang: %v", t)
 	if err != nil {
 		return err
 	}
 	Tang = &t
+	log.Info().Msgf("LOGHERE: tang: %v", Tang)
 	return nil
 }

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -723,7 +724,14 @@ func (r *rpmDaoImpl) fetchSnapshotsForTemplate(ctx context.Context, orgId string
 		repoUuids = append(repoUuids, repoConfig.UUID)
 	}
 
-	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: api.Date(template.Date)})
+	var templateDate time.Time
+	if template.UseLatest {
+		templateDate = time.Now()
+	} else {
+		templateDate = template.Date
+	}
+
+	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: api.Date(templateDate)})
 	if err != nil {
 		return []models.Snapshot{}, err
 	}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	caliri "github.com/content-services/caliri/release/v4"
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -104,7 +105,14 @@ func (t *UpdateTemplateContent) RunPulp() error {
 		return err
 	}
 
-	l := api.ListSnapshotByDateRequest{Date: api.Date(template.Date), RepositoryUUIDS: allRepos}
+	var templateDate time.Time
+	if template.UseLatest {
+		templateDate = time.Now()
+	} else {
+		templateDate = template.Date
+	}
+
+	l := api.ListSnapshotByDateRequest{Date: api.Date(templateDate), RepositoryUUIDS: allRepos}
 	snapshots, err := t.daoReg.Snapshot.FetchSnapshotsModelByDateAndRepository(t.ctx, t.orgId, l)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
After template creation, supports fetching the latest snapshot for each of the repositories in the template, if the use_latest parameter is set.

## Testing steps
1. Create a repository with multiple snapshots by changing the URL after creating the first snapshot
2. Add that repository to a template (should work on create and update for the template)
3. If you navigate to where the distribution servers the content, should be `pulp.content:8080/pulp/content/<domain>/templates/<template_uuid>` locally, you should see only the content for the most recent snapshot.
4. A call to `GET templates/:uuid/rpms` should return only the content of the most recent snapshot

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
