### PR TITLE
Fixes 4541: fix template patch endpoint error on empty date

### DIFF
--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -106,7 +106,7 @@ func (d EmptiableDate) MarshalJSON() ([]byte, error) {
 
 func (d *EmptiableDate) UnmarshalJSON(b []byte) error {
 	str := string(b)
-	if b == nil || len(b) == 0 || str == "null" || str == `""` || str == "" {
+	if len(b) == 0 || str == "null" || str == `""` || str == "" {
 		*d = EmptiableDate(time.Time{})
 		return nil
 	}

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -440,7 +440,7 @@ func templatesCreateApiToModel(api api.TemplateRequest, model *models.Template) 
 		model.Arch = *api.Arch
 	}
 	if api.Date != nil {
-		model.Date = *api.Date
+		model.Date = api.Date.AsTime()
 	}
 	if api.OrgID != nil {
 		model.OrgID = *api.OrgID
@@ -459,7 +459,7 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 		model.Description = *api.Description
 	}
 	if api.Date != nil {
-		model.Date = *api.Date
+		model.Date = api.Date.AsTime()
 	}
 	if api.OrgID != nil {
 		model.OrgID = *api.OrgID

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -46,7 +46,7 @@ func (s *TemplateSuite) TestCreate() {
 		RepositoryUUIDS: []string{repoConfigs[0].UUID, repoConfigs[1].UUID},
 		Arch:            utils.Ptr(config.AARCH64),
 		Version:         utils.Ptr(config.El8),
-		Date:            &timeNow,
+		Date:            (*api.EmptiableDate)(&timeNow),
 		OrgID:           &orgID,
 		UseLatest:       utils.Ptr(false),
 	}
@@ -81,7 +81,7 @@ func (s *TemplateSuite) TestCreateDeleteCreateSameName() {
 		RepositoryUUIDS: []string{repoConfigs[0].UUID, repoConfigs[1].UUID},
 		Arch:            utils.Ptr(config.AARCH64),
 		Version:         utils.Ptr(config.El8),
-		Date:            &timeNow,
+		Date:            (*api.EmptiableDate)(&timeNow),
 		OrgID:           &orgID,
 		User:            utils.Ptr("user"),
 	}
@@ -451,11 +451,11 @@ func (s *TemplateSuite) TestUpdate() {
 
 	// Test use_latest validation error
 	now := time.Now()
-	_, err = templateDao.Update(context.Background(), orgIDTest, found.UUID, api.TemplateUpdateRequest{Date: &now, UseLatest: utils.Ptr(true)})
+	_, err = templateDao.Update(context.Background(), orgIDTest, found.UUID, api.TemplateUpdateRequest{Date: utils.Ptr(api.EmptiableDate(now)), UseLatest: utils.Ptr(true)})
 	assert.Error(s.T(), err)
 
 	// Test use_latest is updated
-	_, err = templateDao.Update(context.Background(), orgIDTest, found.UUID, api.TemplateUpdateRequest{Date: &time.Time{}, UseLatest: utils.Ptr(true)})
+	_, err = templateDao.Update(context.Background(), orgIDTest, found.UUID, api.TemplateUpdateRequest{Date: utils.Ptr(api.EmptiableDate(time.Time{})), UseLatest: utils.Ptr(true)})
 	require.NoError(s.T(), err)
 	found = s.fetchTemplate(origTempl.UUID)
 	assert.Equal(s.T(), true, found.UseLatest)

--- a/pkg/handler/templates_test.go
+++ b/pkg/handler/templates_test.go
@@ -461,12 +461,12 @@ func (suite *TemplatesSuite) TestFullUpdate() {
 	orgID := test_handler.MockOrgId
 	template := api.TemplateUpdateRequest{
 		Description: utils.Ptr("Some desc"),
-		Date:        &time.Time{},
+		Date:        utils.Ptr(api.EmptiableDate(time.Time{})),
 		Name:        utils.Ptr("Some name"),
 	}
 	templateExpected := api.TemplateUpdateRequest{
 		Description: template.Description,
-		Date:        template.Date,
+		Date:        utils.Ptr(api.EmptiableDate(time.Time{})),
 		Name:        template.Name,
 	}
 	templateExpected.FillDefaults()
@@ -478,7 +478,7 @@ func (suite *TemplatesSuite) TestFullUpdate() {
 		Description:     *templateExpected.Description,
 		Arch:            config.AARCH64,
 		Version:         config.El8,
-		Date:            *templateExpected.Date,
+		Date:            time.Time{},
 		RepositoryUUIDS: []string{},
 	}
 

--- a/test/integration/update_latest_snapshot_test.go
+++ b/test/integration/update_latest_snapshot_test.go
@@ -88,7 +88,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshot() {
 		OrgID:           utils.Ptr(repo.OrgID),
 		Arch:            utils.Ptr(config.X8664),
 		Version:         utils.Ptr(config.El8),
-		Date:            utils.Ptr(time.Now()),
+		Date:            utils.Ptr(api.EmptiableDate(time.Now())),
 	}
 	tempResp2, err := s.dao.Template.Create(ctx, reqTemplate)
 	assert.NoError(s.T(), err)


### PR DESCRIPTION
## Summary
There is a problem when sending a `PATCH` to update a template and supplying only the `use_latest=true` and not the date (supplying a null or an empty string), that errors out right now, but it should zero out the date instead.
This PR fixes that, by changing the way the date is decoded/unmarshaled from the JSON request body by wrapping it in a custom type (it's necessary to it this way, so that the parsing doesn't quit after first binding error, can't just silence the error returned by `Bind()` as that would ignore any following data).
Accepting `date=""` as zeroed date was also propagated to accompanying template `PUT` and `POST` endpoints.

## Testing steps
#### 1. Create a new template
```bash
http :8000/api/content-sources/v1.0/templates/ "$( ./scripts/header.sh acme 1111)" arch='x86_64' version='9' repository_uuids:='[]' description='testing patch date latest' name='test' use_latest:=false date="2024-07-20T11:15:17+02:00"
```

#### 2. Update `use_latest` to true with `PATCH` and _don't supply_ the date.
```bash
http PATCH :8000/api/content-sources/v1.0/templates/{_NEW TEMPLATE ID_} "$( ./scripts/header.sh acme 1111)" use_latest:=true
```
Should pass and zero out the date. (`"date": "0001-01-01T00:57:44+00:57"`)

#### 3. Revert the update
```bash
http PATCH :8000/api/content-sources/v1.0/templates/{_NEW TEMPLATE ID_} "$( ./scripts/header.sh acme 1111)" use_latest:=false date="2024-07-20T11:15:17+02:00"
```

#### 4. Update `use_latest` to true with `PATCH` and _supply_ the date as empty string.
```bash
http PATCH :8000/api/content-sources/v1.0/templates/{_NEW TEMPLATE ID_} "$( ./scripts/header.sh acme 1111)" use_latest:=true date="" name="renamed"
```
Should pass and zero out the date. (`"date": "0001-01-01T00:57:44+00:57"`) and the name should also change to "renamed" as the data following the date is also correctly parsed.
