### PR TITLE
Fixes 4423: handle 404 on delete template

### DIFF
--- a/pkg/candlepin_client/environment.go
+++ b/pkg/candlepin_client/environment.go
@@ -198,6 +198,9 @@ func (c *cpClientImpl) DeleteEnvironment(ctx context.Context, templateUUID strin
 		defer httpResp.Body.Close()
 	}
 	if err != nil {
+		if httpResp.StatusCode == 404 {
+			return nil
+		}
 		return errorWithResponseBody("couldn't delete environment", httpResp, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Ignores 404s when trying to delete an environment in candlepin

## Testing steps

- Start the app with candlepin disabled (set the candlepin.server to blank in config.yaml) and create a template
- Restart the app with candlepin enabled and delete the template. You shouldn't see any errors in the logs
- Without this PR you would see `couldn't delete environment: 404 Not Found`
- This [PR](https://github.com/content-services/content-sources-backend/pull/745) resolved the issue we were seeing on fetching environments when removing a repo from a template

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
