### PR TITLE
Fixes 4745: use domain list to detect pulp is up

### DIFF
--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -4,11 +4,12 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/content-services/content-sources-backend/pkg/cache"
-	"github.com/content-services/content-sources-backend/pkg/candlepin_client"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/content-services/content-sources-backend/pkg/cache"
+	"github.com/content-services/content-sources-backend/pkg/candlepin_client"
 
 	spec_api "github.com/content-services/content-sources-backend/api"
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -103,8 +104,7 @@ var PulpConnected bool
 
 func ping(c echo.Context) error {
 	if config.LoadedConfig.Clients.Pulp.Server != "" && !PulpConnected {
-		client := pulp_client.GetPulpClientWithDomain(pulp_client.DefaultDomain)
-		_, err := client.GetRpmRemoteList(c.Request().Context())
+		_, err := pulp_client.GetGlobalPulpClient().LookupDomain(c.Request().Context(), pulp_client.DefaultDomain)
 		if err != nil {
 			return c.JSON(502, echo.Map{
 				"message": err.Error(),


### PR DESCRIPTION
## Summary

Changes our ping call to pulp to use domain list as we won't have permission for remotes list
The health check (using metrics) already uses this!

## Testing steps


monitor the pulp api:
```
 podman logs -f cs_pulp_api_1 
```

launch the server
```
go run cmd/content-sources/main.go api instrumentation consumer
```

call the ping api:
```
 curl localhost:9000/ping  
````

you should only see calls to /api/pulp/default/api/v3/domains/?name=default
You'll only see ping hit this endpoint once per server start.  You should see it get hit by the metrics go routine every ~30 minutes.

