### PR TITLE
Fixes 4415: handle non-UTF8 characters for repository validate

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -1054,7 +1054,7 @@ func (r repositoryConfigDaoImpl) validateName(ctx context.Context, orgId string,
 	}
 	if err := query.Find(&found).Error; err != nil {
 		response.Valid = false
-		return err
+		return DBErrorToApi(err)
 	}
 
 	if found.UUID != "" {
@@ -1086,7 +1086,7 @@ func (r repositoryConfigDaoImpl) validateUrl(ctx context.Context, orgId string, 
 
 	if err := query.Find(&found).Error; err != nil {
 		response.URL.Valid = false
-		return err
+		return DBErrorToApi(err)
 	}
 
 	if found.UUID != "" {


### PR DESCRIPTION
## Summary
Returns 400 instead of 500 (for name and URL) when sending non-UTF8 characters in repository validate request

## Testing steps
1. POST `/api/content-sources/v1/repository_parameters/validate/`

with body:
  [
     {       "url": "\u0000/"   }
  ]

2. Do the same for name
3. Previously, this would return a 500 error. Now it should return a 400.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
