### PR TITLE
Refs 4540: prevent requeue on exit for canceled task

### DIFF
--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -484,11 +484,7 @@ func (p *PgQueue) Finish(taskId uuid.UUID, taskError error) error {
 	var status string
 	var errMsg *string
 	if taskError != nil {
-		if errors.Is(taskError, context.Canceled) {
-			status = config.TaskStatusCanceled
-		} else {
-			status = config.TaskStatusFailed
-		}
+		status = config.TaskStatusFailed
 		s := strings.ToValidUTF8(taskError.Error(), "")
 		errMsg = &s
 	} else {
@@ -542,7 +538,7 @@ func (p *PgQueue) Finish(taskId uuid.UUID, taskError error) error {
 		return fmt.Errorf("error finishing task %s: %w", taskId, err)
 	}
 
-	if status == config.TaskStatusFailed || status == config.TaskStatusCanceled {
+	if status == config.TaskStatusFailed {
 		dependents, err := p.taskDependents(context.Background(), tx.Conn(), taskId)
 		if err != nil {
 			return fmt.Errorf("error fetching task dependents: %w", err)

--- a/pkg/tasks/worker/worker.go
+++ b/pkg/tasks/worker/worker.go
@@ -178,6 +178,7 @@ func (w *worker) process(ctx context.Context, taskInfo *models.TaskInfo) {
 		if errors.Is(handlerErr, context.Canceled) {
 			w.recordMessageResult(true)
 			w.runningTask.taskCancelFunc(queue.ErrNotRunning)
+			w.runningTask.clear()
 			w.readyChan <- struct{}{}
 			return
 		}


### PR DESCRIPTION
## Summary
It was still possible for a canceled task to get requeued on server exit. This fixes that.

It shouldn't be possible for the HeartbeatListener() method to requeue canceled tasks because heartbeats are removed as part of canceling the task. But if this fix doesn't work, that's the next place to look. 

## Testing steps
1. Create and immediately delete a template. Need to replace repository uuid in create request below.

```
UUID=`curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/templates/"     -H "x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxNzc5MTU2MCIsICJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJzbmFwVXNlciJ9LCJhY2NvdW50X251bWJlciI6IjE3NzkxNTYwIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTc3OTE1NjAifX19Cg=="     -H "Content-Type: application/json"     -d "{
          \"name\":\"test-$RANDOM\",
          \"arch\": \"x86_64\",
          \"version\": \"9\",
          \"repository_uuids\": [\"2f859dec-184b-48d4-9451-140a2336ce4d\"],
          \"date\": \"2024-08-09T14:04:05Z\"
        }"  | jq .uuid`


curl -X DELETE --location "http://localhost:8000/api/content-sources/v1.0/templates/$UUID"     -H "x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxNzc5MTU2MCIsICJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJzbmFwVXNlciJ9LCJhY2NvdW50X251bWJlciI6IjE3NzkxNTYwIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTc3OTE1NjAifX19Cg=="
```
2. CTRL+C exit the server. Before these changes, the update-template-content task would get requeued.