### PR TITLE
Fixes 4185: retain systems when deleting template

### DIFF
--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -51,6 +51,36 @@ func (_m *MockCandlepinClient) AssociateEnvironment(ctx context.Context, orgID s
 	return r0
 }
 
+// CreateConsumer provides a mock function with given fields: ctx, orgID, name
+func (_m *MockCandlepinClient) CreateConsumer(ctx context.Context, orgID string, name string) (*caliri.ConsumerDTO, error) {
+	ret := _m.Called(ctx, orgID, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConsumer")
+	}
+
+	var r0 *caliri.ConsumerDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*caliri.ConsumerDTO, error)); ok {
+		return rf(ctx, orgID, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *caliri.ConsumerDTO); ok {
+		r0 = rf(ctx, orgID, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*caliri.ConsumerDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, orgID, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateContent provides a mock function with given fields: ctx, orgID, content
 func (_m *MockCandlepinClient) CreateContent(ctx context.Context, orgID string, content caliri.ContentDTO) error {
 	ret := _m.Called(ctx, orgID, content)
@@ -181,6 +211,24 @@ func (_m *MockCandlepinClient) CreateProduct(ctx context.Context, orgID string) 
 	return r0
 }
 
+// DeleteConsumer provides a mock function with given fields: ctx, consumerUUID
+func (_m *MockCandlepinClient) DeleteConsumer(ctx context.Context, consumerUUID string) error {
+	ret := _m.Called(ctx, consumerUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteConsumer")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, consumerUUID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteContent provides a mock function with given fields: ctx, ownerKey, repoConfigUUID
 func (_m *MockCandlepinClient) DeleteContent(ctx context.Context, ownerKey string, repoConfigUUID string) error {
 	ret := _m.Called(ctx, ownerKey, repoConfigUUID)
@@ -235,6 +283,36 @@ func (_m *MockCandlepinClient) DemoteContentFromEnvironment(ctx context.Context,
 	return r0
 }
 
+// FetchConsumer provides a mock function with given fields: ctx, consumerUUID
+func (_m *MockCandlepinClient) FetchConsumer(ctx context.Context, consumerUUID string) (*caliri.ConsumerDTO, error) {
+	ret := _m.Called(ctx, consumerUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchConsumer")
+	}
+
+	var r0 *caliri.ConsumerDTO
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*caliri.ConsumerDTO, error)); ok {
+		return rf(ctx, consumerUUID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *caliri.ConsumerDTO); ok {
+		r0 = rf(ctx, consumerUUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*caliri.ConsumerDTO)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, consumerUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FetchContent provides a mock function with given fields: ctx, orgID, repoConfigUUID
 func (_m *MockCandlepinClient) FetchContent(ctx context.Context, orgID string, repoConfigUUID string) (*caliri.ContentDTO, error) {
 	ret := _m.Called(ctx, orgID, repoConfigUUID)
@@ -258,36 +336,6 @@ func (_m *MockCandlepinClient) FetchContent(ctx context.Context, orgID string, r
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
 		r1 = rf(ctx, orgID, repoConfigUUID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// FetchContentByLabel provides a mock function with given fields: ctx, orgID, labels
-func (_m *MockCandlepinClient) FetchContentByLabel(ctx context.Context, orgID string, labels string) (*caliri.ContentDTO, error) {
-	ret := _m.Called(ctx, orgID, labels)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FetchContentByLabel")
-	}
-
-	var r0 *caliri.ContentDTO
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*caliri.ContentDTO, error)); ok {
-		return rf(ctx, orgID, labels)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *caliri.ContentDTO); ok {
-		r0 = rf(ctx, orgID, labels)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*caliri.ContentDTO)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, orgID, labels)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/candlepin_client/consumer.go
+++ b/pkg/candlepin_client/consumer.go
@@ -1,0 +1,70 @@
+package candlepin_client
+
+import (
+	"context"
+	"net/http"
+
+	caliri "github.com/content-services/caliri/release/v4"
+	"github.com/content-services/content-sources-backend/pkg/utils"
+)
+
+func (c *cpClientImpl) CreateConsumer(ctx context.Context, orgID string, name string) (*caliri.ConsumerDTO, error) {
+	ctx, client, err := getCandlepinClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	consumerDTO := caliri.ConsumerDTO{
+		Name: utils.Ptr(name),
+		Type: &caliri.ConsumerTypeDTO{
+			Label: utils.Ptr("system"),
+		},
+	}
+	consumer, httpResp, err := client.ConsumerAPI.CreateConsumer(ctx).Owner(OwnerKey(orgID)).ConsumerDTO(consumerDTO).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return nil, errorWithResponseBody("couldn't create consumer", httpResp, err)
+	}
+	return consumer, nil
+}
+
+func (c *cpClientImpl) FetchConsumer(ctx context.Context, consumerUUID string) (*caliri.ConsumerDTO, error) {
+	ctx, client, err := getCandlepinClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	consumer, httpResp, err := client.ConsumerAPI.GetConsumer(ctx, consumerUUID).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, errorWithResponseBody("couldn't list consumers", httpResp, err)
+	}
+
+	return consumer, nil
+}
+
+func (c *cpClientImpl) DeleteConsumer(ctx context.Context, consumerUUID string) error {
+	ctx, client, err := getCandlepinClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	httpResp, err := client.ConsumerAPI.DeleteConsumer(ctx, consumerUUID).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && (httpResp.StatusCode == http.StatusNotFound || httpResp.StatusCode == http.StatusGone) {
+			return nil
+		}
+		return errorWithResponseBody("couldn't delete consumer", httpResp, err)
+	}
+	return nil
+}

--- a/pkg/candlepin_client/environment.go
+++ b/pkg/candlepin_client/environment.go
@@ -193,12 +193,12 @@ func (c *cpClientImpl) DeleteEnvironment(ctx context.Context, templateUUID strin
 		return err
 	}
 
-	httpResp, err := client.EnvironmentAPI.DeleteEnvironment(ctx, GetEnvironmentID(templateUUID)).Execute()
+	httpResp, err := client.EnvironmentAPI.DeleteEnvironment(ctx, GetEnvironmentID(templateUUID)).RetainConsumers(true).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
 	if err != nil {
-		if httpResp.StatusCode == 404 {
+		if httpResp != nil && httpResp.StatusCode == 404 {
 			return nil
 		}
 		return errorWithResponseBody("couldn't delete environment", httpResp, err)

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -42,4 +42,9 @@ type CandlepinClient interface {
 	RemoveContentOverrides(ctx context.Context, templateUUID string, toRemove []caliri.ContentOverrideDTO) error
 	DeleteEnvironment(ctx context.Context, templateUUID string) error
 	RenameEnvironment(ctx context.Context, templateUUID, name string) (*caliri.EnvironmentDTO, error)
+
+	// Consumers
+	CreateConsumer(ctx context.Context, orgID string, name string) (*caliri.ConsumerDTO, error)
+	FetchConsumer(ctx context.Context, consumerUUID string) (*caliri.ConsumerDTO, error)
+	DeleteConsumer(ctx context.Context, consumerUUID string) error
 }


### PR DESCRIPTION
## Summary
When deleting a template, consumers associated to that template will not be deleted.

## Testing steps
1. Create a template
2. Create a consumer
```
curl -X POST --location "http://localhost:8181/candlepin/consumers/?owner=content-sources-test" \
    -H "Content-Type: application/json" \
    -H "Authorization: Basic YWRtaW46YWRtaW4=" \
    -d '{
          "name": "example-consumer",
          "type": {
            "label": "system"
          }
        }'
```
3. Associate the consumer to the template
```
go run cmd/candlepin/main.go add-system <consumer uuid> <template name>
```
4. Delete the template
5. Check that the consumer still exists
```
curl -X GET --location "http://localhost:8181/candlepin/consumers?owner=content-sources-test" \
    -H "Content-Type: application/json" \
    -H "Authorization: Basic YWRtaW46YWRtaW4="
```

You could also test this by
1. Create a template
2. Register a RHEL9 VM to the template as described in [register_client.md](https://github.com/content-services/content-sources-backend/blob/main/docs/register_client.md)
3. Delete the template
4. The system will still have the content until you refresh, afterwards the content would be gone.
5. If you associate a new template to the system and refresh, it will have the new template's content
