### PR TITLE
Refs 4739: new metric check for failing snapshot tasks on RH repos

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -134,6 +134,7 @@ type MetricsDao interface {
 	PendingTasksAverageLatency(ctx context.Context) float64
 	PendingTasksCount(ctx context.Context) int64
 	PendingTasksOldestTask(ctx context.Context) float64
+	RHReposNoSuccessfulSnapshotTaskIn36Hours(ctx context.Context) int64
 }
 
 //go:generate $GO_OUTPUT/mockery --name TaskInfoDao --filename task_info_mock.go --inpackage

--- a/pkg/dao/metrics_mock.go
+++ b/pkg/dao/metrics_mock.go
@@ -103,6 +103,24 @@ func (_m *MockMetricsDao) PublicRepositoriesFailedIntrospectionCount(ctx context
 	return r0
 }
 
+// RHReposNoSuccessfulSnapshotTaskIn36Hours provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) RHReposNoSuccessfulSnapshotTaskIn36Hours(ctx context.Context) int64 {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RHReposNoSuccessfulSnapshotTaskIn36Hours")
+	}
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context) int64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
 // RepositoriesCount provides a mock function with given fields: ctx
 func (_m *MockMetricsDao) RepositoriesCount(ctx context.Context) int {
 	ret := _m.Called(ctx)

--- a/pkg/dao/metrics_test.go
+++ b/pkg/dao/metrics_test.go
@@ -320,3 +320,87 @@ func (s *MetricsSuite) TestPendingTasksOldestTask() {
 	oldestQeuedAt := s.dao.PendingTasksOldestTask(context.Background())
 	assert.True(t, oldestQeuedAt > 1)
 }
+
+func (s *MetricsSuite) TestRHReposNoSuccessfulSnapshotTaskIn36Hours() {
+	t := s.T()
+
+	initialCount := s.dao.RHReposNoSuccessfulSnapshotTaskIn36Hours(context.Background())
+	assert.NotEqual(t, -1, initialCount)
+
+	rcs, err := seeds.SeedRepositoryConfigurations(s.tx, 4, seeds.SeedOptions{OrgID: config.RedHatOrg})
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(rcs))
+
+	r1, r2, r3, r4 := rcs[0], rcs[1], rcs[2], rcs[3]
+
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r1.UUID,
+		RepoUUID:       r1.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-10 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-9 * time.Hour)),
+		Status:         config.TaskStatusCompleted,
+	})
+	assert.NoError(t, err)
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r1.UUID,
+		RepoUUID:       r1.RepositoryUUID,
+		Typename:       config.IntrospectTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-5 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-4 * time.Hour)),
+		Status:         config.TaskStatusFailed,
+	})
+	assert.NoError(t, err)
+
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r2.UUID,
+		RepoUUID:       r2.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-40 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-39 * time.Hour)),
+		Status:         config.TaskStatusCompleted,
+	})
+	assert.NoError(t, err)
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r2.UUID,
+		RepoUUID:       r2.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-30 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-29 * time.Hour)),
+		Status:         config.TaskStatusFailed,
+	})
+	assert.NoError(t, err)
+
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r3.UUID,
+		RepoUUID:       r3.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-30 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-29 * time.Hour)),
+		Status:         config.TaskStatusCompleted,
+	})
+	assert.NoError(t, err)
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r3.UUID,
+		RepoUUID:       r3.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-20 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-19 * time.Hour)),
+		Status:         config.TaskStatusFailed,
+	})
+	assert.NoError(t, err)
+
+	_, err = seeds.SeedTasks(s.tx, 1, seeds.TaskSeedOptions{
+		RepoConfigUUID: r4.UUID,
+		RepoUUID:       r4.RepositoryUUID,
+		Typename:       config.RepositorySnapshotTask,
+		QueuedAt:       utils.Ptr(time.Now().Add(-20 * time.Hour)),
+		FinishedAt:     utils.Ptr(time.Now().Add(-19 * time.Hour)),
+		Status:         config.TaskStatusFailed,
+	})
+	assert.NoError(t, err)
+
+	// expecting r2, r4 to be additionally counted in this metric
+	count := s.dao.RHReposNoSuccessfulSnapshotTaskIn36Hours(context.Background())
+	assert.Equal(t, 2+initialCount, count)
+}

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -26,6 +26,7 @@ const (
 	TaskStatsLabelPendingCount                     = "task_stats_pending_count"
 	TaskStatsLabelOldestWait                       = "task_stats_oldest_wait"
 	TaskStatsLabelAverageWait                      = "task_stats_average_wait"
+	RHRepositories36HourWithoutSuccessfulSnapTask  = "rh_repositories_36_hour_without_successful_snap_task"
 )
 
 type Metrics struct {
@@ -43,6 +44,7 @@ type Metrics struct {
 	TaskStats                                      prometheus.GaugeVec
 	OrgTotal                                       prometheus.Gauge
 	RHCertExpiryDays                               prometheus.Gauge
+	RHRepositories36HourWithoutSuccessfulSnapTask  prometheus.Gauge
 	reg                                            *prometheus.Registry
 }
 
@@ -118,6 +120,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Namespace: NameSpace,
 			Name:      RHCertExpiryDays,
 			Help:      "Number of days until the Red Hat client certificate expires",
+		}),
+		RHRepositories36HourWithoutSuccessfulSnapTask: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      RHRepositories36HourWithoutSuccessfulSnapTask,
+			Help:      "Number of Red Hat repositories that haven't had successful snapshot task in the last 36 hours.",
 		}),
 	}
 

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -99,6 +99,7 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) ([
 			OrgID:                createOrgId(options.OrgID),
 			RepositoryUUID:       repos[i].UUID,
 			LastSnapshotTaskUUID: options.TaskID,
+			Snapshot:             true,
 		}
 		repoConfigurations = append(repoConfigurations, repoConfig)
 	}
@@ -404,6 +405,7 @@ type TaskSeedOptions struct {
 	RepoConfigUUID string
 	RepoUUID       string
 	QueuedAt       *time.Time
+	FinishedAt     *time.Time
 }
 
 func SeedTasks(db *gorm.DB, size int, options TaskSeedOptions) ([]models.TaskInfo, error) {
@@ -469,6 +471,10 @@ func SeedTasks(db *gorm.DB, size int, options TaskSeedOptions) ([]models.TaskInf
 		}
 		started := time.Now().Add(time.Minute * time.Duration(i+5))
 		finished := time.Now().Add(time.Minute * time.Duration(i+10))
+		if options.FinishedAt != nil {
+			started = (*options.FinishedAt).Add(-5 * time.Minute)
+			finished = *options.FinishedAt
+		}
 		tasks[i] = models.TaskInfo{
 			Id:           uuid.New(),
 			Typename:     typename,


### PR DESCRIPTION
## Summary
This PR adds a new metric for checking if the snapshot tasks are failing on RH repos, specifically if there isn't a successful one in the last 36 hours and returns number of repos on which is this happening.

## Testing steps
1. Import RH repos.
2. Make the snapshot task fail for some repo(s) (i.e. status = failed) and see if the metric increases.


