### PR TITLE
Refs 4540: check for soft deleted template on update

### DIFF
--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/utils"
+	"gorm.io/gorm"
 )
 
 type TemplateRequest struct {
@@ -21,20 +22,21 @@ type TemplateRequest struct {
 }
 
 type TemplateResponse struct {
-	UUID              string    `json:"uuid" readonly:"true"`
-	Name              string    `json:"name"`                // Name of the template
-	OrgID             string    `json:"org_id"`              // Organization ID of the owner
-	Description       string    `json:"description"`         // Description of the template
-	Arch              string    `json:"arch"`                // Architecture of the template
-	Version           string    `json:"version"`             // Version of the template
-	Date              time.Time `json:"date"`                // Latest date to include snapshots for
-	RepositoryUUIDS   []string  `json:"repository_uuids"`    // Repositories added to the template
-	RHSMEnvironmentID string    `json:"rhsm_environment_id"` // Environment ID used by subscription-manager and candlepin
-	CreatedBy         string    `json:"created_by"`          // User that created the template
-	LastUpdatedBy     string    `json:"last_updated_by"`     // User that most recently updated the template
-	CreatedAt         time.Time `json:"created_at"`          // Datetime template was created
-	UpdatedAt         time.Time `json:"updated_at"`          // Datetime template was last updated
-	UseLatest         bool      `json:"use_latest"`          // Use latest snapshot for all repositories in the template
+	UUID              string         `json:"uuid" readonly:"true"`
+	Name              string         `json:"name"`                            // Name of the template
+	OrgID             string         `json:"org_id"`                          // Organization ID of the owner
+	Description       string         `json:"description"`                     // Description of the template
+	Arch              string         `json:"arch"`                            // Architecture of the template
+	Version           string         `json:"version"`                         // Version of the template
+	Date              time.Time      `json:"date"`                            // Latest date to include snapshots for
+	RepositoryUUIDS   []string       `json:"repository_uuids"`                // Repositories added to the template
+	RHSMEnvironmentID string         `json:"rhsm_environment_id"`             // Environment ID used by subscription-manager and candlepin
+	CreatedBy         string         `json:"created_by"`                      // User that created the template
+	LastUpdatedBy     string         `json:"last_updated_by"`                 // User that most recently updated the template
+	CreatedAt         time.Time      `json:"created_at"`                      // Datetime template was created
+	UpdatedAt         time.Time      `json:"updated_at"`                      // Datetime template was last updated
+	DeletedAt         gorm.DeletedAt `json:"deleted_at" swaggerignore:"true"` // Datetime template was deleted
+	UseLatest         bool           `json:"use_latest"`                      // Use latest snapshot for all repositories in the template
 }
 
 // We use a separate struct because version and arch cannot be updated

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -23,20 +23,20 @@ type TemplateRequest struct {
 
 type TemplateResponse struct {
 	UUID              string         `json:"uuid" readonly:"true"`
-	Name              string         `json:"name"`                            // Name of the template
-	OrgID             string         `json:"org_id"`                          // Organization ID of the owner
-	Description       string         `json:"description"`                     // Description of the template
-	Arch              string         `json:"arch"`                            // Architecture of the template
-	Version           string         `json:"version"`                         // Version of the template
-	Date              time.Time      `json:"date"`                            // Latest date to include snapshots for
-	RepositoryUUIDS   []string       `json:"repository_uuids"`                // Repositories added to the template
-	RHSMEnvironmentID string         `json:"rhsm_environment_id"`             // Environment ID used by subscription-manager and candlepin
-	CreatedBy         string         `json:"created_by"`                      // User that created the template
-	LastUpdatedBy     string         `json:"last_updated_by"`                 // User that most recently updated the template
-	CreatedAt         time.Time      `json:"created_at"`                      // Datetime template was created
-	UpdatedAt         time.Time      `json:"updated_at"`                      // Datetime template was last updated
-	DeletedAt         gorm.DeletedAt `json:"deleted_at" swaggerignore:"true"` // Datetime template was deleted
-	UseLatest         bool           `json:"use_latest"`                      // Use latest snapshot for all repositories in the template
+	Name              string         `json:"name"`                   // Name of the template
+	OrgID             string         `json:"org_id"`                 // Organization ID of the owner
+	Description       string         `json:"description"`            // Description of the template
+	Arch              string         `json:"arch"`                   // Architecture of the template
+	Version           string         `json:"version"`                // Version of the template
+	Date              time.Time      `json:"date"`                   // Latest date to include snapshots for
+	RepositoryUUIDS   []string       `json:"repository_uuids"`       // Repositories added to the template
+	RHSMEnvironmentID string         `json:"rhsm_environment_id"`    // Environment ID used by subscription-manager and candlepin
+	CreatedBy         string         `json:"created_by"`             // User that created the template
+	LastUpdatedBy     string         `json:"last_updated_by"`        // User that most recently updated the template
+	CreatedAt         time.Time      `json:"created_at"`             // Datetime template was created
+	UpdatedAt         time.Time      `json:"updated_at"`             // Datetime template was last updated
+	DeletedAt         gorm.DeletedAt `json:"-" swaggerignore:"true"` // Datetime template was deleted
+	UseLatest         bool           `json:"use_latest"`             // Use latest snapshot for all repositories in the template
 }
 
 // We use a separate struct because version and arch cannot be updated

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -174,7 +174,7 @@ type EnvironmentDao interface {
 //go:generate $GO_OUTPUT/mockery --name TemplateDao --filename templates_mock.go --inpackage
 type TemplateDao interface {
 	Create(ctx context.Context, templateRequest api.TemplateRequest) (api.TemplateResponse, error)
-	Fetch(ctx context.Context, orgID string, uuid string) (api.TemplateResponse, error)
+	Fetch(ctx context.Context, orgID string, uuid string, includeSoftDel bool) (api.TemplateResponse, error)
 	InternalOnlyFetchByName(ctx context.Context, name string) (models.Template, error)
 	List(ctx context.Context, orgID string, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error)
 	SoftDelete(ctx context.Context, orgID string, uuid string) error

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -496,6 +496,7 @@ func templatesModelToApi(model models.Template, api *api.TemplateResponse) {
 	api.CreatedAt = model.CreatedAt
 	api.UpdatedAt = model.UpdatedAt
 	api.UseLatest = model.UseLatest
+	api.DeletedAt = model.DeletedAt
 }
 
 func templatesConvertToResponses(templates []models.Template) []api.TemplateResponse {

--- a/pkg/dao/templates_mock.go
+++ b/pkg/dao/templates_mock.go
@@ -99,9 +99,9 @@ func (_m *MockTemplateDao) DeleteTemplateRepoConfigs(ctx context.Context, templa
 	return r0
 }
 
-// Fetch provides a mock function with given fields: ctx, orgID, uuid
-func (_m *MockTemplateDao) Fetch(ctx context.Context, orgID string, uuid string) (api.TemplateResponse, error) {
-	ret := _m.Called(ctx, orgID, uuid)
+// Fetch provides a mock function with given fields: ctx, orgID, uuid, includeSoftDel
+func (_m *MockTemplateDao) Fetch(ctx context.Context, orgID string, uuid string, includeSoftDel bool) (api.TemplateResponse, error) {
+	ret := _m.Called(ctx, orgID, uuid, includeSoftDel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Fetch")
@@ -109,17 +109,17 @@ func (_m *MockTemplateDao) Fetch(ctx context.Context, orgID string, uuid string)
 
 	var r0 api.TemplateResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (api.TemplateResponse, error)); ok {
-		return rf(ctx, orgID, uuid)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) (api.TemplateResponse, error)); ok {
+		return rf(ctx, orgID, uuid, includeSoftDel)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) api.TemplateResponse); ok {
-		r0 = rf(ctx, orgID, uuid)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) api.TemplateResponse); ok {
+		r0 = rf(ctx, orgID, uuid, includeSoftDel)
 	} else {
 		r0 = ret.Get(0).(api.TemplateResponse)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, orgID, uuid)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
+		r1 = rf(ctx, orgID, uuid, includeSoftDel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -107,7 +107,7 @@ func (th *TemplateHandler) fetch(c echo.Context) error {
 	_, orgID := getAccountIdOrgId(c)
 	uuid := c.Param("uuid")
 
-	resp, err := th.DaoRegistry.Template.Fetch(c.Request().Context(), orgID, uuid)
+	resp, err := th.DaoRegistry.Template.Fetch(c.Request().Context(), orgID, uuid, false)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching template", err.Error())
 	}
@@ -263,7 +263,7 @@ func (th *TemplateHandler) deleteTemplate(c echo.Context) error {
 	_, orgID := getAccountIdOrgId(c)
 	uuid := c.Param("uuid")
 
-	template, err := th.DaoRegistry.Template.Fetch(c.Request().Context(), orgID, uuid)
+	template, err := th.DaoRegistry.Template.Fetch(c.Request().Context(), orgID, uuid, false)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching template", err.Error())
 	}

--- a/pkg/handler/templates_test.go
+++ b/pkg/handler/templates_test.go
@@ -124,7 +124,7 @@ func (suite *TemplatesSuite) TestFetch() {
 		Date:        time.Time{},
 	}
 
-	suite.reg.Template.On("Fetch", test.MockCtx(), orgID, uuid).Return(expected, nil)
+	suite.reg.Template.On("Fetch", test.MockCtx(), orgID, uuid, false).Return(expected, nil)
 
 	body, err := json.Marshal(expected)
 	require.NoError(suite.T(), err)
@@ -162,7 +162,7 @@ func (suite *TemplatesSuite) TestFetchNotFound() {
 		Message:  "Not found",
 	}
 
-	suite.reg.Template.On("Fetch", test.MockCtx(), orgID, uuid).Return(api.TemplateResponse{}, &daoError)
+	suite.reg.Template.On("Fetch", test.MockCtx(), orgID, uuid, false).Return(api.TemplateResponse{}, &daoError)
 
 	body, err := json.Marshal(template)
 	require.NoError(suite.T(), err)
@@ -353,7 +353,7 @@ func (suite *TemplatesSuite) TestDelete() {
 		Date:        time.Time{},
 	}
 
-	suite.reg.Template.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(expected, nil)
+	suite.reg.Template.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid, false).Return(expected, nil)
 
 	_, err := json.Marshal(expected)
 	require.NoError(suite.T(), err)

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -26,12 +26,12 @@ import (
 )
 
 func lookupTemplate(ctx context.Context, daoReg *dao.DaoRegistry, orgId string, templateUUID string) (*api.TemplateResponse, error) {
-	template, err := daoReg.Template.Fetch(ctx, orgId, templateUUID, false)
+	template, err := daoReg.Template.Fetch(ctx, orgId, templateUUID, true)
 	if err != nil {
-		// If we got an error fetching the template, it could have just been soft deleted, if so try to fetch it
-		//  if that errors, return that error, otherwise return nil
-		_, err := daoReg.Template.Fetch(ctx, orgId, templateUUID, true)
 		return nil, err
+	}
+	if template.DeletedAt.Valid {
+		return nil, nil
 	}
 	return &template, nil
 }

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -491,7 +491,7 @@ func (t *UpdateTemplateContent) fetchOrCreateEnvironment(prefix string) (*caliri
 }
 
 func (t *UpdateTemplateContent) renameEnvironmentIfNeeded(env *caliri.EnvironmentDTO) (*caliri.EnvironmentDTO, error) {
-	template, err := t.daoReg.Template.Fetch(t.ctx, t.orgId, t.payload.TemplateUUID)
+	template, err := t.daoReg.Template.Fetch(t.ctx, t.orgId, t.payload.TemplateUUID, false)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -292,7 +292,8 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.Equal(s.T(), *updateReq.Name, tempResp.Name)
 	assert.Equal(s.T(), tempResp.Name, environment.GetName())
 
-	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID)
+	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID, false)
+
 	assert.NoError(s.T(), err)
 	s.deleteTemplateAndWait(orgID, tempResp)
 
@@ -306,7 +307,7 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.Nil(s.T(), env)
 
 	// Verify template has been deleted
-	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID)
+	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID, false)
 	assert.Error(s.T(), err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)


### PR DESCRIPTION
## Summary
On the template update task, check to see if the template has been softdeleted, and simple return from the task if so

## Testing steps

With your server running
Create a repo with snapshotting

Run the server with just the api:
`go run ./cmd/content-sources/main.go api`

Create a template with the repo:
```
####
POST http://localhost:8000/api/content-sources/v1.0/templates/
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
Content-Type: application/json

{
  "name":"test5",
  "arch": "x86_64",
  "version": "9",
  "repository_uuids": ["cd79da0f-dea2-46d4-82c4-56d3012db8bb"],
  "date": "2024-08-09T14:04:05Z"
}
```

delete the repo:
```
####
DELETE http://localhost:8000/api/content-sources/v1.0/templates/08273910-70b5-45e0-99a6-57706f61efe5
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
Content-Type: application/json
```

Now stop the server and restart it with the worker:
`go run ./cmd/content-sources/main.go api consumer`

This will cause the update and delete task to run at the same time.  Monitor the server logs and look for `Could not find template with UUID d95ee14e-00a1-40fa-be8f-27edfb5e043e`, you shouldn't see it.

