### PR TITLE
Fixes 4539: fix indentation in example yaml config

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -61,10 +61,10 @@ options:
   introspect_api_time_limit_sec: 0
   enable_notifications: true
   template_event_topic: "platform.content-sources.template"
- metrics:
-   path: "/metrics"
-   port: 9000
-   collection_frequency: 60
+metrics:
+  path: "/metrics"
+  port: 9000
+  collection_frequency: 60
 
 # sentry:
 #   dsn: https://public@sentry.example.com/1


### PR DESCRIPTION
## Summary
There is a wrong indentation in the `configs/config.yaml.example` file which when copied to remove `.example` extension doesn't work and causes `make compose-up` fail. 

## Testing steps
Fixed indentation and it works now after copying the file.
