### PR TITLE
Fixes 4297: template API responds in UTC time

### DIFF
--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -76,9 +76,9 @@ func (r *TemplateUpdateRequest) FillDefaults() {
 		r.Description = &emptyStr
 	}
 	if r.Date == nil || r.Date.AsTime().Before(time.Time{}) {
-		r.Date = (*EmptiableDate)(utils.Ptr(time.Now()))
+		r.Date = (*EmptiableDate)(utils.Ptr(time.Now().UTC()))
 		if r.IsUsingLatest() {
-			r.Date = (*EmptiableDate)(utils.Ptr(time.Time{}))
+			r.Date = (*EmptiableDate)(utils.Ptr(time.Time{}.UTC()))
 		}
 	}
 	if r.RepositoryUUIDS == nil {
@@ -101,20 +101,28 @@ func (d EmptiableDate) IsZero() bool {
 }
 
 func (d EmptiableDate) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Time(d).Format(time.RFC3339))
+	return json.Marshal(time.Time(d).UTC().Format(time.RFC3339))
 }
 
 func (d *EmptiableDate) UnmarshalJSON(b []byte) error {
 	str := string(b)
 	if len(b) == 0 || str == "null" || str == `""` || str == "" {
-		*d = EmptiableDate(time.Time{})
+		*d = EmptiableDate(time.Time{}.UTC())
 		return nil
 	}
 
 	var t time.Time
+
+	// try parsing as YYYY-MM-DD first
+	t, err := time.Parse(`"2006-01-02"`, string(b))
+	if err == nil {
+		*d = EmptiableDate(t.UTC())
+		return nil
+	}
+
 	if err := json.Unmarshal(b, &t); err != nil {
 		return err
 	}
-	*d = EmptiableDate(t)
+	*d = EmptiableDate(t.UTC())
 	return nil
 }

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -440,7 +440,7 @@ func templatesCreateApiToModel(api api.TemplateRequest, model *models.Template) 
 		model.Arch = *api.Arch
 	}
 	if api.Date != nil {
-		model.Date = api.Date.AsTime()
+		model.Date = api.Date.AsTime().UTC()
 	}
 	if api.OrgID != nil {
 		model.OrgID = *api.OrgID
@@ -459,7 +459,7 @@ func templatesUpdateApiToModel(api api.TemplateUpdateRequest, model *models.Temp
 		model.Description = *api.Description
 	}
 	if api.Date != nil {
-		model.Date = api.Date.AsTime()
+		model.Date = api.Date.AsTime().UTC()
 	}
 	if api.OrgID != nil {
 		model.OrgID = *api.OrgID
@@ -483,15 +483,15 @@ func templatesModelToApi(model models.Template, api *api.TemplateResponse) {
 	api.Description = model.Description
 	api.Version = model.Version
 	api.Arch = model.Arch
-	api.Date = model.Date
+	api.Date = model.Date.UTC()
 	api.RepositoryUUIDS = make([]string, 0) // prevent null responses
 	for _, repoConfig := range model.RepositoryConfigurations {
 		api.RepositoryUUIDS = append(api.RepositoryUUIDS, repoConfig.UUID)
 	}
 	api.CreatedBy = model.CreatedBy
 	api.LastUpdatedBy = model.LastUpdatedBy
-	api.CreatedAt = model.CreatedAt
-	api.UpdatedAt = model.UpdatedAt
+	api.CreatedAt = model.CreatedAt.UTC()
+	api.UpdatedAt = model.UpdatedAt.UTC()
 	api.UseLatest = model.UseLatest
 }
 

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -56,7 +56,7 @@ func (s *TemplateSuite) TestCreate() {
 	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(respTemplate.UUID), respTemplate.RHSMEnvironmentID)
 	assert.Equal(s.T(), orgID, respTemplate.OrgID)
 	assert.Equal(s.T(), *reqTemplate.Description, respTemplate.Description)
-	assert.Equal(s.T(), timeNow.Round(time.Millisecond), respTemplate.Date.Round(time.Millisecond))
+	assert.True(s.T(), timeNow.Round(time.Millisecond).Equal(respTemplate.Date.Round(time.Millisecond)))
 	assert.Equal(s.T(), *reqTemplate.Arch, respTemplate.Arch)
 	assert.Equal(s.T(), *reqTemplate.Version, respTemplate.Version)
 	assert.Len(s.T(), reqTemplate.RepositoryUUIDS, 2)
@@ -104,7 +104,7 @@ func (s *TemplateSuite) TestCreateDeleteCreateSameName() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), orgID, respTemplate.OrgID)
 	assert.Equal(s.T(), *reqTemplate.Description, respTemplate.Description)
-	assert.Equal(s.T(), timeNow.Round(time.Millisecond), respTemplate.Date.Round(time.Millisecond))
+	assert.True(s.T(), timeNow.Round(time.Millisecond).Equal(respTemplate.Date.Round(time.Millisecond)))
 	assert.Equal(s.T(), *reqTemplate.Arch, respTemplate.Arch)
 	assert.Equal(s.T(), *reqTemplate.Version, respTemplate.Version)
 	assert.Len(s.T(), reqTemplate.RepositoryUUIDS, 2)
@@ -129,8 +129,8 @@ func (s *TemplateSuite) TestFetch() {
 	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(resp.UUID), resp.RHSMEnvironmentID)
 	assert.Equal(s.T(), found.LastUpdatedBy, resp.LastUpdatedBy)
 	assert.Equal(s.T(), found.CreatedBy, resp.CreatedBy)
-	assert.Equal(s.T(), found.CreatedAt, resp.CreatedAt)
-	assert.Equal(s.T(), found.UpdatedAt, resp.UpdatedAt)
+	assert.True(s.T(), found.CreatedAt.Equal(resp.CreatedAt))
+	assert.True(s.T(), found.UpdatedAt.Equal(resp.UpdatedAt))
 }
 
 func (s *TemplateSuite) TestFetchNotFound() {
@@ -174,8 +174,8 @@ func (s *TemplateSuite) TestList() {
 	assert.Equal(s.T(), candlepin_client.GetEnvironmentID(responses.Data[0].UUID), responses.Data[0].RHSMEnvironmentID)
 	assert.Equal(s.T(), responses.Data[0].CreatedBy, found[0].CreatedBy)
 	assert.Equal(s.T(), responses.Data[0].LastUpdatedBy, found[0].LastUpdatedBy)
-	assert.Equal(s.T(), responses.Data[0].CreatedAt, found[0].CreatedAt)
-	assert.Equal(s.T(), responses.Data[0].UpdatedAt, found[0].UpdatedAt)
+	assert.True(s.T(), responses.Data[0].CreatedAt.Equal(found[0].CreatedAt))
+	assert.True(s.T(), responses.Data[0].UpdatedAt.Equal(found[0].UpdatedAt))
 	assert.Equal(s.T(), responses.Data[0].UseLatest, found[0].UseLatest)
 }
 


### PR DESCRIPTION
## Summary
This PR makes the template part of the API respond with times in UTC time format, which fixes weird timezone/location converted output of the zero date (and others). This has to be done, even though all of our `time.Time` data is stored as UTC in our DB, but that is converted when reading it to the local time of the system it's running on (and also output in that).
Also has a [sibling front-end PR](https://github.com/content-services/content-sources-frontend/pull/325) addressing [this issue](https://issues.redhat.com/browse/HMS-4297) there.
We should think about doing this for all of our endpoints so that the responses are clearer and less "confusing"/more standardized.

## Testing steps
Make a request to the endpoint which lists all templates and check date that the format of all dates is in UTC (doesn't have a time offset)
```bash
http :8000/api/content-sources/v1.0/templates/ "$( ./scripts/header.sh acme 1111)
```
