### PR TITLE
Fixes 4692: pass org id to FetchContentsByLabel

### DIFF
--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -588,7 +588,7 @@ func (t *UpdateTemplateContent) getRedHatContentIDs(rhRepos []api.RepositoryResp
 	for _, rhRepo := range rhRepos {
 		labels = append(labels, rhRepo.Label)
 	}
-	contents, err := t.cpClient.FetchContentsByLabel(t.ctx, t.payload.TemplateUUID, labels)
+	contents, err := t.cpClient.FetchContentsByLabel(t.ctx, t.orgId, labels)
 	if err != nil {
 		return []string{}, err
 	}


### PR DESCRIPTION
## Summary

FetchContentsByLabel takes an orgID not a templateID.  This wasn't detected in dev because the ID passed in isn't used, instead a global org ID is used.  

There isn't a test for this and right now, its not easily testable.   Proper testing in stage would have caught it, and i've opened this issue to try to come up with a better test 

## Testing steps



