### PR TITLE
Fixes 4666: lookup content sets instead of listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.37.5
 	github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2 v2.15.2
 	github.com/cloudevents/sdk-go/v2 v2.15.2
-	github.com/content-services/caliri/release/v4 v4.4.9
+	github.com/content-services/caliri/release/v4 v4.4.15
 	github.com/content-services/zest/release/v2024 v2024.8.1723836162
 	github.com/getsentry/sentry-go v0.28.1
 	github.com/jackc/pgx-zerolog v0.0.0-20230315001418-f978528409eb

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/cloudflare/circl v1.3.9 h1:QFrlgFYf2Qpi8bSpVPK1HBvWpx16v/1TZivyo7pGuB
 github.com/cloudflare/circl v1.3.9/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZFnBQS5QU=
 github.com/content-services/caliri/release/v4 v4.4.9 h1:wC74+2h3U+X3ZP0gkF3lITZpNvb5Sq7R84GE/O4GCNY=
 github.com/content-services/caliri/release/v4 v4.4.9/go.mod h1:+FDRCiyWWdfd8mYmbXOjHkbInwlZXp+cqfABEcEdF7o=
+github.com/content-services/caliri/release/v4 v4.4.15 h1:5AF11V6yWcuOG0oaLa5FeeLRDhRTR0YkES6A131Knhg=
+github.com/content-services/caliri/release/v4 v4.4.15/go.mod h1:+FDRCiyWWdfd8mYmbXOjHkbInwlZXp+cqfABEcEdF7o=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
 github.com/content-services/tang v0.0.8 h1:mOFTj95cs9O4owWRyfDETgag2Q1ZL5sgMAk9qHK2l/U=

--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -265,6 +265,36 @@ func (_m *MockCandlepinClient) FetchContent(ctx context.Context, orgID string, r
 	return r0, r1
 }
 
+// FetchContentByLabel provides a mock function with given fields: ctx, orgID, labels
+func (_m *MockCandlepinClient) FetchContentByLabel(ctx context.Context, orgID string, labels string) (*caliri.ContentDTO, error) {
+	ret := _m.Called(ctx, orgID, labels)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchContentByLabel")
+	}
+
+	var r0 *caliri.ContentDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*caliri.ContentDTO, error)); ok {
+		return rf(ctx, orgID, labels)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *caliri.ContentDTO); ok {
+		r0 = rf(ctx, orgID, labels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*caliri.ContentDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, orgID, labels)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchContentOverrides provides a mock function with given fields: ctx, templateUUID
 func (_m *MockCandlepinClient) FetchContentOverrides(ctx context.Context, templateUUID string) ([]caliri.ContentOverrideDTO, error) {
 	ret := _m.Called(ctx, templateUUID)
@@ -318,6 +348,36 @@ func (_m *MockCandlepinClient) FetchContentOverridesForRepo(ctx context.Context,
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
 		r1 = rf(ctx, templateUUID, label)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// FetchContentsByLabel provides a mock function with given fields: ctx, orgID, labels
+func (_m *MockCandlepinClient) FetchContentsByLabel(ctx context.Context, orgID string, labels []string) ([]caliri.ContentDTO, error) {
+	ret := _m.Called(ctx, orgID, labels)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchContentsByLabel")
+	}
+
+	var r0 []caliri.ContentDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string) ([]caliri.ContentDTO, error)); ok {
+		return rf(ctx, orgID, labels)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string) []caliri.ContentDTO); ok {
+		r0 = rf(ctx, orgID, labels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]caliri.ContentDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
+		r1 = rf(ctx, orgID, labels)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/candlepin_client/content.go
+++ b/pkg/candlepin_client/content.go
@@ -2,7 +2,6 @@ package candlepin_client
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	caliri "github.com/content-services/caliri/release/v4"
@@ -29,7 +28,7 @@ func (c *cpClientImpl) ListContents(ctx context.Context, orgID string) ([]string
 		defer httpResp.Body.Close()
 	}
 	if err != nil {
-		return labels, ids, fmt.Errorf("could not fetch contents for owner %w", err)
+		return labels, ids, errorWithResponseBody("could not fetch contents for owner", httpResp, err)
 	}
 
 	for _, c := range contents {

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -26,6 +26,7 @@ type CandlepinClient interface {
 	AddContentBatchToProduct(ctx context.Context, orgID string, contentIDs []string) error
 	UpdateContent(ctx context.Context, orgID string, repoConfigUUID string, content caliri.ContentDTO) error
 	FetchContent(ctx context.Context, orgID string, repoConfigUUID string) (*caliri.ContentDTO, error)
+	FetchContentsByLabel(ctx context.Context, orgID string, labels []string) ([]caliri.ContentDTO, error)
 	DeleteContent(ctx context.Context, ownerKey string, repoConfigUUID string) error
 
 	// Environments


### PR DESCRIPTION
## Summary

The newer version of candlepin limits the number of content sets returned and errors if more than 3000 are returned. 
Candlepin does support  paging, but these options are not exposed in the api spec for reasons.
We really don't need to list them all, so this changes it to fetch the contet sets by label (which is a new feature)

## Testing steps

Create a content template with some subset of rhel 9 repos and a custom repo.  Verify that a client sees just those pieces of content (or check the db and verify that the  cp_environment_content table in candlepin has what is expected

