### PR TITLE
Fixes 4672: on AddUploads add task to last_snapshot

### DIFF
--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -169,6 +169,13 @@ func mockTaskClientEnqueueAddUploads(repoSuite *ReposSuite, repo api.RepositoryR
 		ObjectType: utils.Ptr(config.ObjectTypeRepository),
 		Priority:   0,
 	}).Return(nil, nil)
+	repoSuite.reg.RepositoryConfig.On(
+		"UpdateLastSnapshotTask",
+		test.MockCtx(),
+		"00000000-0000-0000-0000-000000000000",
+		repo.OrgID,
+		repo.RepositoryUUID,
+	).Return(nil)
 }
 
 func mockSnapshotDeleteEvent(tcMock *client.MockTaskClient, repoConfigUUID string) {


### PR DESCRIPTION
## Summary

Adds the AddUploads task as the last_snapshot on the repository

## Testing steps

1.  create an upload repository


2. using its uuid, upload an rpm to it:
```
IDENTITY_HEADER="eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==" python ./scripts/uploads.py  30d60f06-b45d-44fa-aece-869d55edf002  ~/rpms/zebra-0.1-2.noarch.rpm 
```

3.  Fetch the repository and see a new last_snapshot_task

