### PR TITLE
Fixes 4523: use clock timestamp for started_at

### DIFF
--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -33,7 +33,7 @@ const (
 	sqlEnqueue = `INSERT INTO tasks(id, type, payload, queued_at, org_id, object_uuid, object_type, status, request_id, account_id, priority) VALUES ($1, $2, $3, statement_timestamp(), $4, $5, $6, $7, $8, $9, $10)`
 	sqlDequeue = `
 		UPDATE tasks
-		SET token = $1, started_at = statement_timestamp(), status = 'running'
+		SET token = $1, started_at = clock_timestamp(), status = 'running'
 		WHERE id = (
 		  SELECT id
 		  FROM ready_tasks
@@ -44,19 +44,6 @@ const (
 		  FOR UPDATE SKIP LOCKED
 		)
 		RETURNING ` + taskInfoReturning
-
-	//nolint:unused,deadcode,varcheck
-	sqlDequeueByID = `
-		UPDATE tasks
-		SET token = $1, started_at = statement_timestamp()
-		WHERE id = (
-		  SELECT id
-		  FROM ready_tasks
-		  WHERE id = $2
-		  LIMIT 1
-		  FOR UPDATE SKIP LOCKED
-		)
-		RETURNING token, type, payload, queued_at, started_at`
 
 	sqlRequeue = `
 		UPDATE tasks


### PR DESCRIPTION
## Summary

statement_timestamp() calculates the timestamp of when the statement starts.  I suspect that a new task is being added while this query is executing in rare cases (but don't actually have much evidence for this).  By using clock_timestamp(), we could (in theory) ensure that the started_at is always set after the queued_at is set.

We'll probably have to commit this and monitor errors for a couple weeks to see if its still occuring.

## Testing steps

tests pass