### PR TITLE
Fixes 4821: expose URL on snapshot/for_date

### DIFF
--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -388,6 +388,11 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Conte
 		return api.ListSnapshotByDateResponse{}, err
 	}
 
+	pulpContentPath, err := sDao.pulpClient.GetContentPath(ctx)
+	if err != nil {
+		return api.ListSnapshotByDateResponse{}, err
+	}
+
 	repoUUIDCount := len(request.RepositoryUUIDS)
 	listResponse := make([]api.SnapshotForDate, repoUUIDCount)
 
@@ -400,9 +405,8 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Conte
 		})
 
 		if indx != -1 {
-			apiResponse := api.SnapshotResponse{}
-			snapshotModelToApi(snaps[indx], &apiResponse)
-			listResponse[i].Match = &apiResponse
+			apiResponse := snapshotConvertToResponses([]models.Snapshot{snaps[indx]}, pulpContentPath)
+			listResponse[i].Match = &apiResponse[0]
 		}
 
 		listResponse[i].IsAfter = indx != -1 && snaps[indx].Base.CreatedAt.After(date)


### PR DESCRIPTION
## Summary

fills in the URL field on the snapshot response on the for_date snapshot api

## Testing steps

1.  create a repo, let it snapshot
2. call the for_date api:
```
####
POST http://localhost:8000/api/content-sources/v1.0/snapshots/for_date/
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
Content-Type: application/json

{
  "repository_uuids": ["cace7ad3-e385-41a8-afc2-aae94bde6cf6"],
  "date": "2024-10-08T14:19:58Z"
}
```

verify the response has a url filled in:

```

{
  "data": [
    {
      "repository_uuid": "cace7ad3-e385-41a8-afc2-aae94bde6cf6",
      "is_after": true,
      "match": {
        "uuid": "ac856ef6-bd0f-473f-9574-26328a26a215",
        "created_at": "2024-10-09T14:17:31.029366Z",
        "repository_path": "95161890/cace7ad3-e385-41a8-afc2-aae94bde6cf6/2c1f5a50-0087-4368-bc9f-e1d62c5c836c",
        "content_counts": {
          "rpm.advisory": 4,
          "rpm.package": 32
        },
        "added_counts": {
          "rpm.advisory": 4,
          "rpm.package": 32
        },
        "removed_counts": {},
        "url": "http://pulp.content:8080/pulp/content/95161890/cace7ad3-e385-41a8-afc2-aae94bde6cf6/2c1f5a50-0087-4368-bc9f-e1d62c5c836c/",
        "repository_name": "test57",
        "repository_uuid": "cace7ad3-e385-41a8-afc2-aae94bde6cf6"
      }
    }
  ]
}
```

