### PR TITLE
Fixes 4422: edited repo returns incorrect snapshot task

### DIFF
--- a/pkg/dao/environments.go
+++ b/pkg/dao/environments.go
@@ -189,6 +189,7 @@ func (r environmentDaoImpl) Search(ctx context.Context, orgID string, request ap
 		Where("environments.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
 		Where(r.db.Where("repositories.url in ?", urls).
 			Or("repository_configurations.uuid in ?", UuidifyStrings(uuids))).
+		Where("repository_configurations.deleted_at IS NULL").
 		Order("environments.name ASC").
 		Limit(*request.Limit).
 		Scan(&dataResponse)

--- a/pkg/dao/package_groups.go
+++ b/pkg/dao/package_groups.go
@@ -189,6 +189,7 @@ func (r packageGroupDaoImpl) Search(ctx context.Context, orgID string, request a
 					(repository_configurations.org_id = ? OR repositories.public)
 					AND package_groups.name ILIKE ?
 					AND (repositories.url IN ? OR repository_configurations.uuid IN ?)
+					AND repository_configurations.deleted_at IS NULL
 			GROUP BY
 					package_groups.name, package_groups.id, package_groups.description
 			ORDER BY

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -573,6 +573,7 @@ func (r *rpmDaoImpl) DetectRpms(ctx context.Context, orgID string, request api.D
 		Where("rpms.name IN ?", request.RpmNames).
 		Where(r.db.Where("repositories.url IN ?", urls).
 			Or("repository_configurations.uuid IN ?", UuidifyStrings(uuids))).
+		Where("repository_configurations.deleted_at is NULL").
 		Order("rpms.name").
 		Limit(*request.Limit).
 		Scan(&foundRpmsModel)

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -46,7 +46,7 @@ func (t taskInfoDaoImpl) Fetch(ctx context.Context, orgID string, id string) (ap
 	result := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid AND rc.org_id = ?", orgID).
-		Where("t.id = ? AND t.org_id in (?)", UuidifyString(id), []string{config.RedHatOrg, orgID}).First(&taskInfo)
+		Where("t.id = ? AND t.org_id in (?) AND rc.deleted_at is NULL", UuidifyString(id), []string{config.RedHatOrg, orgID}).First(&taskInfo)
 
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
@@ -80,7 +80,7 @@ func (t taskInfoDaoImpl) List(
 	filteredDB := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.repository_uuid = rc.repository_uuid  AND rc.org_id in (?)", []string{config.RedHatOrg, orgID}).
-		Where("t.org_id in (?)", orgsForQuery)
+		Where("t.org_id in (?) AND rc.deleted_at is NULL", orgsForQuery)
 
 	if filterData.Status != "" {
 		filteredDB = filteredDB.Where("t.status = ?", filterData.Status)


### PR DESCRIPTION
## Summary

- Adds a clause to a few queries to check only repo configs that have not been soft-deleted

## Testing steps

- Add a repository, let it snapshot, and grab the snapshot task uuid
- Restart the app with pulp disabled to force the delete-repository-snapshots task to fail
- Delete the repository
- Fetch the task associated with that repository, you should get a 404
- Listing tasks filtered on that repository uuid should return an empty list
- Searching environments, package groups, and rpms should work as before
- For QE, this should fix the issue that caused `test_repo_snapshot_functions` to fail, so we should make sure this test passes