### PR TITLE
Fixes 4548: add public upload create and upload chunk apis

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -737,6 +737,13 @@ const docTemplate = `{
                         "name": "sha256",
                         "in": "formData",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Content-Range header",
+                        "name": "Content-Range",
+                        "in": "header",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/api/docs.go
+++ b/api/docs.go
@@ -709,7 +709,7 @@ const docTemplate = `{
             "post": {
                 "description": "Upload a file chunk.",
                 "consumes": [
-                    "application/json"
+                    "multipart/form-data"
                 ],
                 "produces": [
                     "application/json"

--- a/api/docs.go
+++ b/api/docs.go
@@ -1020,6 +1020,9 @@ const docTemplate = `{
         "/repositories/{uuid}/add_uploads/": {
             "post": {
                 "description": "Add uploads to a repository.",
+                "consumes": [
+                    "application/json"
+                ],
                 "tags": [
                     "repositories"
                 ],
@@ -1037,6 +1040,7 @@ const docTemplate = `{
                         "description": "request body",
                         "name": "body",
                         "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/api.AddUploadsRequest"
                         }

--- a/api/docs.go
+++ b/api/docs.go
@@ -733,7 +733,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.PublicUploadChunkRequest"
+                            "$ref": "#/definitions/api.UploadChunkRequest"
                         }
                     }
                 ],
@@ -3383,23 +3383,6 @@ const docTemplate = `{
                 }
             }
         },
-        "api.PublicUploadChunkRequest": {
-            "type": "object",
-            "properties": {
-                "file": {
-                    "description": "A chunk of the uploaded file",
-                    "type": "string"
-                },
-                "sha256": {
-                    "description": "SHA-256 checksum of the chunk",
-                    "type": "string"
-                },
-                "uploadUuid": {
-                    "description": "Upload UUID",
-                    "type": "string"
-                }
-            }
-        },
         "api.RepositoryCollectionResponse": {
             "type": "object",
             "properties": {
@@ -4387,6 +4370,23 @@ const docTemplate = `{
                 },
                 "uuid": {
                     "description": "Upload UUID, use with public API",
+                    "type": "string"
+                }
+            }
+        },
+        "api.UploadChunkRequest": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "description": "A chunk of the uploaded file",
+                    "type": "string"
+                },
+                "sha256": {
+                    "description": "SHA-256 checksum of the chunk",
+                    "type": "string"
+                },
+                "uploadUuid": {
+                    "description": "Upload UUID",
                     "type": "string"
                 }
             }

--- a/api/docs.go
+++ b/api/docs.go
@@ -652,6 +652,119 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/uploads/": {
+            "post": {
+                "description": "Create an upload.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Create an upload",
+                "operationId": "createUpload",
+                "parameters": [
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateUploadRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.UploadResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/repositories/uploads/{upload_uuid}/upload_chunk/": {
+            "post": {
+                "description": "Upload a file chunk.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Upload a file chunk",
+                "operationId": "uploadChunk",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Upload ID.",
+                        "name": "upload_uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "request body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.PublicUploadChunkRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.UploadResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}": {
             "get": {
                 "description": "Get repository information.",
@@ -897,11 +1010,11 @@ const docTemplate = `{
         },
         "/repositories/{uuid}/add_uploads/": {
             "post": {
-                "description": "Check for repository updates.",
+                "description": "Add uploads to a repository.",
                 "tags": [
                     "repositories"
                 ],
-                "summary": "add uploads to a repository",
+                "summary": "Add uploads to a repository",
                 "operationId": "add_upload",
                 "parameters": [
                     {
@@ -2989,6 +3102,15 @@ const docTemplate = `{
                 }
             }
         },
+        "api.CreateUploadRequest": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "description": "Size of the upload in bytes",
+                    "type": "integer"
+                }
+            }
+        },
         "api.DetectRpmsRequest": {
             "type": "object",
             "properties": {
@@ -3257,6 +3379,23 @@ const docTemplate = `{
                 },
                 "url": {
                     "description": "URL of the remote yum repository",
+                    "type": "string"
+                }
+            }
+        },
+        "api.PublicUploadChunkRequest": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "description": "A chunk of the uploaded file",
+                    "type": "string"
+                },
+                "sha256": {
+                    "description": "SHA-256 checksum of the chunk",
+                    "type": "string"
+                },
+                "uploadUuid": {
+                    "description": "Upload UUID",
                     "type": "string"
                 }
             }
@@ -4239,11 +4378,40 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "href": {
-                    "description": "HREF to the unfinished upload",
+                    "description": "HREF to the unfinished upload, use with internal API",
                     "type": "string"
                 },
                 "sha256": {
                     "description": "SHA256 sum of the uploaded file",
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "Upload UUID, use with public API",
+                    "type": "string"
+                }
+            }
+        },
+        "api.UploadResponse": {
+            "type": "object",
+            "properties": {
+                "completed": {
+                    "description": "Timestamp when upload is committed",
+                    "type": "string"
+                },
+                "created": {
+                    "description": "Timestamp of creation",
+                    "type": "string"
+                },
+                "last_updated": {
+                    "description": "Timestamp of last update",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "Size of the upload in bytes",
+                    "type": "integer"
+                },
+                "upload_uuid": {
+                    "description": "Upload UUID",
                     "type": "string"
                 }
             }

--- a/api/docs.go
+++ b/api/docs.go
@@ -708,12 +708,6 @@ const docTemplate = `{
         "/repositories/uploads/{upload_uuid}/upload_chunk/": {
             "post": {
                 "description": "Upload a file chunk.",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "repositories"
                 ],

--- a/api/docs.go
+++ b/api/docs.go
@@ -708,6 +708,9 @@ const docTemplate = `{
         "/repositories/uploads/{upload_uuid}/upload_chunk/": {
             "post": {
                 "description": "Upload a file chunk.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
                 "tags": [
                     "repositories"
                 ],
@@ -722,13 +725,18 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "request body",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.UploadChunkRequest"
-                        }
+                        "type": "file",
+                        "description": "file chunk",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "sha256",
+                        "name": "sha256",
+                        "in": "formData",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -4364,23 +4372,6 @@ const docTemplate = `{
                 },
                 "uuid": {
                     "description": "Upload UUID, use with public API",
-                    "type": "string"
-                }
-            }
-        },
-        "api.UploadChunkRequest": {
-            "type": "object",
-            "properties": {
-                "file": {
-                    "description": "A chunk of the uploaded file",
-                    "type": "string"
-                },
-                "sha256": {
-                    "description": "SHA-256 checksum of the chunk",
-                    "type": "string"
-                },
-                "uploadUuid": {
-                    "description": "Upload UUID",
                     "type": "string"
                 }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -60,6 +60,15 @@
                 },
                 "type": "object"
             },
+            "api.CreateUploadRequest": {
+                "properties": {
+                    "size": {
+                        "description": "Size of the upload in bytes",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
             "api.DetectRpmsRequest": {
                 "properties": {
                     "limit": {
@@ -323,6 +332,23 @@
                     },
                     "url": {
                         "description": "URL of the remote yum repository",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.PublicUploadChunkRequest": {
+                "properties": {
+                    "file": {
+                        "description": "A chunk of the uploaded file",
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "description": "SHA-256 checksum of the chunk",
+                        "type": "string"
+                    },
+                    "uploadUuid": {
+                        "description": "Upload UUID",
                         "type": "string"
                     }
                 },
@@ -1281,11 +1307,40 @@
             "api.Upload": {
                 "properties": {
                     "href": {
-                        "description": "HREF to the unfinished upload",
+                        "description": "HREF to the unfinished upload, use with internal API",
                         "type": "string"
                     },
                     "sha256": {
                         "description": "SHA256 sum of the uploaded file",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "description": "Upload UUID, use with public API",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.UploadResponse": {
+                "properties": {
+                    "completed": {
+                        "description": "Timestamp when upload is committed",
+                        "type": "string"
+                    },
+                    "created": {
+                        "description": "Timestamp of creation",
+                        "type": "string"
+                    },
+                    "last_updated": {
+                        "description": "Timestamp of last update",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size of the upload in bytes",
+                        "type": "integer"
+                    },
+                    "upload_uuid": {
+                        "description": "Upload UUID",
                         "type": "string"
                     }
                 },
@@ -2200,6 +2255,145 @@
                 ]
             }
         },
+        "/repositories/uploads/": {
+            "post": {
+                "description": "Create an upload.",
+                "operationId": "createUpload",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.CreateUploadRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.UploadResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Create an upload",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
+        "/repositories/uploads/{upload_uuid}/upload_chunk/": {
+            "post": {
+                "description": "Upload a file chunk.",
+                "operationId": "uploadChunk",
+                "parameters": [
+                    {
+                        "description": "Upload ID.",
+                        "in": "path",
+                        "name": "upload_uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.PublicUploadChunkRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.UploadResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Upload a file chunk",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
         "/repositories/{uuid}": {
             "delete": {
                 "description": "This enables deleting a specific repository.",
@@ -2525,7 +2719,7 @@
         },
         "/repositories/{uuid}/add_uploads/": {
             "post": {
-                "description": "Check for repository updates.",
+                "description": "Add uploads to a repository.",
                 "operationId": "add_upload",
                 "parameters": [
                     {
@@ -2591,7 +2785,7 @@
                         "description": "Internal Server Error"
                     }
                 },
-                "summary": "add uploads to a repository",
+                "summary": "Add uploads to a repository",
                 "tags": [
                     "repositories"
                 ]

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2336,7 +2336,7 @@
                 ],
                 "requestBody": {
                     "content": {
-                        "multipart/form-data": {
+                        "*/*": {
                             "schema": {
                                 "$ref": "#/components/schemas/api.UploadChunkRequest"
                             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1304,23 +1304,6 @@
                 },
                 "type": "object"
             },
-            "api.UploadChunkRequest": {
-                "properties": {
-                    "file": {
-                        "description": "A chunk of the uploaded file",
-                        "type": "string"
-                    },
-                    "sha256": {
-                        "description": "SHA-256 checksum of the chunk",
-                        "type": "string"
-                    },
-                    "uploadUuid": {
-                        "description": "Upload UUID",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "api.UploadResponse": {
                 "properties": {
                     "completed": {
@@ -2336,15 +2319,29 @@
                 ],
                 "requestBody": {
                     "content": {
-                        "*/*": {
+                        "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/api.UploadChunkRequest"
+                                "properties": {
+                                    "file": {
+                                        "description": "file chunk",
+                                        "format": "binary",
+                                        "type": "string",
+                                        "x-formData-name": "file"
+                                    },
+                                    "sha256": {
+                                        "description": "sha256",
+                                        "type": "string",
+                                        "x-formData-name": "sha256"
+                                    }
+                                },
+                                "required": [
+                                    "file",
+                                    "sha256"
+                                ],
+                                "type": "object"
                             }
                         }
-                    },
-                    "description": "request body",
-                    "required": true,
-                    "x-originalParamName": "body"
+                    }
                 },
                 "responses": {
                     "200": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2315,6 +2315,15 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Content-Range header",
+                        "in": "header",
+                        "name": "Content-Range",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "requestBody": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2344,8 +2344,8 @@
                                     }
                                 },
                                 "required": [
-                                    "file",
-                                    "sha256"
+                                    "sha256",
+                                    "file"
                                 ],
                                 "type": "object"
                             }
@@ -2740,13 +2740,14 @@
                 ],
                 "requestBody": {
                     "content": {
-                        "*/*": {
+                        "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/api.AddUploadsRequest"
                             }
                         }
                     },
                     "description": "request body",
+                    "required": true,
                     "x-originalParamName": "body"
                 },
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2336,7 +2336,7 @@
                 ],
                 "requestBody": {
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
                                 "$ref": "#/components/schemas/api.PublicUploadChunkRequest"
                             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -337,23 +337,6 @@
                 },
                 "type": "object"
             },
-            "api.PublicUploadChunkRequest": {
-                "properties": {
-                    "file": {
-                        "description": "A chunk of the uploaded file",
-                        "type": "string"
-                    },
-                    "sha256": {
-                        "description": "SHA-256 checksum of the chunk",
-                        "type": "string"
-                    },
-                    "uploadUuid": {
-                        "description": "Upload UUID",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "api.RepositoryCollectionResponse": {
                 "properties": {
                     "data": {
@@ -1316,6 +1299,23 @@
                     },
                     "uuid": {
                         "description": "Upload UUID, use with public API",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.UploadChunkRequest": {
+                "properties": {
+                    "file": {
+                        "description": "A chunk of the uploaded file",
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "description": "SHA-256 checksum of the chunk",
+                        "type": "string"
+                    },
+                    "uploadUuid": {
+                        "description": "Upload UUID",
                         "type": "string"
                     }
                 },
@@ -2338,7 +2338,7 @@
                     "content": {
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/api.PublicUploadChunkRequest"
+                                "$ref": "#/components/schemas/api.UploadChunkRequest"
                             }
                         }
                     },

--- a/pkg/api/pulp.go
+++ b/pkg/api/pulp.go
@@ -4,7 +4,7 @@ type CreateUploadRequest struct {
 	Size int64 `json:"size"` // Size of the upload in bytes
 }
 
-type UploadChunkRequest struct {
+type PulpUploadChunkRequest struct {
 	UploadHref string `param:"upload_href"` // Upload identifier
 	File       string `form:"file"`         // A chunk of the uploaded file
 	Sha256     string `form:"sha256"`       // SHA-256 checksum of the chunk

--- a/pkg/api/uploads.go
+++ b/pkg/api/uploads.go
@@ -1,16 +1,33 @@
 package api
 
+import "time"
+
 type AddUploadsRequest struct {
 	Uploads   []Upload   `json:"uploads"`   // List of unfinished uploads
 	Artifacts []Artifact `json:"artifacts"` // List of created artifacts
 }
 
 type Upload struct {
-	Href   string `json:"href"`   // HREF to the unfinished upload
+	Uuid   string `json:"uuid"`   // Upload UUID, use with public API
+	Href   string `json:"href"`   // HREF to the unfinished upload, use with internal API
 	Sha256 string `json:"sha256"` // SHA256 sum of the uploaded file
 }
 
 type Artifact struct {
 	Href   string // HREF to the  completed artifact
 	Sha256 string // SHA256 sum of the completed artifact
+}
+
+type PublicUploadChunkRequest struct {
+	UploadUuid string `param:"upload_uuid"` // Upload UUID
+	File       string `form:"file"`         // A chunk of the uploaded file
+	Sha256     string `form:"sha256"`       // SHA-256 checksum of the chunk
+}
+
+type UploadResponse struct {
+	UploadUuid  *string    `json:"upload_uuid"`         // Upload UUID
+	Created     *time.Time `json:"created"`             // Timestamp of creation
+	LastUpdated *time.Time `json:"last_updated"`        // Timestamp of last update
+	Size        int64      `json:"size"`                // Size of the upload in bytes
+	Completed   *time.Time `json:"completed,omitempty"` // Timestamp when upload is committed
 }

--- a/pkg/api/uploads.go
+++ b/pkg/api/uploads.go
@@ -18,7 +18,7 @@ type Artifact struct {
 	Sha256 string // SHA256 sum of the completed artifact
 }
 
-type PublicUploadChunkRequest struct {
+type UploadChunkRequest struct {
 	UploadUuid string `param:"upload_uuid"` // Upload UUID
 	File       string `form:"file"`         // A chunk of the uploaded file
 	Sha256     string `form:"sha256"`       // SHA-256 checksum of the chunk

--- a/pkg/handler/pulp.go
+++ b/pkg/handler/pulp.go
@@ -68,7 +68,7 @@ func (ph *PulpHandler) createUpload(c echo.Context) error {
 
 func (ph *PulpHandler) uploadChunkInternal(c echo.Context) (*zest.UploadResponse, error) {
 	_, orgId := getAccountIdOrgId(c)
-	dataInput := api.UploadChunkRequest{}
+	dataInput := api.PulpUploadChunkRequest{}
 	if err := c.Bind(&dataInput); err != nil {
 		return nil, ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
 	}

--- a/pkg/handler/pulp.go
+++ b/pkg/handler/pulp.go
@@ -11,6 +11,7 @@ import (
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/rbac"
+	zest "github.com/content-services/zest/release/v2024"
 	"github.com/labstack/echo/v4"
 )
 
@@ -35,20 +36,29 @@ func RegisterPulpRoutes(engine *echo.Group, daoReg *dao.DaoRegistry) {
 	addRepoRoute(engine, http.MethodGet, "/pulp/tasks/:task_href", pulpHandler.getTask, rbac.RbacVerbRead)
 }
 
-func (ph *PulpHandler) createUpload(c echo.Context) error {
+func (ph *PulpHandler) createUploadInternal(c echo.Context) (*zest.UploadResponse, error) {
 	_, orgId := getAccountIdOrgId(c)
 	dataInput := api.CreateUploadRequest{}
 	if err := c.Bind(&dataInput); err != nil {
-		return ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
+		return nil, ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
 	}
 
 	domainName, err := ph.DaoRegistry.Domain.FetchOrCreateDomain(c.Request().Context(), orgId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	pulpClient := pulp_client.GetPulpClientWithDomain(domainName)
 
 	apiResponse, err := pulpClient.CreateUpload(c.Request().Context(), dataInput.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiResponse, nil
+}
+
+func (ph *PulpHandler) createUpload(c echo.Context) error {
+	apiResponse, err := ph.createUploadInternal(c)
 	if err != nil {
 		return err
 	}
@@ -56,23 +66,23 @@ func (ph *PulpHandler) createUpload(c echo.Context) error {
 	return c.JSON(200, apiResponse)
 }
 
-func (ph *PulpHandler) uploadChunk(c echo.Context) error {
+func (ph *PulpHandler) uploadChunkInternal(c echo.Context) (*zest.UploadResponse, error) {
 	_, orgId := getAccountIdOrgId(c)
 	dataInput := api.UploadChunkRequest{}
 	if err := c.Bind(&dataInput); err != nil {
-		return ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
+		return nil, ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
 	}
 
 	sha256 := c.FormValue("sha256")
 	file, err := c.FormFile("file")
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "error retrieving file from request", err.Error())
+		return nil, ce.NewErrorResponse(http.StatusInternalServerError, "error retrieving file from request", err.Error())
 	}
 
 	// convert file part from request to temp file
 	tempFile, err := getFile(file)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// close and remove the temp file on exit
@@ -81,11 +91,20 @@ func (ph *PulpHandler) uploadChunk(c echo.Context) error {
 
 	domainName, err := ph.DaoRegistry.Domain.Fetch(c.Request().Context(), orgId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	pulpClient := pulp_client.GetPulpClientWithDomain(domainName)
 
 	apiResponse, err := pulpClient.UploadChunk(c.Request().Context(), dataInput.UploadHref, c.Request().Header.Get("Content-Range"), tempFile, sha256)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiResponse, nil
+}
+
+func (ph *PulpHandler) uploadChunk(c echo.Context) error {
+	apiResponse, err := ph.uploadChunkInternal(c)
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -664,8 +664,9 @@ func (rh *RepositoryHandler) uploadChunk(c echo.Context) error {
 // @ID				add_upload
 // @Description     Add uploads to a repository.
 // @Tags			repositories
+// @Accept          json
 // @Param  			uuid            path    string                          true   "Repository ID."
-// @Param			body            body    api.AddUploadsRequest			false  "request body"
+// @Param			body            body    api.AddUploadsRequest			true  "request body"
 // @Success			200 {object} api.TaskInfoResponse
 // @Failure      	400 {object} ce.ErrorResponse
 // @Failure      	404 {object} ce.ErrorResponse

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -610,9 +610,10 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 // @Description     Upload a file chunk.
 // @Tags            repositories
 // @Accept          multipart/form-data
-// @Param           upload_uuid            path    string                          true   "Upload ID."
+// @Param           upload_uuid            path     string true  "Upload ID."
 // @Param           file                   formData file   true  "file chunk"
 // @Param           sha256                 formData string true  "sha256"
+// @Param           Content-Range          header   string true  "Content-Range header"
 // @Success         200 {object} api.UploadResponse
 // @Failure         400 {object} ce.ErrorResponse
 // @Failure         404 {object} ce.ErrorResponse

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -609,8 +609,6 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 // @ID              uploadChunk
 // @Description     Upload a file chunk.
 // @Tags            repositories
-// @Accept          multipart/form-data
-// @Produce         json
 // @Param           upload_uuid            path    string                          true   "Upload ID."
 // @Param           body            body    api.UploadChunkRequest	true  "request body"
 // @Success         200 {object} api.UploadResponse

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -609,14 +609,14 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 // @Accept          multipart/form-data
 // @Produce         json
 // @Param           upload_uuid            path    string                          true   "Upload ID."
-// @Param           body            body    api.PublicUploadChunkRequest	true  "request body"
+// @Param           body            body    api.UploadChunkRequest	true  "request body"
 // @Success         200 {object} api.UploadResponse
 // @Failure         400 {object} ce.ErrorResponse
 // @Failure         404 {object} ce.ErrorResponse
 // @Failure         500 {object} ce.ErrorResponse
 // @Router          /repositories/uploads/{upload_uuid}/upload_chunk/ [post]
 func (rh *RepositoryHandler) uploadChunk(c echo.Context) error {
-	var req api.PublicUploadChunkRequest
+	var req api.UploadChunkRequest
 
 	_, orgId := getAccountIdOrgId(c)
 	uploadUuid := c.Param("upload_uuid")

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -609,8 +609,10 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 // @ID              uploadChunk
 // @Description     Upload a file chunk.
 // @Tags            repositories
+// @Accept          multipart/form-data
 // @Param           upload_uuid            path    string                          true   "Upload ID."
-// @Param           body            body    api.UploadChunkRequest	true  "request body"
+// @Param           file                   formData file   true  "file chunk"
+// @Param           sha256                 formData string true  "sha256"
 // @Success         200 {object} api.UploadResponse
 // @Failure         400 {object} ce.ErrorResponse
 // @Failure         404 {object} ce.ErrorResponse

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -606,7 +606,7 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 // @ID              uploadChunk
 // @Description     Upload a file chunk.
 // @Tags            repositories
-// @Accept          json
+// @Accept          multipart/form-data
 // @Produce         json
 // @Param           upload_uuid            path    string                          true   "Upload ID."
 // @Param           body            body    api.PublicUploadChunkRequest	true  "request body"

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -588,7 +588,10 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	uploadUuid := extractUploadUuid(*pulpResp.PulpHref)
+	uploadUuid := ""
+	if pulpResp != nil && pulpResp.PulpHref != nil {
+		uploadUuid = extractUploadUuid(*pulpResp.PulpHref)
+	}
 
 	resp := &api.UploadResponse{
 		UploadUuid:  &uploadUuid,
@@ -640,7 +643,9 @@ func (rh *RepositoryHandler) uploadChunk(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	uploadUuid = extractUploadUuid(*pulpResp.PulpHref)
+	if pulpResp != nil && pulpResp.PulpHref != nil {
+		uploadUuid = extractUploadUuid(*pulpResp.PulpHref)
+	}
 
 	resp := &api.UploadResponse{
 		UploadUuid:  &uploadUuid,

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -52,3 +52,12 @@ func preprocessInput(input *api.ContentUnitSearchRequest) {
 		*input.Limit = api.ContentUnitSearchRequestLimitMaximum
 	}
 }
+
+func extractUploadUuid(href string) string {
+	uuid := strings.TrimSuffix(href, "/")
+	lastIndex := strings.LastIndex(uuid, "/")
+	if lastIndex == -1 {
+		return ""
+	}
+	return uuid[lastIndex+1:]
+}

--- a/pkg/tasks/add_uploads.go
+++ b/pkg/tasks/add_uploads.go
@@ -27,7 +27,7 @@ type AddUploadsPayload struct {
 	Uploads              []api.Upload
 
 	VersionHref          *string // href of repo version created as part of this
-	PublicationTaskHref  *string //
+	PublicationTaskHref  *string
 	DistributionTaskHref *string
 	SnapshotIdent        *string
 }
@@ -187,6 +187,9 @@ func (ur *AddUploads) ConvertUploadsToArtifacts() ([]api.Artifact, error) {
 			return artifacts, fmt.Errorf("could not lookup artifact: %w", err)
 		}
 		if found == nil {
+			if upload.Href == "" && upload.Uuid != "" {
+				upload.Href = fmt.Sprintf("/api/pulp/%s/api/v3/uploads/%s/", ur.domainName, upload.Uuid)
+			}
 			task, err := ur.pulpClient.FinishUpload(ur.ctx, upload.Href, upload.Sha256)
 			if err != nil {
 				return artifacts, fmt.Errorf("could not finish upload: %w", err)

--- a/scripts/uploads.py
+++ b/scripts/uploads.py
@@ -3,7 +3,7 @@
 # 1. Create and activate virtual environment: `cd scripts && python3 -m venv .venv && source .venv/bin/activate`
 # 2. Install requests: `pip3 install requests`
 # 3. Set your identity header: `export IDENTITY_HEADER=<identity_header>`
-# 4. Run: `python3 uploads.py <repo_uuid> <rpm1 rpm2 ...>`
+# 4. Run: `python3 uploads.py <repo_uuid> <rpm1 rpm2 ...> --api <public | internal>`
 
 import os
 import requests

--- a/scripts/uploads.py
+++ b/scripts/uploads.py
@@ -3,7 +3,7 @@
 # 1. Create and activate virtual environment: `cd scripts && python3 -m venv .venv && source .venv/bin/activate`
 # 2. Install requests: `pip3 install requests`
 # 3. Set your identity header: `export IDENTITY_HEADER=<identity_header>`
-# 4. Run: `python3 uploads.py <path_to_rpm>`
+# 4. Run: `python3 uploads.py <repo_uuid> <rpm1 rpm2 ...>`
 
 import os
 import requests
@@ -18,9 +18,10 @@ import re
 
 BASE_URL = 'http://localhost:8000/api/content-sources/v1.0'
 IDENTITY_HEADER = os.environ['IDENTITY_HEADER']
+API = 'public'
 
 def sanitize(input):
-    if not re.match(r'^[a-zA-Z0-9/.\-_ ]+$', input):
+    if not re.match(r'^[a-zA-Z0-9/.\-_ ]+$', input) and not re.match(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', input):
         raise ValueError(f'Invalid input: {input}')
     return input
 
@@ -44,12 +45,18 @@ def create_upload(size):
         'x-rh-identity': IDENTITY_HEADER,
         'Content-Type': 'application/json'
     }
-    response = requests.post(f'{BASE_URL}/pulp/uploads/', headers=headers, json=data)
-    response.raise_for_status()
-    print("upload:" + response.json()['pulp_href'])
-    return response.json()['pulp_href']
+    if API == 'public':
+        response = requests.post(f'{BASE_URL}/repositories/uploads/', headers=headers, json=data)
+        response.raise_for_status()
+        print("upload: " + response.json()['upload_uuid'])
+        return response.json()['upload_uuid']
+    elif API == 'internal':
+        response = requests.post(f'{BASE_URL}/pulp/uploads/', headers=headers, json=data)
+        response.raise_for_status()
+        print("upload: " + response.json()['pulp_href'])
+        return response.json()['pulp_href']
 
-def upload_chunk(upload_href, file_path, total_size, start_byte, chunk_size, sha256):
+def upload_chunk(upload_id, file_path, total_size, start_byte, chunk_size, sha256):
     # upload a chunk
     with open(file_path, 'rb') as f:
         files = {'file': f}
@@ -62,8 +69,12 @@ def upload_chunk(upload_href, file_path, total_size, start_byte, chunk_size, sha
             'x-rh-identity': IDENTITY_HEADER,
             'Content-Range': f'bytes {start_byte}-{final_byte}/*'
         }
-        upload_href = sanitize(upload_href)
-        response = requests.put(f'{BASE_URL}/pulp/uploads/{upload_href}', headers=headers, files=files, json=data)
+        if API == 'public':
+            upload_uuid = sanitize(upload_id)
+            response = requests.post(f'{BASE_URL}/repositories/uploads/{upload_uuid}/upload_chunk/', headers=headers, files=files, json=data)
+        if API == 'internal':
+            upload_id = sanitize(upload_id)
+            response = requests.put(f'{BASE_URL}/pulp/uploads/{upload_id}', headers=headers, files=files, json=data)
         response.raise_for_status()
         return response.json()
 
@@ -109,6 +120,7 @@ def addArtifactsToRepository(repoUUID, artifacts):
     for artifact in artifacts:
         data["artifacts"] += [{"href":artifact[1], "sha256": artifact[0]}]
     response = requests.post(f'{BASE_URL}/repositories/{repoUUID}/add_uploads/', headers=headers, json=data)
+    response.raise_for_status()
     
 def addUploadsToRepository(repoUUID, uploads):
    headers = {
@@ -119,9 +131,13 @@ def addUploadsToRepository(repoUUID, uploads):
            'uploads': []
    }
    for upload in uploads:
-       data["uploads"] += [{"href":upload[1], "sha256": upload[0]}]
+      if API == 'internal':
+         data["uploads"] += [{"href":upload[1], "sha256": upload[0]}]
+      elif API == 'public':
+         data["uploads"] += [{"uuid":upload[1], "sha256": upload[0]}]
 
    response = requests.post(f'{BASE_URL}/repositories/{repoUUID}/add_uploads/', headers=headers, json=data)
+   response.raise_for_status()
 
 
 def main():
@@ -134,18 +150,23 @@ def main():
     parser.add_argument('-f', '--finalize',
                         action='store_true',
                         help='finalize uploads before saving them')
+    parser.add_argument('--api', choices=['public', 'internal'], default='public',
+                        help='specify whether to use the public or internal APIs (default: public)')
     args = parser.parse_args()
 
     rpms = args.files
     finalize = args.finalize
     repo_uuid = args.repo_uuid
 
+    global API
+    API = args.api
+
     UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
     if not re.match(UUID_REGEX, repo_uuid):
         raise ValueError(repo_uuid + " is not a valid UUID")
 
-    upload_hrefs = [] #tuples of [sha256, upload_href]
+    upload_ids = [] #tuples of [sha256, upload_href or upload_uuid]
     for rpm_file in rpms:
         if not os.path.isfile(rpm_file) or not rpm_file.endswith('.rpm'):
             raise ValueError('File does not exist or is not an rpm')
@@ -166,9 +187,9 @@ def main():
         print(f'sha256 for rpm: {rpm_sha256}')
 
         # create the upload
-        upload_href = create_upload(rpm_size)
-        print(f'upload_href: {upload_href}')
-        upload_hrefs += [(rpm_sha256, upload_href)]
+        upload_id = create_upload(rpm_size)
+        print(f'upload href or uuid: {upload_id}')
+        upload_ids += [(rpm_sha256, upload_id)]
 
         # upload the chunks
         start_byte = 0
@@ -177,7 +198,7 @@ def main():
                 chunk_path = os.path.join(tempDir, chunk_file)
                 chunk_size = os.path.getsize(chunk_path)
                 chunk_sha256 = generate_checksum(chunk_path)
-                upload_chunk(upload_href, chunk_path, rpm_size, start_byte, chunk_size, chunk_sha256)
+                upload_chunk(upload_id, chunk_path, rpm_size, start_byte, chunk_size, chunk_sha256)
                 start_byte += chunk_size
 
         # remove chunk files if any exist
@@ -187,14 +208,14 @@ def main():
 
     # add the uploads directly and we are done
     if not finalize:
-        addUploadsToRepository(repo_uuid, upload_hrefs)
+        addUploadsToRepository(repo_uuid, upload_ids)
         return
 
     # finalize the uploads and then add them
 
     # commit/finish the upload
     artifacts = [] #tuples of sha256, artifact_href
-    for upload in upload_hrefs:
+    for upload in upload_ids:
         sha256 = upload[0]
         task_href = commit_upload(upload[1], sha256)
         print(f'task href: {task_href}')


### PR DESCRIPTION
## Summary

- Adds the public APIs for creating an upload and uploading a chunk: `POST /repositories/uploads/` and `POST /repositories/uploads/:upload_uuid/upload_chunk/`
- Modifies the existing addUploads API to use either an upload UUID or an upload href
- Modifies the python script for testing the upload process to use either the public or internal APIs

## Testing steps

- Create an upload repository with snapshot set to true
- Use the ./scripts/uploads.py script to use the public APIs to create an upload, upload the chunks, and add the uploads:
`python3 uploads.py <repo_uuid> <rpm1 rpm2 ...> --api public` (the same script should still be able to be used with the internal APIs: `python3 uploads.py <repo_uuid> <rpm1 rpm2 ...> --api internal`)
- Fetch the repository and verify the package count (should be 1)
- Fetch the repository's rpms and the snapshot's rpms and verify they include the one you just uploaded
- Access the pulp content via the pulp URL and verify the expected rpm is there
- Upload the same rpm and verify no new snapshot is created
- Upload a different rpm and verify a new snapshot is created with that rpm added
- For QE, the upload chunk API in particular may be difficult to test and I may need to change some things so this works with generated client. 

Here are some example commands in case it's helpful:

```
Create upload request:
curl -X POST 'localhost:8000/api/content-sources/v1.0/repositories/uploads/' \
-H 'x-rh-identity: <identity_header>' \
-H 'Content-Type: application/json' \
-d '{    
    "size": 7036
}'

IQE shell:
app.content_sources.rest_client.repositories_api.create_upload({"size": 7036})

Response:
{
    "upload_uuid": "01916bde-8e8a-76a6-aa34-17acdfb86ceb",
    "created": "2024-08-19T18:20:33.290458Z",
    "last_updated": "2024-08-19T18:20:33.290468Z",
    "size": 7036
}

Upload chunk request:
curl -X POST 'localhost:8000/api/content-sources/v1.0/repositories/uploads/01916bde-8e8a-76a6-aa34-17acdfb86ceb/upload_chunk/' \
-H 'x-rh-identity:  <identity_header>' \
-H 'Content-Range: bytes 0-7035/*' \
-F 'file=@"/Users/bhouse/rpms/rpm_chunkaa"' \
-F 'sha256="7e380bd4c000378f407c1a3663dedfda01248564fd7d4e33d56a1c691046bce1"'

IQE shell:
with open('/Users/bhouse/rpms/rpm_chunkaa', 'rb') as file:
   response = app.content_sources.rest_client.repositories_api.upload_chunk('01916bde-8e8a-76a6-aa34-17acdfb86ceb', 'bytes 0-7035/*', file, '7e380bd4c000378f407c1a3663dedfda01248564fd7d4e33d56a1c691046bce1')
response

Response:
{
    "upload_uuid": "01916bde-8e8a-76a6-aa34-17acdfb86ceb",
    "created": "2024-08-19T18:20:33.290458Z",
    "last_updated": "2024-08-19T18:20:33.290468Z",
    "size": 7036
}

Add uploads request:
curl -X POST 'localhost:8000/api/content-sources/v1.0/repositories/8a578521-50be-48df-b029-d7f240aa7dfa/add_uploads/' \
-H 'x-rh-identity: <identity_header>' \
-H 'Content-Type: application/json' \
-d '{
    "uploads": [
        {
            "uuid": "01916bde-8e8a-76a6-aa34-17acdfb86ceb",
            "sha256": "7e380bd4c000378f407c1a3663dedfda01248564fd7d4e33d56a1c691046bce1"
        }
    ]
}'

IQE shell:
body = { 'uploads': [{'uuid':'01916bde-8e8a-76a6-aa34-17acdfb86ceb', 'sha256':'7e380bd4c000378f407c1a3663dedfda01248564fd7d4e33d56a1c691046bce1'}], 'artifacts': [] }
app.content_sources.rest_client.repositories_api.add_upload('8a578521-50be-48df-b029-d7f240aa7dfa', body)


Response:
{
    "uuid": "29125d02-d11c-4d44-973d-878c9b963d64",
    "status": "pending",
    "created_at": "2024-08-22T11:55:13-04:00",
    "ended_at": "",
    "error": "",
    "org_id": "17684632",
    "type": "add-uploads-repository",
    "repository_name": "test",
    "repository_uuid": "8a578521-50be-48df-b029-d7f240aa7dfa",
    "dependencies": [],
    "dependents": []
}

```