### PR TITLE
Fixes 4716: Add "latest" snapshot distribution

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1225,6 +1225,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/{uuid}/config.repo": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "repositories"
+                ],
+                "summary": "Get latest configuration file for a repository",
+                "operationId": "getLatestRepoConfigurationFile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository ID.",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}/environments": {
             "get": {
                 "description": "List environments in a repository.",
@@ -3831,6 +3887,10 @@ const docTemplate = `{
                     "description": "Timestamp of last introspection that had updates",
                     "type": "string"
                 },
+                "latest_snapshot_url": {
+                    "description": "Latest URL for the snapshot distribution",
+                    "type": "string"
+                },
                 "metadata_verification": {
                     "description": "Verify packages",
                     "type": "boolean"
@@ -4083,6 +4143,10 @@ const docTemplate = `{
                 },
                 "last_update_introspection_time": {
                     "description": "Timestamp of last introspection that had updates",
+                    "type": "string"
+                },
+                "latest_snapshot_url": {
+                    "description": "Latest URL for the snapshot distribution",
                     "type": "string"
                 },
                 "metadata_verification": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -527,6 +527,10 @@
                         "description": "Timestamp of last introspection that had updates",
                         "type": "string"
                     },
+                    "latest_snapshot_url": {
+                        "description": "Latest URL for the snapshot distribution",
+                        "type": "string"
+                    },
                     "metadata_verification": {
                         "description": "Verify packages",
                         "type": "boolean"
@@ -775,6 +779,10 @@
                     },
                     "last_update_introspection_time": {
                         "description": "Timestamp of last introspection that had updates",
+                        "type": "string"
+                    },
+                    "latest_snapshot_url": {
+                        "description": "Latest URL for the snapshot distribution",
                         "type": "string"
                     },
                     "metadata_verification": {
@@ -3200,6 +3208,78 @@
                     }
                 },
                 "summary": "Add uploads to a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
+        "/repositories/{uuid}/config.repo": {
+            "get": {
+                "operationId": "getLatestRepoConfigurationFile",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get latest configuration file for a repository",
                 "tags": [
                     "repositories"
                 ]

--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -34,6 +34,7 @@ type RepositoryResponse struct {
 	LastSnapshot                 *SnapshotResponse `json:"last_snapshot,omitempty"`             // Latest Snapshot taken
 	LastSnapshotTaskUUID         string            `json:"last_snapshot_task_uuid,omitempty"`   // UUID of the last snapshot task
 	LastSnapshotTask             *TaskInfoResponse `json:"last_snapshot_task,omitempty"`        // Last snapshot task response (contains last snapshot status)
+	LatestSnapshotURL            string            `json:"latest_snapshot_url,omitempty"`       // Latest URL for the snapshot distribution
 }
 
 // RepositoryRequest holds data received from request to create repository

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -119,7 +119,7 @@ type SnapshotDao interface {
 	FetchLatestSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
 	FetchSnapshotsByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) (api.ListSnapshotByDateResponse, error)
 	FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
-	GetRepositoryConfigurationFile(ctx context.Context, orgID, snapshotUUID string) (string, error)
+	GetRepositoryConfigurationFile(ctx context.Context, orgID, snapshotUUID string, isLatest bool) (string, error)
 	Fetch(ctx context.Context, uuid string) (api.SnapshotResponse, error)
 	FetchSnapshotsModelByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) ([]models.Snapshot, error)
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -1184,6 +1184,8 @@ func convertToResponses(repoConfigs []models.RepositoryConfiguration, pulpConten
 		ModelToApiFields(repoConfigs[i], &repos[i])
 		if repoConfigs[i].LastSnapshot != nil {
 			repos[i].LastSnapshot.URL = pulpContentURL(pulpContentPath, repos[i].LastSnapshot.RepositoryPath)
+			repos[i].LatestSnapshotURL = pulpContentURL(pulpContentPath,
+				fmt.Sprintf("%v/%v/%v", strings.Split(repos[i].LastSnapshot.RepositoryPath, "/")[0], repos[i].UUID, "latest"))
 		}
 	}
 	return repos

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -255,9 +255,9 @@ func (_m *MockSnapshotDao) FetchSnapshotsModelByDateAndRepository(ctx context.Co
 	return r0, r1
 }
 
-// GetRepositoryConfigurationFile provides a mock function with given fields: ctx, orgID, snapshotUUID
-func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(ctx context.Context, orgID string, snapshotUUID string) (string, error) {
-	ret := _m.Called(ctx, orgID, snapshotUUID)
+// GetRepositoryConfigurationFile provides a mock function with given fields: ctx, orgID, snapshotUUID, isLatest
+func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(ctx context.Context, orgID string, snapshotUUID string, isLatest bool) (string, error) {
+	ret := _m.Called(ctx, orgID, snapshotUUID, isLatest)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRepositoryConfigurationFile")
@@ -265,17 +265,17 @@ func (_m *MockSnapshotDao) GetRepositoryConfigurationFile(ctx context.Context, o
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, orgID, snapshotUUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) (string, error)); ok {
+		return rf(ctx, orgID, snapshotUUID, isLatest)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, orgID, snapshotUUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) string); ok {
+		r0 = rf(ctx, orgID, snapshotUUID, isLatest)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, orgID, snapshotUUID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
+		r1 = rf(ctx, orgID, snapshotUUID, isLatest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -776,7 +776,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 
 	// Test happy scenario
 	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
-	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID)
+	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID, false)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfig.Name)
 	assert.Contains(t, repoConfigFile, expectedRepoID)
@@ -785,7 +785,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 
 	// Test error from pulp call
 	mockPulpClient.On("GetContentPath", ctx).Return("", fmt.Errorf("some error")).Once()
-	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID)
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID, false)
 	assert.Error(t, err)
 	assert.Empty(t, repoConfigFile)
 
@@ -803,7 +803,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	assert.NoError(t, err)
 
 	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
-	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfigRh.OrgID, snapshot.UUID)
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfigRh.OrgID, snapshot.UUID, false)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfigRh.Name)
 	assert.Contains(t, repoConfigFile, config.RedHatGpgKeyPath)
@@ -825,7 +825,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 
 	// Test bad snapshot UUID
 	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
-	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, uuid2.NewString())
+	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, uuid2.NewString(), false)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)
@@ -837,7 +837,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 
 	//  Test bad org ID
 	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
-	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), "bad orgID", snapshot.UUID)
+	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), "bad orgID", snapshot.UUID, false)
 	assert.Error(t, err)
 	if err != nil {
 		daoError, ok := err.(*ce.DaoError)

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -29,6 +29,7 @@ func RegisterSnapshotRoutes(group *echo.Group, daoReg *dao.DaoRegistry) {
 	sh := SnapshotHandler{DaoRegistry: *daoReg}
 	addRepoRoute(group, http.MethodPost, "/snapshots/for_date/", sh.listSnapshotsByDate, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/repositories/:uuid/snapshots/", sh.listSnapshotsForRepo, rbac.RbacVerbRead)
+	addRepoRoute(group, http.MethodGet, "/repositories/:uuid/config.repo", sh.getLatestRepoConfigurationFile, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/snapshots/:snapshot_uuid/config.repo", sh.getRepoConfigurationFile, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/templates/:uuid/snapshots/", sh.listSnapshotsForTemplate, rbac.RbacVerbRead)
 }
@@ -98,6 +99,36 @@ func (sh *SnapshotHandler) listSnapshotsForRepo(c echo.Context) error {
 	return c.JSON(200, setCollectionResponseMetadata(&snapshots, c, totalSnaps))
 }
 
+// Get Snapshots godoc
+// @Summary      Get latest configuration file for a repository
+// @ID           getLatestRepoConfigurationFile
+// @Tags         repositories
+// @Accept       json
+// @Produce      text/plain
+// @Param  uuid  path  string    true  "Repository ID."
+// @Success      200   {string} string
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      401 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{uuid}/config.repo [get]
+func (sh *SnapshotHandler) getLatestRepoConfigurationFile(c echo.Context) error {
+	_, orgID := getAccountIdOrgId(c)
+	repoUUID := c.Param("uuid")
+
+	latestSnapshot, err := sh.DaoRegistry.Snapshot.FetchLatestSnapshot(c.Request().Context(), repoUUID)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching latest snapshot", err.Error())
+	}
+
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.GetRepositoryConfigurationFile(c.Request().Context(), orgID, latestSnapshot.UUID, true)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
+	}
+
+	return c.String(http.StatusOK, repoConfigFile)
+}
+
 // Post Snapshots godoc
 // @Summary      Get nearest snapshot by date for a list of repositories.
 // @ID           listSnapshotsByDate
@@ -163,7 +194,7 @@ func (sh *SnapshotHandler) getRepoConfigurationFile(c echo.Context) error {
 	_, orgID := getAccountIdOrgId(c)
 	snapshotUUID := c.Param("snapshot_uuid")
 
-	repoConfigFile, err := sh.DaoRegistry.Snapshot.GetRepositoryConfigurationFile(c.Request().Context(), orgID, snapshotUUID)
+	repoConfigFile, err := sh.DaoRegistry.Snapshot.GetRepositoryConfigurationFile(c.Request().Context(), orgID, snapshotUUID, false)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error getting repository configuration file", err.Error())
 	}

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -9,6 +10,7 @@ import (
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/rbac"
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 // SnapshotByDateQueryLimit - Max number of repository snapshots permitted to query at a time by date.
@@ -118,6 +120,9 @@ func (sh *SnapshotHandler) getLatestRepoConfigurationFile(c echo.Context) error 
 
 	latestSnapshot, err := sh.DaoRegistry.Snapshot.FetchLatestSnapshot(c.Request().Context(), repoUUID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = &ce.DaoError{NotFound: true, Message: "Could not find repository with UUID " + repoUUID}
+		}
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching latest snapshot", err.Error())
 	}
 

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -192,7 +192,7 @@ func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {
 	repoConfigFile := "file"
 	refererHeader := "anotherhost.example.com"
 
-	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", test.MockCtx(), orgID, snapUUID).Return(repoConfigFile, nil).Once()
+	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", test.MockCtx(), orgID, snapUUID, false).Return(repoConfigFile, nil).Once()
 
 	path := fmt.Sprintf("%s/snapshots/%s/config.repo", api.FullRootPath(), snapUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -131,6 +131,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithClient() {
 	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID).Return([]models.Snapshot{}, nil).Once()
 	s.mockDaoRegistry.RepositoryConfig.On("Delete", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 
+	s.MockPulpClient.On("FindDistributionByPath", ctx, fmt.Sprintf("%v/%v", repoConfig.UUID, "latest")).Return(nil, nil).Once()
 	s.MockPulpClient.On("GetRpmRemoteByName", ctx, repoConfig.UUID).Return(nil).Return(nil, nil).Once()
 	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(nil, nil).Once()
 
@@ -191,6 +192,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 
 	s.MockPulpClient.On("PollTask", ctx, "taskHref").Return(&taskResp, nil).Times(3)
 	s.MockPulpClient.On("DeleteRpmRepositoryVersion", ctx, expectedSnap.VersionHref).Return(nil).Once()
+	s.MockPulpClient.On("FindDistributionByPath", ctx, fmt.Sprintf("%v/%v", repoConfig.UUID, "latest")).Return(nil, nil).Once()
 	s.MockPulpClient.On("DeleteRpmDistribution", ctx, expectedSnap.DistributionHref).Return("taskHref", nil).Once()
 
 	s.MockPulpClient.On("GetRpmRemoteByName", ctx, repoConfig.UUID).Return(nil).Return(&remoteResp, nil).Once()

--- a/pkg/tasks/helpers/pulp_distribution_helper_test.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper_test.go
@@ -80,17 +80,13 @@ func (s *PulpDistributionHelperTest) TestRedHatDistributionUpdate() {
 	orgId := config.RedHatOrg
 	taskHref := "taskHref"
 	var guardHref *string
-	taskResp := zest.TaskResponse{
-		PulpHref: &taskHref,
-	}
 
 	mockPulp.On("UpdateRpmDistribution", ctx, distHref, pubHref, distName, distPath, guardHref).Return(taskHref, nil)
-	mockPulp.On("PollTask", ctx, taskHref).Return(&taskResp, nil)
 
 	mockPulp.On("FindDistributionByPath", ctx, distPath).Return(&zest.RpmRpmDistributionResponse{
 		PulpHref: &distHref,
 	}, nil)
 
-	err := helper.CreateOrUpdateDistribution(orgId, distName, distPath, pubHref)
+	_, _, err := helper.CreateOrUpdateDistribution(orgId, distName, distPath, pubHref)
 	assert.NoError(s.T(), err)
 }

--- a/pkg/tasks/repository_snapshot_test.go
+++ b/pkg/tasks/repository_snapshot_test.go
@@ -385,14 +385,14 @@ func (s *SnapshotSuite) mockCreateDist(ctx context.Context, pubHref string) (str
 	distTaskhref := "distTaskHref"
 
 	s.MockPulpClient.On("FindDistributionByPath", ctx, distPath).Return(nil, nil)
-	s.MockPulpClient.On("CreateRpmDistribution", ctx, pubHref, mock.AnythingOfType("string"), distPath, guardPath).Return(&distTaskhref, nil).Once()
+	s.MockPulpClient.On("CreateRpmDistribution", ctx, pubHref, mock.AnythingOfType("string"), distPath, guardPath).Return(&distTaskhref, nil).Twice()
 	status := pulp_client.COMPLETED
 	task := zest.TaskResponse{
 		PulpHref:         &distTaskhref,
 		State:            &status,
 		CreatedResources: []string{distHref},
 	}
-	s.MockPulpClient.On("PollTask", ctx, distTaskhref).Return(&task, nil).Once()
+	s.MockPulpClient.On("PollTask", ctx, distTaskhref).Return(&task, nil).Twice()
 	return distHref, distTaskhref
 }
 

--- a/pkg/tasks/update_latest_snapshot.go
+++ b/pkg/tasks/update_latest_snapshot.go
@@ -109,7 +109,7 @@ func (t *UpdateLatestSnapshot) updateLatestSnapshot(repo api.RepositoryResponse,
 		return err
 	}
 
-	err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(t.orgID, distName, distPath, snap.PublicationHref)
+	_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(t.orgID, distName, distPath, snap.PublicationHref)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -246,7 +246,7 @@ func (t *UpdateTemplateContent) handleReposUnchanged(reposUnchanged []string, sn
 			return err
 		}
 
-		err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo.OrgID, distName, distPath, snapshots[snapIndex].PublicationHref)
+		_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo.OrgID, distName, distPath, snapshots[snapIndex].PublicationHref)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- When a new snapshot is taken either via a sync, or via an upload, a new distribution there is a new distribution in pulp pointing to /latest.

- The full URL to the above 'latest' snapshot distribution is returned with each snapshotted & upload repository, as the attribute:  "latest_snapshot_url"

- New route to download the repo-config with associated 'latest' url @/repositories/UUID/config.repo  

## Testing steps

- Create a custom repository > wait for snapshot > check the response for the "latest_snapshot_url"
- Call the /repositories/UUID/config.repo endpoint with the above repository uuid, see the latest_snapshot_url represented there as "url"
- Check that you can download the above distribution.
