### PR TITLE
Fixes 4416: listing tasks returns 500 for bad repo uuid

### DIFF
--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -91,7 +91,7 @@ func (t taskInfoDaoImpl) List(
 	}
 
 	if filterData.RepoConfigUUID != "" {
-		filteredDB = filteredDB.Where("rc.uuid = ?", filterData.RepoConfigUUID)
+		filteredDB = filteredDB.Where("rc.uuid = ?", UuidifyString(filterData.RepoConfigUUID))
 	}
 
 	// First get count


### PR DESCRIPTION
## Summary

Fixes 500 error on invalid repo uuids when listing tasks

## Testing steps

- List tasks filtered by an invalid repository uuid (for devs: `/tasks/?repository_uuid=repository_uuid`, for QE: `app.content_sources.rest_client.tasks_api.list_tasks(repository_uuid="repository_uuid")`)
- Should return 200 and an empty list

## Checklist

- [ ] Tested with snapshotting feature disabled and pulp server URL not configured if appropriate
