### PR TITLE
Fixes 4290: update candlepin env name after template rename

### DIFF
--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	caliri "github.com/content-services/caliri/release/v4"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -506,6 +505,36 @@ func (_m *MockCandlepinClient) RemoveContentOverrides(ctx context.Context, templ
 	}
 
 	return r0
+}
+
+// RenameEnvironment provides a mock function with given fields: ctx, templateUUID, name
+func (_m *MockCandlepinClient) RenameEnvironment(ctx context.Context, templateUUID string, name string) (*caliri.EnvironmentDTO, error) {
+	ret := _m.Called(ctx, templateUUID, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RenameEnvironment")
+	}
+
+	var r0 *caliri.EnvironmentDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*caliri.EnvironmentDTO, error)); ok {
+		return rf(ctx, templateUUID, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *caliri.EnvironmentDTO); ok {
+		r0 = rf(ctx, templateUUID, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*caliri.EnvironmentDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, templateUUID, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpdateContent provides a mock function with given fields: ctx, orgID, repoConfigUUID, content

--- a/pkg/candlepin_client/environment.go
+++ b/pkg/candlepin_client/environment.go
@@ -205,3 +205,24 @@ func (c *cpClientImpl) DeleteEnvironment(ctx context.Context, templateUUID strin
 	}
 	return nil
 }
+
+func (c *cpClientImpl) RenameEnvironment(ctx context.Context, templateUUID, name string) (*caliri.EnvironmentDTO, error) {
+	ctx, client, err := getCandlepinClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	envDto := caliri.EnvironmentDTO{Name: &name}
+	env, httpResp, err := client.EnvironmentAPI.
+		UpdateEnvironment(ctx, GetEnvironmentID(templateUUID)).
+		EnvironmentDTO(envDto).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return nil, errorWithResponseBody("couldn't update environment", httpResp, err)
+	}
+
+	return env, nil
+}

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -39,4 +39,5 @@ type CandlepinClient interface {
 	FetchContentOverridesForRepo(ctx context.Context, templateUUID string, label string) ([]caliri.ContentOverrideDTO, error)
 	RemoveContentOverrides(ctx context.Context, templateUUID string, toRemove []caliri.ContentOverrideDTO) error
 	DeleteEnvironment(ctx context.Context, templateUUID string) error
+	RenameEnvironment(ctx context.Context, templateUUID, name string) (*caliri.EnvironmentDTO, error)
 }

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -300,6 +300,23 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 
 	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride})
 
+	// Rename template
+	updateReq = api.TemplateUpdateRequest{
+		Name: utils.Ptr(fmt.Sprintf("updated %s", *reqTemplate.Name)),
+	}
+	tempResp, err = s.dao.Template.Update(ctx, orgID, tempResp.UUID, updateReq)
+	assert.NoError(s.T(), err)
+
+	// Update template so that the environment name also changes
+	s.updateTemplateContentAndWait(orgID, tempResp.UUID, []string{repo1.UUID})
+
+	// Verify renaming of the environment
+	environment, err = s.cpClient.FetchEnvironment(ctx, environmentID)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), environmentID, environment.GetId())
+	assert.Equal(s.T(), *updateReq.Name, tempResp.Name)
+	assert.Equal(s.T(), tempResp.Name, environment.GetName())
+
 	tempResp, err = s.dao.Template.Fetch(ctx, orgID, tempResp.UUID)
 	assert.NoError(s.T(), err)
 	s.deleteTemplateAndWait(orgID, tempResp)


### PR DESCRIPTION
## Summary
When template name is updated, the associated environment name in Candlepin isn't being updated. This PR fixes that.
Added a new `RenameEnvironment()` method to our Candlepin client. This method is called from the `update_template_content` task, which is started after updating the template, when the names are different.

## Testing steps
_Change integration test passes._
_Manual test:_
#### 1. Create a new template:
```sh
http :8000/api/content-sources/v1.0/templates/ "$( ./scripts/header.sh acme 1111)" arch='x86_64' version='8' repository_uuids:='[]' description='testing rename' name='test' use_latest:=true
```

#### 2. Verify the template and the environment with the same name exist:
```sh
http :8000/api/content-sources/v1.0/templates/{_New template ID_} "$( ./scripts/header.sh acme 1111)"
http -a admin:admin :8181/candlepin/environments/{_New template ID without hyphens_}
```

#### 3. Update the name of the template:
```sh
http PATCH :8000/api/content-sources/v1.0/templates/{_New template ID_}  "$( ./scripts/header.sh acme 1111)" name='renamed'
```

#### 4. Verify the name has changed both in the template and the associated environment:
```sh
http :8000/api/content-sources/v1.0/templates/{_New template ID_} "$( ./scripts/header.sh acme 1111)"
http -a admin:admin :8181/candlepin/environments/{_New template ID without hyphens_}
```