### PR TITLE
Fixes 4777: remove custom param in list candlepin products

### DIFF
--- a/pkg/candlepin_client/product.go
+++ b/pkg/candlepin_client/product.go
@@ -80,19 +80,9 @@ func (c *cpClientImpl) ListProducts(ctx context.Context, orgID string, productID
 		return []caliri.ProductDTO{}, nil
 	}
 
-	// we want to set custom to "exclusive" so that the results are filtered to the org
-	// but this also excludes content imported from manifests, which is how we access content locally
-	var custom string
-	if OwnerKey(orgID) == DevelOrgKey {
-		custom = ""
-	} else {
-		custom = "exclusive"
-	}
-
 	products, httpResp, err := client.OwnerProductAPI.
 		GetProductsByOwner(ctx, OwnerKey(orgID)).
 		Product(productIDs).
-		Custom(custom).
 		Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()


### PR DESCRIPTION
## Summary
We don't need the custom param defined to correctly query products here. I think I misunderstood how the parameter worked when I first implemented this. 

Without this change, only custom products are included in the response, but we want to return custom and red hat products (which is the default behavior).

## Testing steps
I tested the API call in stage so it should work there

To test locally:
1. Turn off devel_org in the config file
2. `GET /api/content-sources/v1/subscription_check/` should return false
3. Turn on devel_org
4.  `GET /api/content-sources/v1/subscription_check/` should return true