### PR TITLE
Fixes 4643: return object name for red hat task fetch

### DIFF
--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -52,7 +52,7 @@ func (t taskInfoDaoImpl) Fetch(ctx context.Context, orgID string, id string) (ap
 	result := t.db.WithContext(ctx).Table(taskInfo.TableName()+" AS t ").
 		Select(JoinSelectQuery).
 		Joins("LEFT JOIN repository_configurations rc on t.object_uuid = rc.repository_uuid AND t.object_type = ? AND rc.org_id in (?)", config.ObjectTypeRepository, orgIDs).
-		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id in (?)", config.ObjectTypeTemplate, orgIDs).
+		Joins("LEFT JOIN templates on t.object_uuid = templates.uuid AND t.object_type = ? AND templates.org_id = ?", config.ObjectTypeTemplate, orgID).
 		Joins("LEFT JOIN task_dependencies td on t.id = td.dependency_id").
 		Where("t.id = ? AND t.org_id in (?) AND rc.deleted_at is NULL", UuidifyString(id), orgIDs).First(&taskInfo)
 

--- a/pkg/dao/task_info_test.go
+++ b/pkg/dao/task_info_test.go
@@ -84,7 +84,7 @@ func (suite *TaskInfoSuite) TestFetch() {
 }
 
 func (suite *TaskInfoSuite) TestFetchRedHat() {
-	task, _ := suite.createRedHatTask()
+	task, repoConfig := suite.createRedHatTask()
 	t := suite.T()
 
 	dao := GetTaskInfoDao(suite.tx)
@@ -94,6 +94,12 @@ func (suite *TaskInfoSuite) TestFetchRedHat() {
 	fetchedUUID, uuidErr := uuid.Parse(fetchedTask.UUID)
 	assert.NoError(t, uuidErr)
 	assert.Equal(t, task.Id, fetchedUUID)
+
+	fetchedTask, err = dao.Fetch(context.Background(), "non red hat org", task.Id.String())
+	assert.NoError(t, err)
+	assert.Equal(t, config.RedHatOrg, fetchedTask.OrgId)
+	assert.Equal(t, repoConfig.Name, fetchedTask.ObjectName)
+	assert.Equal(t, repoConfig.UUID, fetchedTask.ObjectUUID)
 }
 
 func (suite *TaskInfoSuite) TestFetchWithOrgs() {


### PR DESCRIPTION
## Summary
object name and UUID was not being returned for the fetch endpoint

## Testing steps
1. Fetch a task that has the red hat org is the orgID
2. The object UUID and name should appear. Previously, those would be blank.

