### PR TITLE
Fixes 4478: support cancel pending tasks

### DIFF
--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	caliri "github.com/content-services/caliri/release/v4"
+
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -137,7 +137,7 @@ type MetricsDao interface {
 type TaskInfoDao interface {
 	Fetch(ctx context.Context, OrgID string, id string) (api.TaskInfoResponse, error)
 	List(ctx context.Context, OrgID string, pageData api.PaginationData, filterData api.TaskInfoFilterData) (api.TaskInfoCollectionResponse, int64, error)
-	IsTaskInProgress(ctx context.Context, orgID, repoUUID, taskType string) (bool, string, error)
+	IsTaskInProgressOrPending(ctx context.Context, orgID, repoUUID, taskType string) (bool, string, error)
 	Cleanup(ctx context.Context) error
 }
 

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -143,10 +143,10 @@ func (t taskInfoDaoImpl) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (t taskInfoDaoImpl) IsTaskInProgress(ctx context.Context, orgID, repoUUID, taskType string) (bool, string, error) {
+func (t taskInfoDaoImpl) IsTaskInProgressOrPending(ctx context.Context, orgID, repoUUID, taskType string) (bool, string, error) {
 	taskInfo := models.TaskInfo{}
-	result := t.db.WithContext(ctx).Where("org_id = ? and repository_uuid = ? and status = ? and type = ?",
-		orgID, repoUUID, config.TaskStatusRunning, taskType).First(&taskInfo)
+	result := t.db.WithContext(ctx).Where("org_id = ? and repository_uuid = ? and (status = ? or status = ?) and type = ?",
+		orgID, repoUUID, config.TaskStatusRunning, config.TaskStatusPending, taskType).First(&taskInfo)
 	if result.Error != nil {
 		if result.Error == gorm.ErrRecordNotFound {
 			return false, "", nil
@@ -154,7 +154,7 @@ func (t taskInfoDaoImpl) IsTaskInProgress(ctx context.Context, orgID, repoUUID, 
 			return false, "", result.Error
 		}
 	}
-	if taskInfo.Status == config.TaskStatusRunning {
+	if taskInfo.Status == config.TaskStatusRunning || taskInfo.Status == config.TaskStatusPending {
 		return true, taskInfo.Id.String(), nil
 	}
 	return false, taskInfo.Id.String(), nil

--- a/pkg/dao/task_info_mock.go
+++ b/pkg/dao/task_info_mock.go
@@ -61,12 +61,12 @@ func (_m *MockTaskInfoDao) Fetch(ctx context.Context, OrgID string, id string) (
 	return r0, r1
 }
 
-// IsTaskInProgress provides a mock function with given fields: ctx, orgID, repoUUID, taskType
-func (_m *MockTaskInfoDao) IsTaskInProgress(ctx context.Context, orgID string, repoUUID string, taskType string) (bool, string, error) {
+// IsTaskInProgressOrPending provides a mock function with given fields: ctx, orgID, repoUUID, taskType
+func (_m *MockTaskInfoDao) IsTaskInProgressOrPending(ctx context.Context, orgID string, repoUUID string, taskType string) (bool, string, error) {
 	ret := _m.Called(ctx, orgID, repoUUID, taskType)
 
 	if len(ret) == 0 {
-		panic("no return value specified for IsTaskInProgress")
+		panic("no return value specified for IsTaskInProgressOrPending")
 	}
 
 	var r0 bool

--- a/pkg/dao/task_info_test.go
+++ b/pkg/dao/task_info_test.go
@@ -556,7 +556,7 @@ func (suite *TaskInfoSuite) TestTaskCleanup() {
 	}
 }
 
-func (suite *TaskInfoSuite) TestIsTaskInProgress() {
+func (suite *TaskInfoSuite) TestIsTaskInProgressOrPending() {
 	t := suite.T()
 	dao := GetTaskInfoDao(suite.tx)
 	repoUUID := uuid.New()
@@ -584,31 +584,31 @@ func (suite *TaskInfoSuite) TestIsTaskInProgress() {
 	createErr = suite.tx.Create(notRunningSnap).Error
 	require.NoError(t, createErr)
 
-	val, _, err := dao.IsTaskInProgress(context.Background(), orgID, repoUUID.String(), config.RepositorySnapshotTask)
+	val, _, err := dao.IsTaskInProgressOrPending(context.Background(), orgID, repoUUID.String(), config.RepositorySnapshotTask)
 	assert.NoError(t, err)
 	assert.False(t, val)
 
-	val, id, err := dao.IsTaskInProgress(context.Background(), orgID, repoUUID.String(), config.IntrospectTask)
+	val, id, err := dao.IsTaskInProgressOrPending(context.Background(), orgID, repoUUID.String(), config.IntrospectTask)
 	assert.NoError(t, err)
 	assert.True(t, val)
 	assert.NotEmpty(t, id)
 
-	runningSnap := models.TaskInfo{
+	pendingSnap := models.TaskInfo{
 		Typename:       config.RepositorySnapshotTask,
-		Status:         "running",
+		Status:         "pending",
 		RepositoryUUID: repoUUID,
 		Token:          uuid.New(),
 		Id:             uuid.New(),
 		OrgId:          orgID,
 	}
-	createErr = suite.tx.Create(runningSnap).Error
+	createErr = suite.tx.Create(pendingSnap).Error
 	require.NoError(t, createErr)
 
-	val, _, err = dao.IsTaskInProgress(context.Background(), orgID, repoUUID.String(), config.RepositorySnapshotTask)
+	val, _, err = dao.IsTaskInProgressOrPending(context.Background(), orgID, repoUUID.String(), config.RepositorySnapshotTask)
 	assert.NoError(t, err)
 	assert.True(t, val)
 
-	val, _, err = dao.IsTaskInProgress(context.Background(), "bad org ID", repoUUID.String(), config.RepositorySnapshotTask)
+	val, _, err = dao.IsTaskInProgressOrPending(context.Background(), "bad org ID", repoUUID.String(), config.RepositorySnapshotTask)
 	assert.NoError(t, err)
 	assert.False(t, val)
 }

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -682,8 +682,8 @@ func (suite *ReposSuite) TestDelete() {
 		UUID:           uuid,
 		RepositoryUUID: uuid,
 	}, nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
 	suite.reg.RepositoryConfig.On("SoftDelete", test.MockCtx(), test_handler.MockOrgId, uuid).Return(nil)
 	mockSnapshotDeleteEvent(suite.tcMock, uuid)
 
@@ -709,8 +709,8 @@ func (suite *ReposSuite) TestDeleteNotFound() {
 		UUID:           uuid,
 		RepositoryUUID: uuid,
 	}, nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
 	suite.reg.RepositoryConfig.On("SoftDelete", test.MockCtx(), test_handler.MockOrgId, uuid).Return(&daoError)
 
 	req := httptest.NewRequest(http.MethodDelete, api.FullRootPath()+"/repositories/"+uuid, nil)
@@ -731,9 +731,9 @@ func (suite *ReposSuite) TestSnapshotInProgress() {
 		UUID:           uuid,
 		RepositoryUUID: uuid,
 	}, nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(true, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
-	suite.tcMock.On("SendCancelNotification", test.MockCtx(), "").Return(nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.RepositorySnapshotTask).Return(true, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuid, config.IntrospectTask).Return(false, "", nil)
+	suite.tcMock.On("Cancel", test.MockCtx(), "").Return(nil)
 	suite.reg.RepositoryConfig.On("SoftDelete", test.MockCtx(), test_handler.MockOrgId, uuid).Return(nil)
 	mockSnapshotDeleteEvent(suite.tcMock, uuid)
 
@@ -756,8 +756,8 @@ func (suite *ReposSuite) TestBulkDelete() {
 			UUID:           uuids[i],
 			RepositoryUUID: uuids[i],
 		}, nil)
-		suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[i], config.RepositorySnapshotTask).Return(false, "", nil)
-		suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[i], config.IntrospectTask).Return(false, "", nil)
+		suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[i], config.RepositorySnapshotTask).Return(false, "", nil)
+		suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[i], config.IntrospectTask).Return(false, "", nil)
 		mockSnapshotDeleteEvent(suite.tcMock, uuids[i])
 	}
 
@@ -813,8 +813,8 @@ func (suite *ReposSuite) TestBulkDeleteNotFound() {
 		UUID:           uuids[0],
 		RepositoryUUID: uuids[0],
 	}, nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.RepositorySnapshotTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.RepositorySnapshotTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.IntrospectTask).Return(false, "", nil)
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuids[0]).Return(api.RepositoryResponse{}, nil)
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuids[1]).Return(api.RepositoryResponse{}, &daoError)
 
@@ -849,12 +849,12 @@ func (suite *ReposSuite) TestBulkDeleteSnapshotInProgress() {
 			RepositoryUUID: uuids[i],
 		}, nil)
 	}
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.RepositorySnapshotTask).Return(true, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[1], config.RepositorySnapshotTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.IntrospectTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, uuids[1], config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.RepositorySnapshotTask).Return(true, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[1], config.RepositorySnapshotTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[0], config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, uuids[1], config.IntrospectTask).Return(false, "", nil)
 
-	suite.tcMock.On("SendCancelNotification", test.MockCtx(), "").Return(nil)
+	suite.tcMock.On("Cancel", test.MockCtx(), "").Return(nil)
 	suite.reg.RepositoryConfig.On("BulkDelete", test.MockCtx(), test_handler.MockOrgId, uuids).Return([]error{})
 	mockSnapshotDeleteEvent(suite.tcMock, uuids[0])
 	mockSnapshotDeleteEvent(suite.tcMock, uuids[1])
@@ -947,8 +947,8 @@ func (suite *ReposSuite) TestPartialUpdateUrlChange() {
 
 	suite.reg.RepositoryConfig.WithContextMock().On("Update", test.MockCtx(), test_handler.MockOrgId, repoConfigUuid, expected).Return(true, nil)
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, repoConfigUuid).Return(repoConfig, nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repoUuid, config.RepositorySnapshotTask).Return(false, "", nil)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repoUuid, config.IntrospectTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repoUuid, config.RepositorySnapshotTask).Return(false, "", nil)
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repoUuid, config.IntrospectTask).Return(false, "", nil)
 
 	mockTaskClientEnqueueUpdate(suite, repoConfig)
 	mockTaskClientEnqueueSnapshot(suite, &repoConfig)
@@ -1107,9 +1107,9 @@ func (suite *ReposSuite) TestCreateSnapshot() {
 
 	// Fetch will filter the request by Org ID before updating
 	suite.reg.Repository.On("Update", test.MockCtx(), repoUpdate).Return(nil).NotBefore(
-		suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(false, "", nil).
+		suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(false, "", nil).
 			NotBefore(suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, repoConfigUUID).Return(repoResp, nil)),
-		suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(false, "", nil).
+		suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(false, "", nil).
 			NotBefore(suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, repoConfigUUID).Return(repoResp, nil)),
 	)
 
@@ -1201,10 +1201,10 @@ func (suite *ReposSuite) TestCreateSnapshotError() {
 
 	repo := dao.Repository{UUID: repoUuid}
 
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(true, "", nil).NotBefore(
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(true, "", nil).NotBefore(
 		suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(repoResp, nil),
 	)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(true, "", nil).NotBefore(
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(true, "", nil).NotBefore(
 		suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(repoResp, nil),
 	)
 
@@ -1239,10 +1239,10 @@ func (suite *ReposSuite) TestCreateSnapshotErrorSnapshottingNotEnabled() {
 
 	repo := dao.Repository{UUID: repoUuid}
 
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(false, "", nil).NotBefore(
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.RepositorySnapshotTask).Return(false, "", nil).NotBefore(
 		suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(repoResp, nil),
 	)
-	suite.reg.TaskInfo.On("IsTaskInProgress", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(false, "", nil).NotBefore(
+	suite.reg.TaskInfo.On("IsTaskInProgressOrPending", test.MockCtx(), test_handler.MockOrgId, repo.UUID, config.IntrospectTask).Return(false, "", nil).NotBefore(
 		suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(repoResp, nil),
 	)
 

--- a/pkg/handler/task_info.go
+++ b/pkg/handler/task_info.go
@@ -107,7 +107,7 @@ func (t *TaskInfoHandler) cancel(c echo.Context) error {
 	if task.OrgId == config.RedHatOrg {
 		return ce.NewErrorResponse(http.StatusBadRequest, "error canceling task", "Cannot cancel a Red Hat Task")
 	}
-	err = t.TaskClient.SendCancelNotification(c.Request().Context(), id)
+	err = t.TaskClient.Cancel(c.Request().Context(), id)
 	if err != nil {
 		if err == queue.ErrNotCancellable {
 			return ce.NewErrorResponse(http.StatusBadRequest, "error canceling task", err.Error())

--- a/pkg/tasks/client/client_mock.go
+++ b/pkg/tasks/client/client_mock.go
@@ -16,6 +16,24 @@ type MockTaskClient struct {
 	mock.Mock
 }
 
+// Cancel provides a mock function with given fields: ctx, taskId
+func (_m *MockTaskClient) Cancel(ctx context.Context, taskId string) error {
+	ret := _m.Called(ctx, taskId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Cancel")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, taskId)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Enqueue provides a mock function with given fields: task
 func (_m *MockTaskClient) Enqueue(task queue.Task) (uuid.UUID, error) {
 	ret := _m.Called(task)
@@ -44,24 +62,6 @@ func (_m *MockTaskClient) Enqueue(task queue.Task) (uuid.UUID, error) {
 	}
 
 	return r0, r1
-}
-
-// SendCancelNotification provides a mock function with given fields: ctx, taskId
-func (_m *MockTaskClient) SendCancelNotification(ctx context.Context, taskId string) error {
-	ret := _m.Called(ctx, taskId)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SendCancelNotification")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, taskId)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // NewMockTaskClient creates a new instance of MockTaskClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/tasks/client/client_test.go
+++ b/pkg/tasks/client/client_test.go
@@ -34,7 +34,7 @@ func (s *ClientSuite) TestEnqueue() {
 	assert.Equal(s.T(), expectedUuid, actualUuid)
 }
 
-func (s *ClientSuite) TestSendCancelNotification() {
+func (s *ClientSuite) TestCancel() {
 	mockQueue := queue.NewMockQueue(s.T())
 	expectedUuid1 := uuid.New()
 	expectedUuid2 := uuid.New()
@@ -47,12 +47,12 @@ func (s *ClientSuite) TestSendCancelNotification() {
 
 	// Test cancel succeeds for cancellable task type
 	mockQueue.On("Status", expectedUuid1).Return(cancellableTask, nil)
-	mockQueue.On("SendCancelNotification", context.Background(), expectedUuid1).Return(nil)
+	mockQueue.On("Cancel", context.Background(), expectedUuid1).Return(nil)
 	tc := NewTaskClient(mockQueue)
 	taskInfo, err := mockQueue.Status(expectedUuid1)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), taskInfo)
-	err = tc.SendCancelNotification(context.Background(), expectedUuid1.String())
+	err = tc.Cancel(context.Background(), expectedUuid1.String())
 	assert.NoError(s.T(), err)
 
 	// Test cancel errors for un-cancellable task type
@@ -60,6 +60,6 @@ func (s *ClientSuite) TestSendCancelNotification() {
 	taskInfo, err = mockQueue.Status(expectedUuid2)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), taskInfo)
-	err = tc.SendCancelNotification(context.Background(), expectedUuid2.String())
+	err = tc.Cancel(context.Background(), expectedUuid2.String())
 	assert.Error(s.T(), err)
 }

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -104,13 +104,12 @@ const (
 	sqlFinishTask = `
 		UPDATE tasks
 		SET finished_at = statement_timestamp(), status = $1, error = (left($2, 4000)), next_retry_time = $3
-		WHERE id = $4 AND finished_at IS NULL
+		WHERE id = $4 AND finished_at is NULL
 		RETURNING finished_at`
 	sqlCancelTask = `
 		UPDATE tasks
 		SET status = 'canceled', error = (left($2, 4000))
 		WHERE id = $1 AND finished_at IS NULL`
-
 	// sqlUpdatePayload
 	sqlUpdatePayload = `
 		UPDATE tasks
@@ -583,7 +582,57 @@ func (p *PgQueue) Finish(taskId uuid.UUID, taskError error) error {
 	return nil
 }
 
-func (p *PgQueue) SendCancelNotification(ctx context.Context, taskId uuid.UUID) error {
+func (p *PgQueue) Cancel(ctx context.Context, taskId uuid.UUID) error {
+	conn, err := p.Pool.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("error starting database transaction: %w", err)
+	}
+	defer func() {
+		err = tx.Rollback(context.Background())
+		if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Logger.Error().Err(err).Msg(fmt.Sprintf("Error rolling back cancel task transaction for task %v", taskId.String()))
+		}
+	}()
+
+	err = p.sendCancelNotification(ctx, taskId)
+	if err != nil {
+		return err
+	}
+
+	// Remove from heartbeats
+	tag, err := tx.Exec(ctx, sqlDeleteHeartbeat, taskId)
+	if err != nil {
+		return fmt.Errorf("error removing task %s from heartbeats: %v", taskId, err)
+	}
+	if tag.RowsAffected() != 1 {
+		logger := log.Logger.With().Str("task_id", taskId.String()).Logger()
+		logger.Warn().Msgf("error canceling task: error deleting heartbeat: heartbeat not found. was this task requeued recently?")
+	}
+
+	_, err = tx.Exec(ctx, sqlCancelTask, taskId, "task canceled")
+	if err != nil {
+		return fmt.Errorf("error canceling task: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, sqlNotify)
+	if err != nil {
+		return fmt.Errorf("error notifying tasks channel: %w", err)
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to commit database transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (p *PgQueue) sendCancelNotification(ctx context.Context, taskId uuid.UUID) error {
 	conn, err := p.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -593,9 +642,8 @@ func (p *PgQueue) SendCancelNotification(ctx context.Context, taskId uuid.UUID) 
 	channelName := getCancelChannelName(taskId)
 	_, err = conn.Exec(ctx, "select pg_notify($1, 'cancel')", channelName)
 	if err != nil {
-		return err
+		return fmt.Errorf("error notifying cancel channel: %w", err)
 	}
-
 	return nil
 }
 

--- a/pkg/tasks/queue/queue.go
+++ b/pkg/tasks/queue/queue.go
@@ -46,8 +46,8 @@ type Queue interface {
 	UpdatePayload(task *models.TaskInfo, payload interface{}) (*models.TaskInfo, error)
 	// ListenForCancel registers a channel and listens for notification for given task, then calls cancelFunc on receive. Should run as goroutine.
 	ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelFunc context.CancelCauseFunc)
-	// SendCancelNotification sends notification to cancel given task
-	SendCancelNotification(ctx context.Context, taskId uuid.UUID) error
+	// Cancel sends notification to cancel given task and sets task state to canceled
+	Cancel(ctx context.Context, taskId uuid.UUID) error
 	// RequeueFailedTasks requeues all failed tasks of taskTypes to the queue
 	RequeueFailedTasks(taskTypes []string) error
 }

--- a/pkg/tasks/queue/queue_mock.go
+++ b/pkg/tasks/queue/queue_mock.go
@@ -18,6 +18,24 @@ type MockQueue struct {
 	mock.Mock
 }
 
+// Cancel provides a mock function with given fields: ctx, taskId
+func (_m *MockQueue) Cancel(ctx context.Context, taskId uuid.UUID) error {
+	ret := _m.Called(ctx, taskId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Cancel")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
+		r0 = rf(ctx, taskId)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Dequeue provides a mock function with given fields: ctx, taskTypes
 func (_m *MockQueue) Dequeue(ctx context.Context, taskTypes []string) (*models.TaskInfo, error) {
 	ret := _m.Called(ctx, taskTypes)
@@ -205,24 +223,6 @@ func (_m *MockQueue) RequeueFailedTasks(taskTypes []string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]string) error); ok {
 		r0 = rf(taskTypes)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SendCancelNotification provides a mock function with given fields: ctx, taskId
-func (_m *MockQueue) SendCancelNotification(ctx context.Context, taskId uuid.UUID) error {
-	ret := _m.Called(ctx, taskId)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SendCancelNotification")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
-		r0 = rf(ctx, taskId)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/tasks/worker/worker.go
+++ b/pkg/tasks/worker/worker.go
@@ -174,16 +174,20 @@ func (w *worker) process(ctx context.Context, taskInfo *models.TaskInfo) {
 
 		handlerErr := handler(ctx, taskInfo, &w.queue)
 
+		// Exit early if the task is canceled. Finish is not needed.
+		if errors.Is(handlerErr, context.Canceled) {
+			w.recordMessageResult(true)
+			w.runningTask.taskCancelFunc(queue.ErrNotRunning)
+			w.readyChan <- struct{}{}
+			return
+		}
+
 		err := w.queue.Finish(taskInfo.Id, handlerErr)
 		if err != nil {
 			logger.Error().Msgf("error finishing task: %v", err)
 		}
 
-		if errors.Is(handlerErr, context.Canceled) {
-			finishStr = "task canceled"
-			w.recordMessageResult(true)
-			logger.Info().Msgf("[Finished Task] %v", finishStr)
-		} else if handlerErr != nil && taskInfo.Retries >= queue.MaxTaskRetries {
+		if handlerErr != nil && taskInfo.Retries >= queue.MaxTaskRetries {
 			finishStr = "task failed and retry limit reached"
 			w.recordMessageResult(false)
 			logger.Error().Err(handlerErr).Msgf("[Finished Task] %v", finishStr)

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -268,7 +268,7 @@ func (s *SnapshotSuite) snapshotAndWait(taskClient client.TaskClient, repo api.R
 
 func (s *SnapshotSuite) cancelAndWait(taskClient client.TaskClient, taskUUID uuid2.UUID, repo api.RepositoryResponse) {
 	var err error
-	err = taskClient.SendCancelNotification(context.Background(), taskUUID.String())
+	err = taskClient.Cancel(context.Background(), taskUUID.String())
 	assert.NoError(s.T(), err)
 
 	s.WaitOnCanceledTask(taskUUID)


### PR DESCRIPTION
## Summary
Adds support for cancelling pending tasks. Anywhere in our code that was cancelling a running task will now cancel a running or pending task.

## Testing steps
1. Add all the EPEL repos, so their snapshot tasks will use all 3 workers. These snapshot tasks will be running.
2. Create another repo with snapshot. This snapshot task will be pending.
3. Delete all the repos you just created.
4. Both the running and pending snapshot tasks should be canceled.

