### PR TITLE
Fixes 4151: remove support for YYYY-MM-DD date formats

### DIFF
--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -18,35 +17,8 @@ type SnapshotResponse struct {
 }
 
 type ListSnapshotByDateRequest struct {
-	RepositoryUUIDS []string `json:"repository_uuids"` // Repository UUIDs to find snapshots for
-	Date            Date     `json:"date"`             // Exact date to search by.
-}
-
-type Date time.Time
-
-func (d Date) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Time(d).Format(time.RFC3339))
-}
-
-func (d *Date) UnmarshalJSON(b []byte) error {
-	// try parsing as YYYY-MM-DD first
-	t, err := time.Parse(`"2006-01-02"`, string(b))
-	if err == nil {
-		*d = Date(t)
-		return nil
-	}
-
-	// if parsing as YYYY-MM-DD fails, try parsing as RFC3339
-	var t2 time.Time
-	if err := json.Unmarshal(b, &t2); err != nil {
-		return err
-	}
-	*d = Date(t2)
-	return nil
-}
-
-func (d *Date) Format(layout string) string {
-	return time.Time(*d).Format(layout)
+	RepositoryUUIDS []string  `json:"repository_uuids"` // Repository UUIDs to find snapshots for
+	Date            time.Time `json:"date"`             // Exact date to search by.
 }
 
 type ListSnapshotByDateResponse struct {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -744,7 +744,7 @@ func (r *rpmDaoImpl) fetchSnapshotsForTemplate(ctx context.Context, orgId string
 		templateDate = template.Date
 	}
 
-	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: api.Date(templateDate)})
+	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: templateDate})
 	if err != nil {
 		return []models.Snapshot{}, err
 	}

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -135,11 +135,11 @@ func (sDao *snapshotDaoImpl) ListByTemplate(
 	}
 
 	// Get snapshots for template date
-	var date api.Date
+	var date time.Time
 	if template.UseLatest {
-		date = api.Date(time.Now())
+		date = time.Now()
 	} else {
-		date = api.Date(template.Date)
+		date = template.Date
 	}
 	snapshotsForTemplateDate, err := sDao.FetchSnapshotsByDateAndRepository(ctx, orgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: template.RepositoryUUIDS,

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -480,7 +480,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 
 	request := api.ListSnapshotByDateRequest{}
 
-	request.Date = api.Date(second.Base.CreatedAt)
+	request.Date = second.Base.CreatedAt
 
 	request.RepositoryUUIDS = []string{repoConfig.UUID}
 
@@ -515,7 +515,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 	target3 := s.createSnapshotAtSpecifiedTime(redhatRepo, baseTime.Add(-time.Hour*100)) // Closest to Target Date
 
 	request := api.ListSnapshotByDateRequest{}
-	request.Date = api.Date(target1.Base.CreatedAt)
+	request.Date = target1.Base.CreatedAt
 
 	// Intentionally not found ID
 	randomUUID, _ := uuid2.NewUUID()

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -63,7 +64,7 @@ func (suite *SnapshotSuite) serveSnapshotsRouter(req *http.Request) (int, []byte
 func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	t := suite.T()
 	repoUUID := "abcadaba"
-	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: []string{repoUUID}}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: []string{repoUUID}}
 	response := api.ListSnapshotByDateResponse{Data: []api.SnapshotForDate{{RepositoryUUID: repoUUID}}}
 
 	suite.reg.Snapshot.On("FetchSnapshotsByDateAndRepository", test.MockCtx(), test_handler.MockOrgId, request).Return(response, nil)
@@ -84,7 +85,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	t := suite.T()
 	RepositoryUUIDS := []string{}
 
-	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
@@ -105,7 +106,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 		RepositoryUUIDS = append(RepositoryUUIDS, seeds.RandomOrgId())
 	}
 
-	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -129,7 +129,7 @@ func (t *UpdateTemplateContent) RunPulp() error {
 		templateDate = t.template.Date
 	}
 
-	l := api.ListSnapshotByDateRequest{Date: api.Date(templateDate), RepositoryUUIDS: allRepos}
+	l := api.ListSnapshotByDateRequest{Date: templateDate, RepositoryUUIDS: allRepos}
 	snapshots, err := t.daoReg.Snapshot.FetchSnapshotsModelByDateAndRepository(t.ctx, t.orgId, l)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Changes /snapshots/for_date/ request to remove support for YYYY-MM-DD date formats
    - We currently support both RFC3339 and YYYY-MM-DD formats to maintain backward compatibility with IB. We can remove support for YYYY-MM-DD now as they've made the necessary changes [here](https://github.com/osbuild/image-builder/pull/1252)
- [ Frontend PR](https://github.com/content-services/content-sources-frontend/pull/352) should be merged first

## Testing steps

1. Try to make a request to /snapshots/for_date/ with a YYYY-MM-DD date, this should fail:
```
{
  "date": "2024-10-02",
  "repository_uuids": ["30050c99-e904-4bf3-a31d-c213e203e19d"]
}
```
2. A request like this should still work:
```
{
  "date": "2024-10-02T00:00:00Z",
  "repository_uuids": ["30050c99-e904-4bf3-a31d-c213e203e19d"]
}
```


