### PR TITLE
Fixes 4468: listing snapshot errata does not include CVEs

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -643,8 +643,12 @@ func (r *rpmDaoImpl) ListSnapshotErrata(ctx context.Context, orgId string, snaps
 
 	for _, pkg := range pkgs {
 		updatedDate := ""
+		CVEs := []string{}
 		if pkg.UpdatedDate != nil {
 			updatedDate = *pkg.UpdatedDate
+		}
+		if pkg.CVEs != nil {
+			CVEs = pkg.CVEs
 		}
 		response = append(response, api.SnapshotErrata{
 			Id:              pkg.Id,
@@ -657,6 +661,7 @@ func (r *rpmDaoImpl) ListSnapshotErrata(ctx context.Context, orgId string, snaps
 			Type:            pkg.Type,
 			Severity:        pkg.Severity,
 			RebootSuggested: pkg.RebootSuggested,
+			CVEs:            CVEs,
 		})
 	}
 

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -997,11 +997,13 @@ func (s *RpmSuite) TestListRpmsAndErrataForSnapshots() {
 			ErrataId: "Foodidly",
 			Summary:  "there was a great foo",
 			Type:     "bugfix",
+			CVEs:     []string{},
 		},
 		{
 			ErrataId: "Foodidly2",
 			Summary:  "there was another great foo",
 			Type:     "security",
+			CVEs:     []string{},
 		},
 	}
 
@@ -1017,11 +1019,13 @@ func (s *RpmSuite) TestListRpmsAndErrataForSnapshots() {
 			ErrataId: expectedErrataItem[0].ErrataId,
 			Summary:  expectedErrataItem[0].Summary,
 			Type:     expectedErrataItem[0].Type,
+			CVEs:     expectedErrataItem[0].CVEs,
 		},
 		{
 			ErrataId: expectedErrataItem[1].ErrataId,
 			Summary:  expectedErrataItem[1].Summary,
 			Type:     expectedErrataItem[1].Type,
+			CVEs:     expectedErrataItem[1].CVEs,
 		},
 	}, resp)
 }


### PR DESCRIPTION
## Summary

This adds CVEs to the response when listing snapshot errata.

## Testing steps

- Add 2 repos with and without CVEs and let them snapshot (the small RH repo https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/ has CVEs)
- Make a request to list the snapshot errata (`GET /snapshots/:uuid/errata`). You should see the CVEs listed in the response for the one with CVEs and an empty array for the CVEs for the one without
- Without this PR you would see `"cves": null`

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
