### PR TITLE
Fixes 4797: no repo name or uuid in last_snapshot

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -1115,6 +1115,8 @@ func ModelToApiFields(repoConfig models.RepositoryConfiguration, apiRepo *api.Re
 			AddedCounts:    repoConfig.LastSnapshot.AddedCounts,
 			RemovedCounts:  repoConfig.LastSnapshot.RemovedCounts,
 			RepositoryPath: repoConfig.LastSnapshot.RepositoryPath,
+			RepositoryUUID: repoConfig.UUID,
+			RepositoryName: repoConfig.Name,
 		}
 	}
 

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1102,6 +1102,8 @@ func (suite *RepositoryConfigSuite) TestFetch() {
 	assert.Equal(t, found.Name, fetched.Name)
 	assert.Equal(t, found.Repository.URL, fetched.URL)
 	assert.Equal(t, found.LastSnapshot.UUID, fetched.LastSnapshot.UUID)
+	assert.Equal(t, found.UUID, fetched.LastSnapshot.RepositoryUUID)
+	assert.Equal(t, found.Name, fetched.LastSnapshot.RepositoryName)
 
 	if config.Get().Features.Snapshots.Enabled {
 		assert.Equal(t, testContentPath+"/", fetched.LastSnapshot.URL)
@@ -1269,6 +1271,8 @@ func (suite *RepositoryConfigSuite) TestList() {
 		assert.Equal(t, repoConfig.Repository.URL, response.Data[0].URL)
 		assert.Equal(t, repoConfig.LastSnapshot.UUID, response.Data[0].LastSnapshot.UUID)
 		assert.Equal(t, repoConfig.LastSnapshot.RepositoryPath, response.Data[0].LastSnapshot.RepositoryPath)
+		assert.Equal(t, repoConfig.UUID, response.Data[0].LastSnapshot.RepositoryUUID)
+		assert.Equal(t, repoConfig.Name, response.Data[0].LastSnapshot.RepositoryName)
 		if config.Get().Features.Snapshots.Enabled {
 			assert.Equal(t, testContentPath+"/", response.Data[0].LastSnapshot.URL)
 		}


### PR DESCRIPTION
## Summary

Fixes a bug where the repo UUID and name were missing from `last_snapshot` in the repository response

## Testing steps

1. Create a repository and let it snapshot
2. Fetch that repository. The `repository_uuid` and `repository_name` should not be empty in `last_snapshot`
```
...
"last_snapshot": {
        "uuid": "911a76a9-2942-42b4-85aa-406222e543d2",
        "created_at": "2024-10-16T18:22:58.496151Z",
        "repository_path": "34aadb80/30d9d7b9-d49a-45b5-8a75-a527c35bd821/9eb85075-6c1e-426e-aff2-8454eb5f8c80",
        "content_counts": {
            "rpm.advisory": 2,
            "rpm.package": 8,
            "rpm.packagecategory": 1,
            "rpm.packagegroup": 2
        },
        "added_counts": {
            "rpm.advisory": 2,
            "rpm.package": 8,
            "rpm.packagecategory": 1,
            "rpm.packagegroup": 2
        },
        "removed_counts": {},
        "url": "http://pulp.content:8080/pulp/content/34aadb80/30d9d7b9-d49a-45b5-8a75-a527c35bd821/9eb85075-6c1e-426e-aff2-8454eb5f8c80/",
        "repository_name": "test1",
        "repository_uuid": "30d9d7b9-d49a-45b5-8a75-a527c35bd821"
    },
...   
```