### PR TITLE
Fixes 4712: add content override for sslverifystatus

### DIFF
--- a/pkg/candlepin_client/content.go
+++ b/pkg/candlepin_client/content.go
@@ -9,6 +9,7 @@ import (
 
 const OverrideNameBaseUrl = "baseurl"
 const OverrideNameCaCert = "sslcacert"
+const OverrideSSLVerifyStatus = "sslverifystatus"
 const OverrideModuleHotfixes = "module_hotfixes"
 
 func GetContentID(repoConfigUUID string) string {

--- a/pkg/tasks/candlepin_helpers.go
+++ b/pkg/tasks/candlepin_helpers.go
@@ -65,6 +65,12 @@ func ContentOverridesForRepo(orgId string, domainName string, templateUUID strin
 		ContentLabel: &repo.Label,
 		Value:        utils.Ptr(" "), // use a single space because candlepin doesn't allow "" or null
 	})
+	// Disable OCSP checking, as aws doesn't support it?
+	mapping = append(mapping, caliri.ContentOverrideDTO{
+		Name:         utils.Ptr(candlepin_client.OverrideSSLVerifyStatus),
+		ContentLabel: &repo.Label,
+		Value:        utils.Ptr("0"),
+	})
 
 	if repo.OrgID == orgId { // Don't override RH repo baseurls
 		distPath := customTemplateSnapshotPath(templateUUID, repo.UUID)

--- a/pkg/tasks/candlepin_helpers_test.go
+++ b/pkg/tasks/candlepin_helpers_test.go
@@ -87,11 +87,16 @@ func (s *CandlepinHelpersTest) TestContentOverridesForRepo() {
 	overrides, err := ContentOverridesForRepo(orgId, domain, templateUUID, pulpContentPath, Repo)
 	assert.NoError(s.T(), err)
 
-	assert.Len(s.T(), overrides, 2)
+	assert.Len(s.T(), overrides, 3)
 	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
 		Name:         utils.Ptr("sslcacert"),
 		ContentLabel: &Repo.Label,
 		Value:        utils.Ptr(" "),
+	})
+	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
+		Name:         utils.Ptr("sslverifystatus"),
+		ContentLabel: &Repo.Label,
+		Value:        utils.Ptr("0"),
 	})
 	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
 		Name:         utils.Ptr("baseurl"),
@@ -102,7 +107,7 @@ func (s *CandlepinHelpersTest) TestContentOverridesForRepo() {
 	Repo.ModuleHotfixes = true
 	overrides, err = ContentOverridesForRepo(orgId, domain, templateUUID, pulpContentPath, Repo)
 	assert.NoError(s.T(), err)
-	assert.Len(s.T(), overrides, 3)
+	assert.Len(s.T(), overrides, 4)
 	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
 		Name:         utils.Ptr("module_hotfixes"),
 		ContentLabel: &Repo.Label,
@@ -112,10 +117,15 @@ func (s *CandlepinHelpersTest) TestContentOverridesForRepo() {
 	Repo.Origin = config.OriginRedHat
 	overrides, err = ContentOverridesForRepo(orgId, domain, templateUUID, pulpContentPath, Repo)
 	assert.NoError(s.T(), err)
-	assert.Len(s.T(), overrides, 1)
+	assert.Len(s.T(), overrides, 2)
 	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
 		Name:         utils.Ptr("sslcacert"),
 		ContentLabel: &Repo.Label,
 		Value:        utils.Ptr(" "),
+	})
+	assert.Contains(s.T(), overrides, caliri.ContentOverrideDTO{
+		Name:         utils.Ptr("sslverifystatus"),
+		ContentLabel: &Repo.Label,
+		Value:        utils.Ptr("0"),
 	})
 }

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -152,6 +152,11 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 		ContentLabel: utils.Ptr(repo1.Label),
 		Value:        utils.Ptr(" "),
 	}
+	repo1VerifyOverride := caliri.ContentOverrideDTO{
+		Name:         utils.Ptr("sslverifystatus"),
+		ContentLabel: utils.Ptr(repo1.Label),
+		Value:        utils.Ptr("0"),
+	}
 
 	repo2UrlOverride := caliri.ContentOverrideDTO{
 		Name:         utils.Ptr("baseurl"),
@@ -162,6 +167,11 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 		Name:         utils.Ptr("sslcacert"),
 		ContentLabel: utils.Ptr(repo2.Label),
 		Value:        utils.Ptr(" "),
+	}
+	repo2VerifyOverride := caliri.ContentOverrideDTO{
+		Name:         utils.Ptr("sslverifystatus"),
+		ContentLabel: utils.Ptr(repo2.Label),
+		Value:        utils.Ptr("0"),
 	}
 
 	// Update template with new repository
@@ -200,7 +210,7 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	}
 	assert.Contains(s.T(), environmentContentIDs, repo1ContentID)
 
-	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride})
+	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride, repo1VerifyOverride})
 
 	// Add new repositories to template
 	updateReq := api.TemplateUpdateRequest{
@@ -237,7 +247,7 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.Contains(s.T(), environmentContentIDs, repo2ContentID)
 	assert.NotContains(s.T(), environmentContentIDs, repo3ContentID)
 
-	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride, repo2UrlOverride, repo2CaOverride})
+	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride, repo1VerifyOverride, repo2UrlOverride, repo2CaOverride, repo2VerifyOverride})
 
 	// Remove 2 repositories from the template
 	updateReq = api.TemplateUpdateRequest{
@@ -273,7 +283,7 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.NotContains(s.T(), environmentContentIDs, repo2ContentID)
 	assert.NotContains(s.T(), environmentContentIDs, repo3ContentID)
 
-	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride})
+	s.AssertOverrides(ctx, environmentID, []caliri.ContentOverrideDTO{repo1UrlOverride, repo1CaOverride, repo1VerifyOverride})
 
 	// Rename template
 	updateReq = api.TemplateUpdateRequest{


### PR DESCRIPTION
## Summary

By default clients registered to stage/prod have  sslsslverifystatus set to 1, which works fine for cdn.redhat.com, but not for s3.   This overrides that setting for each content set.

## Testing steps

Register a system and associate it to a template: https://github.com/content-services/content-sources-backend/blob/main/docs/register_client.md

on the client run 'subscription-manager refresh'

```
# grep sslverifystatus /etc/yum.repos.d/redhat.repo 
sslverifystatus = 0
```

