### PR TITLE
Fixes 4446: improve task context canceled logging

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -61,12 +61,12 @@ func main() {
 
 	// Setup cancellation context
 	var wg sync.WaitGroup
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancelCause(context.Background())
 	go func() {
 		exit := make(chan os.Signal, 1)
 		signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 		<-exit
-		cancel()
+		cancel(ce.ErrServerExited)
 	}()
 
 	// If we're not running an api server, still listen for ping requests for liveliness probes

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -498,7 +498,9 @@ func (r repositoryConfigDaoImpl) InternalOnly_FetchRepoConfigsForRepoUUID(ctx co
 
 	filteredDB.Preload("Repository").Preload("LastSnapshot").Preload("LastSnapshotTask").Find(&repoConfigs)
 	if filteredDB.Error != nil {
-		log.Error().Err(filteredDB.Error).Msgf("error fetching repoConfigs for repo")
+		if !errors.Is(filteredDB.Error, context.Canceled) {
+			log.Error().Err(filteredDB.Error).Msgf("error fetching repoConfigs for repo")
+		}
 		return []api.RepositoryResponse{}
 	}
 

--- a/pkg/tasks/introspect.go
+++ b/pkg/tasks/introspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -793,9 +793,10 @@ func (p *PgQueue) RemoveAllTasks() error {
 func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelCauseFunc) {
 	logger := zerolog.Ctx(ctx)
 	conn, err := p.Pool.Acquire(ctx)
+
 	if err != nil {
-		// If the task is finished before listen is initiated, a context canceled error is expected
-		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
+		// If the task is finished before listen is initiated, or server is exited, a context canceled error is expected
+		if !isContextCancelled(ctx) {
 			logger.Error().Err(err).Msg("ListenForCancel: error acquiring connection")
 		}
 		return
@@ -806,7 +807,7 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 	channelName := getCancelChannelName(taskID)
 	_, err = conn.Conn().Exec(ctx, "listen "+channelName)
 	if err != nil {
-		if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
+		if !isContextCancelled(ctx) {
 			logger.Error().Err(err).Msg("ListenForCancel: error registering channel")
 		}
 		return
@@ -823,18 +824,21 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 	// Wait for a notification on the channel. This blocks until the channel receives a notification.
 	_, err = conn.Conn().WaitForNotification(ctx)
 	if err != nil {
-		log.Error().Msgf("cause: %v", context.Cause(ctx))
-		if !errors.Is(ErrNotRunning, context.Cause(ctx)) && !errors.Is(ce.ErrServerExited, context.Cause(ctx)) {
+		if !isContextCancelled(ctx) {
 			logger.Error().Err(err).Msg("ListenForCancel: error waiting for notification")
 		}
 		return
 	}
 
 	// Cancel context only if context has not already been canceled. If the context has already been canceled, the task has finished.
-	if !errors.Is(ctx.Err(), context.Canceled) {
+	if !errors.Is(ErrNotRunning, context.Cause(ctx)) {
 		logger.Debug().Msg("[Canceled Task]")
 		cancelFunc(ErrTaskCanceled)
 	}
+}
+
+func isContextCancelled(ctx context.Context) bool {
+	return errors.Is(ErrNotRunning, context.Cause(ctx)) || errors.Is(ce.ErrServerExited, context.Cause(ctx))
 }
 
 func getCancelChannelName(taskID uuid.UUID) string {


### PR DESCRIPTION
## Summary
We are seeing what's likely expected error logs from tasks that are cancelled. We want to avoid logging these errors because they are expected when a task is cancelled and can be ignored.

## Testing steps
1. `make repos-import`
2. `go run cmd/external-repos/main.go nightly-jobs`. Turn off snapshotting to save time.
3. Keep exiting the server with CTRL+C and restarting it
4. You shouldn't see error logs, expect maybe `error requeuing task with task_id: 00000000-0000-0000-0000-000000000000`. Ignore that one.

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
