### PR TITLE
Fixes 4644: task info response shows template name and uuid

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2373,6 +2373,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "A unique identifier of a template to filter the results.",
+                        "name": "template_uuid",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "A flag to exclude tasks for the red hat org from the query.",
                         "name": "exclude_red_hat_org",

--- a/api/docs.go
+++ b/api/docs.go
@@ -4256,16 +4256,20 @@ const docTemplate = `{
                     "description": "Error thrown while running task",
                     "type": "string"
                 },
+                "object_name": {
+                    "description": "Name of the associated repository or template",
+                    "type": "string"
+                },
+                "object_type": {
+                    "description": "Type of the associated object, either repository or template",
+                    "type": "string"
+                },
+                "object_uuid": {
+                    "description": "UUID of the associated repository or template",
+                    "type": "string"
+                },
                 "org_id": {
                     "description": "Organization ID of the owner",
-                    "type": "string"
-                },
-                "repository_name": {
-                    "description": "Name of the associated repository",
-                    "type": "string"
-                },
-                "repository_uuid": {
-                    "description": "UUID of the associated repository",
                     "type": "string"
                 },
                 "status": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1111,16 +1111,20 @@
                         "description": "Error thrown while running task",
                         "type": "string"
                     },
+                    "object_name": {
+                        "description": "Name of the associated repository or template",
+                        "type": "string"
+                    },
+                    "object_type": {
+                        "description": "Type of the associated object, either repository or template",
+                        "type": "string"
+                    },
+                    "object_uuid": {
+                        "description": "UUID of the associated repository or template",
+                        "type": "string"
+                    },
                     "org_id": {
                         "description": "Organization ID of the owner",
-                        "type": "string"
-                    },
-                    "repository_name": {
-                        "description": "Name of the associated repository",
-                        "type": "string"
-                    },
-                    "repository_uuid": {
-                        "description": "UUID of the associated repository",
                         "type": "string"
                     },
                     "status": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4476,6 +4476,14 @@
                         }
                     },
                     {
+                        "description": "A unique identifier of a template to filter the results.",
+                        "in": "query",
+                        "name": "template_uuid",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "A flag to exclude tasks for the red hat org from the query.",
                         "in": "query",
                         "name": "exclude_red_hat_org",

--- a/pkg/api/task_info.go
+++ b/pkg/api/task_info.go
@@ -2,15 +2,16 @@ package api
 
 // TaskInfoResponse holds data returned by a tasks API response
 type TaskInfoResponse struct {
-	UUID           string   `json:"uuid"`                   // UUID of the object
-	Status         string   `json:"status"`                 // Status of task (running, failed, completed, canceled, pending)
-	CreatedAt      string   `json:"created_at"`             // Timestamp of task creation
-	EndedAt        string   `json:"ended_at"`               // Timestamp task ended running at
-	Error          string   `json:"error"`                  // Error thrown while running task
-	OrgId          string   `json:"org_id"`                 // Organization ID of the owner
-	Typename       string   `json:"type"`                   // Type of task
-	RepoConfigName string   `json:"repository_name"`        // Name of the associated repository
-	RepoConfigUUID string   `json:"repository_uuid"`        // UUID of the associated repository
+	UUID         string   `json:"uuid"`         // UUID of the object
+	Status       string   `json:"status"`       // Status of task (running, failed, completed, canceled, pending)
+	CreatedAt    string   `json:"created_at"`   // Timestamp of task creation
+	EndedAt      string   `json:"ended_at"`     // Timestamp task ended running at
+	Error        string   `json:"error"`        // Error thrown while running task
+	OrgId        string   `json:"org_id"`       // Organization ID of the owner
+	Typename     string   `json:"type"`         // Type of task
+	ObjectType   string   `json:"object_type"`  // Type of the associated object, either repository or template
+	ObjectName   string   `json:"object_name"`  // Name of the associated repository or template
+	ObjectUUID   string   `json:"object_uuid"`  // UUID of the associated repository or template
 	Dependencies   []string `json:"dependencies,omitempty"` // UUIDs of parent tasks
 	Dependents     []string `json:"dependents,omitempty"`   // UUIDs of child tasks
 }

--- a/pkg/api/task_info.go
+++ b/pkg/api/task_info.go
@@ -2,18 +2,18 @@ package api
 
 // TaskInfoResponse holds data returned by a tasks API response
 type TaskInfoResponse struct {
-	UUID         string   `json:"uuid"`         // UUID of the object
-	Status       string   `json:"status"`       // Status of task (running, failed, completed, canceled, pending)
-	CreatedAt    string   `json:"created_at"`   // Timestamp of task creation
-	EndedAt      string   `json:"ended_at"`     // Timestamp task ended running at
-	Error        string   `json:"error"`        // Error thrown while running task
-	OrgId        string   `json:"org_id"`       // Organization ID of the owner
-	Typename     string   `json:"type"`         // Type of task
-	ObjectType   string   `json:"object_type"`  // Type of the associated object, either repository or template
-	ObjectName   string   `json:"object_name"`  // Name of the associated repository or template
-	ObjectUUID   string   `json:"object_uuid"`  // UUID of the associated repository or template
-	Dependencies   []string `json:"dependencies,omitempty"` // UUIDs of parent tasks
-	Dependents     []string `json:"dependents,omitempty"`   // UUIDs of child tasks
+	UUID         string   `json:"uuid"`                   // UUID of the object
+	Status       string   `json:"status"`                 // Status of task (running, failed, completed, canceled, pending)
+	CreatedAt    string   `json:"created_at"`             // Timestamp of task creation
+	EndedAt      string   `json:"ended_at"`               // Timestamp task ended running at
+	Error        string   `json:"error"`                  // Error thrown while running task
+	OrgId        string   `json:"org_id"`                 // Organization ID of the owner
+	Typename     string   `json:"type"`                   // Type of task
+	ObjectType   string   `json:"object_type"`            // Type of the associated object, either repository or template
+	ObjectName   string   `json:"object_name"`            // Name of the associated repository or template
+	ObjectUUID   string   `json:"object_uuid"`            // UUID of the associated repository or template
+	Dependencies []string `json:"dependencies,omitempty"` // UUIDs of parent tasks
+	Dependents   []string `json:"dependents,omitempty"`   // UUIDs of child tasks
 }
 
 type TaskInfoCollectionResponse struct {

--- a/pkg/api/task_info.go
+++ b/pkg/api/task_info.go
@@ -31,5 +31,6 @@ type TaskInfoFilterData struct {
 	Status           string `query:"status" json:"status"`
 	Typename         string `query:"type" json:"type"`
 	RepoConfigUUID   string `query:"repository_uuid" json:"repository_uuid"`
+	TemplateUUID     string `query:"template_uuid" json:"template_uuid"`
 	ExcludeRedHatOrg bool   `json:"exclude_red_hat_org"`
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -918,12 +918,13 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 	apiRepo.LastSnapshotTaskUUID = repoConfig.LastSnapshotTaskUUID
 	if repoConfig.LastSnapshotTask != nil {
 		apiRepo.LastSnapshotTask = &api.TaskInfoResponse{
-			UUID:           repoConfig.LastSnapshotTaskUUID,
-			Status:         repoConfig.LastSnapshotTask.Status,
-			Typename:       repoConfig.LastSnapshotTask.Typename,
-			OrgId:          repoConfig.LastSnapshotTask.OrgId,
-			RepoConfigUUID: repoConfig.UUID,
-			RepoConfigName: repoConfig.Name,
+			UUID:         repoConfig.LastSnapshotTaskUUID,
+			Status:       repoConfig.LastSnapshotTask.Status,
+			Typename:     repoConfig.LastSnapshotTask.Typename,
+			OrgId:        repoConfig.LastSnapshotTask.OrgId,
+			ObjectType:   config.ObjectTypeRepository,
+			ObjectUUID:   repoConfig.UUID,
+			ObjectName:   repoConfig.Name,
 		}
 		if repoConfig.LastSnapshotTask.Started != nil {
 			apiRepo.LastSnapshotTask.CreatedAt = repoConfig.LastSnapshotTask.Started.Format(time.RFC3339)

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -918,13 +918,13 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 	apiRepo.LastSnapshotTaskUUID = repoConfig.LastSnapshotTaskUUID
 	if repoConfig.LastSnapshotTask != nil {
 		apiRepo.LastSnapshotTask = &api.TaskInfoResponse{
-			UUID:         repoConfig.LastSnapshotTaskUUID,
-			Status:       repoConfig.LastSnapshotTask.Status,
-			Typename:     repoConfig.LastSnapshotTask.Typename,
-			OrgId:        repoConfig.LastSnapshotTask.OrgId,
-			ObjectType:   config.ObjectTypeRepository,
-			ObjectUUID:   repoConfig.UUID,
-			ObjectName:   repoConfig.Name,
+			UUID:       repoConfig.LastSnapshotTaskUUID,
+			Status:     repoConfig.LastSnapshotTask.Status,
+			Typename:   repoConfig.LastSnapshotTask.Typename,
+			OrgId:      repoConfig.LastSnapshotTask.OrgId,
+			ObjectType: config.ObjectTypeRepository,
+			ObjectUUID: repoConfig.UUID,
+			ObjectName: repoConfig.Name,
 		}
 		if repoConfig.LastSnapshotTask.Started != nil {
 			apiRepo.LastSnapshotTask.CreatedAt = repoConfig.LastSnapshotTask.Started.Format(time.RFC3339)

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -99,7 +99,15 @@ func (t taskInfoDaoImpl) List(
 	}
 
 	if filterData.RepoConfigUUID != "" {
-		filteredDB = filteredDB.Where("rc.uuid = ?", UuidifyString(filterData.RepoConfigUUID))
+		query := "rc.uuid = ?"
+		args := []interface{}{UuidifyString(filterData.RepoConfigUUID)}
+		if filterData.TemplateUUID != "" {
+			query = fmt.Sprintf("%s OR templates.uuid = ?", query)
+			args = append(args, UuidifyString(filterData.TemplateUUID))
+		}
+		filteredDB = filteredDB.Where(query, args...)
+	} else if filterData.TemplateUUID != "" {
+		filteredDB = filteredDB.Where("templates.uuid = ?", UuidifyString(filterData.TemplateUUID))
 	}
 
 	// First get count

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -51,7 +51,7 @@ func (t taskInfoDaoImpl) Fetch(ctx context.Context, orgID string, id string) (ap
 	result := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.object_uuid = rc.repository_uuid AND rc.org_id = ? and t.object_type = ?", orgID, config.ObjectTypeRepository).
-		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id in (?)", config.ObjectTypeTemplate, []string{config.RedHatOrg, orgID}).
+		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id = ?", config.ObjectTypeTemplate, orgID).
 		Joins("LEFT JOIN task_dependencies td on t.id = td.dependency_id").
 		Where("t.id = ? AND t.org_id in (?) AND rc.deleted_at is NULL", UuidifyString(id), []string{config.RedHatOrg, orgID}).First(&taskInfo)
 
@@ -87,7 +87,7 @@ func (t taskInfoDaoImpl) List(
 	filteredDB := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.object_uuid = rc.repository_uuid AND t.object_type = ? AND rc.org_id in (?)", config.ObjectTypeRepository, []string{config.RedHatOrg, orgID}).
-		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id in (?)", config.ObjectTypeTemplate, []string{config.RedHatOrg, orgID}).
+		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id = ?", config.ObjectTypeTemplate, orgID).
 		Where("t.org_id in (?) AND rc.deleted_at is NULL", orgsForQuery)
 
 	if filterData.Status != "" {

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -18,6 +18,7 @@ const JoinSelectQuery = ` t.id,
        t.payload,
        t.org_id,
        t.object_uuid,
+	   t.object_type,
        t.token,
        t.queued_at,
        t.started_at,
@@ -27,6 +28,8 @@ const JoinSelectQuery = ` t.id,
        t.request_id,
        rc.uuid as rc_uuid,
        rc.name as rc_name,
+       templates.uuid as template_uuid,
+	   templates.name as template_name,
        ARRAY (SELECT td.dependency_id FROM task_dependencies td WHERE td.task_id = t.id) as t_dependencies,
        ARRAY (SELECT td.task_id FROM task_dependencies td WHERE td.dependency_id = t.id) as t_dependents
 `
@@ -48,6 +51,7 @@ func (t taskInfoDaoImpl) Fetch(ctx context.Context, orgID string, id string) (ap
 	result := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.object_uuid = rc.repository_uuid AND rc.org_id = ? and t.object_type = ?", orgID, config.ObjectTypeRepository).
+		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id in (?)", config.ObjectTypeTemplate, []string{config.RedHatOrg, orgID}).
 		Joins("LEFT JOIN task_dependencies td on t.id = td.dependency_id").
 		Where("t.id = ? AND t.org_id in (?) AND rc.deleted_at is NULL", UuidifyString(id), []string{config.RedHatOrg, orgID}).First(&taskInfo)
 
@@ -83,6 +87,7 @@ func (t taskInfoDaoImpl) List(
 	filteredDB := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.object_uuid = rc.repository_uuid AND t.object_type = ? AND rc.org_id in (?)", config.ObjectTypeRepository, []string{config.RedHatOrg, orgID}).
+		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id in (?)", config.ObjectTypeTemplate, []string{config.RedHatOrg, orgID}).
 		Where("t.org_id in (?) AND rc.deleted_at is NULL", orgsForQuery)
 
 	if filterData.Status != "" {
@@ -163,10 +168,21 @@ func taskInfoModelToApiFields(taskInfo *models.TaskInfoRepositoryConfiguration, 
 	apiTaskInfo.OrgId = taskInfo.OrgId
 	apiTaskInfo.Status = taskInfo.Status
 	apiTaskInfo.Typename = taskInfo.Typename
-	apiTaskInfo.RepoConfigUUID = taskInfo.RepositoryConfigUUID
-	apiTaskInfo.RepoConfigName = taskInfo.RepositoryConfigName
 	apiTaskInfo.Dependencies = taskInfo.Dependencies
 	apiTaskInfo.Dependents = taskInfo.Dependents
+
+	if taskInfo.ObjectType != nil {
+		switch *taskInfo.ObjectType {
+		case config.ObjectTypeTemplate:
+			apiTaskInfo.ObjectType = *taskInfo.ObjectType
+			apiTaskInfo.ObjectUUID = taskInfo.TemplateUUID
+			apiTaskInfo.ObjectName = taskInfo.TemplateName
+		case config.ObjectTypeRepository:
+			apiTaskInfo.ObjectType = *taskInfo.ObjectType
+			apiTaskInfo.ObjectUUID = taskInfo.RepositoryConfigUUID
+			apiTaskInfo.ObjectName = taskInfo.RepositoryConfigName
+		}
+	}
 
 	if taskInfo.Error != nil {
 		apiTaskInfo.Error = *taskInfo.Error

--- a/pkg/handler/task_info.go
+++ b/pkg/handler/task_info.go
@@ -49,6 +49,7 @@ func RegisterTaskInfoRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, taskCli
 // @Param		 status query string false "A comma separated list of statuses to control response. Statuses can include `running`, `completed`, `failed`."
 // @Param 		 type query string false "Filter results based on a specific task types. Helps to narrow down the results to a specific type. Task types can be `snapshot` or `introspect`. "
 // @Param 		 repository_uuid query string false "A unique identifier of a repository to filter the results."
+// @Param 		 template_uuid query string false "A unique identifier of a template to filter the results."
 // @Param 		 exclude_red_hat_org query bool false "A flag to exclude tasks for the red hat org from the query."
 // @Accept       json
 // @Produce      json
@@ -123,12 +124,14 @@ func ParseTaskInfoFilters(c echo.Context) api.TaskInfoFilterData {
 		Status:         "",
 		Typename:       "",
 		RepoConfigUUID: "",
+		TemplateUUID:   "",
 	}
 
 	err := echo.QueryParamsBinder(c).
 		String("status", &filterData.Status).
 		String("type", &filterData.Typename).
 		String("repository_uuid", &filterData.RepoConfigUUID).
+		String("template_uuid", &filterData.TemplateUUID).
 		Bool("exclude_red_hat_org", &filterData.ExcludeRedHatOrg).
 		BindError()
 

--- a/pkg/handler/task_info_test.go
+++ b/pkg/handler/task_info_test.go
@@ -355,14 +355,15 @@ func (suite *TaskInfoSuite) TestFetch() {
 
 	uuid := "abcadaba"
 	task := api.TaskInfoResponse{
-		UUID:           uuid,
-		Status:         "status",
-		CreatedAt:      time.Now().Format(time.RFC3339),
-		EndedAt:        time.Now().Format(time.RFC3339),
-		Error:          "error",
-		OrgId:          "org id",
-		RepoConfigUUID: "abc",
-		RepoConfigName: "repo1",
+		UUID:       uuid,
+		Status:     "status",
+		CreatedAt:  time.Now().Format(time.RFC3339),
+		EndedAt:    time.Now().Format(time.RFC3339),
+		Error:      "error",
+		OrgId:      "org id",
+		ObjectType: config.ObjectTypeRepository,
+		ObjectUUID: "abc",
+		ObjectName: "repo1",
 	}
 
 	suite.reg.TaskInfo.On("Fetch", test.MockCtx(), test_handler.MockOrgId, uuid).Return(task, nil)
@@ -393,14 +394,15 @@ func (suite *TaskInfoSuite) TestFetchNotFound() {
 
 	uuid := "abcadaba"
 	task := api.TaskInfoResponse{
-		UUID:           uuid,
-		Status:         "status",
-		CreatedAt:      time.Now().Format(time.RFC3339),
-		EndedAt:        time.Now().Format(time.RFC3339),
-		Error:          "error",
-		OrgId:          "org id",
-		RepoConfigUUID: "abc",
-		RepoConfigName: "repo1",
+		UUID:       uuid,
+		Status:     "status",
+		CreatedAt:  time.Now().Format(time.RFC3339),
+		EndedAt:    time.Now().Format(time.RFC3339),
+		Error:      "error",
+		OrgId:      "org id",
+		ObjectType: config.ObjectTypeRepository,
+		ObjectUUID: "abc",
+		ObjectName: "repo1",
 	}
 
 	daoError := ce.DaoError{

--- a/pkg/models/task_info.go
+++ b/pkg/models/task_info.go
@@ -36,6 +36,8 @@ type TaskInfoRepositoryConfiguration struct {
 	*TaskInfo
 	RepositoryConfigUUID string `gorm:"column:rc_uuid"`
 	RepositoryConfigName string `gorm:"column:rc_name"`
+	TemplateUUID         string `gorm:"column:template_uuid"`
+	TemplateName         string `gorm:"column:template_name"`
 }
 
 func (*TaskInfo) TableName() string {


### PR DESCRIPTION
## Summary
For tasks relating to templates it doesn't make sense to use the `repository_name` and `repository_uuid` fields, so this PR changes those to `object_name` and `object_uuid` and a new field `object_type` which distinguishes to which type of object (`"repository" || "template"`) they are associated to.

## Testing steps
1. Create a repository and a template.
2. List tasks with `GET /api/content-sources/v1.0/tasks/`.
3. Verify the `object_*` fields are present and correct.
