### PR TITLE
Fixes 4853: fix gosec errors and enable gosec in CI

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -45,7 +45,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.3
+          version: v1.61.0
           skip-go-installation: true
           args: --timeout=5m
   
@@ -179,5 +179,3 @@ jobs:
           CLIENTS_PULP_SERVER: http://localhost:8080
           CLIENTS_PULP_USERNAME: admin
           CLIENTS_PULP_PASSWORD: password
-
-

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,11 @@ linters:
     - forcetypeassert
     - gci
     - bodyclose
+    - gosec
+linters-settings:
+  gosec:
+    excludes:
+      - G404 # we want to use pseudo-random numbers in some cases, so this should be excluded
 issues:
   exclude:
     - composite

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: v1.61.0
     hooks:
       - id: golangci-lint
+        language_version: 1.23.1
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/cmd/swagger2openapi/main.go
+++ b/cmd/swagger2openapi/main.go
@@ -36,7 +36,7 @@ func main() {
 		panic(err)
 	}
 
-	err = os.WriteFile(outputFile, openapiJson, 0644)
+	err = os.WriteFile(outputFile, openapiJson, 0644) //nolint:gosec
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/candlepin_client/client.go
+++ b/pkg/candlepin_client/client.go
@@ -28,7 +28,7 @@ func errorWithResponseBody(message string, httpResp *http.Response, err error) e
 		if readErr != nil {
 			log.Logger.Error().Err(readErr).Msg("could not read http body")
 		}
-		errWithBody := fmt.Errorf("%w: %v", err, string(body[:]))
+		errWithBody := fmt.Errorf("%w: %v", err, string(body))
 		return fmt.Errorf("%v: %w", errors.New(message), errWithBody)
 	}
 	return err
@@ -48,6 +48,7 @@ func getHTTPClient() (http.Client, error) {
 		}
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
 		}
 		if ca != "" {
 			pool, err := certPool(ca)

--- a/pkg/dao/main_test.go
+++ b/pkg/dao/main_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	//open database connection
+	// open database connection
 	var err = db.Connect()
 	config.ConfigureLogging()
 	if err != nil {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -170,7 +171,10 @@ func getPreviousMigrationVersion(m *migrate.Migrate) (int, error) {
 		datetime, _ := strconv.Atoi(nameArr[0])
 		datetimes = append(datetimes, datetime)
 	}
-	previousMigrationIndex = sort.IntSlice(datetimes).Search(int(version)) - 1
+	if version > math.MaxInt {
+		return 0, fmt.Errorf("invalid version: %d", version)
+	}
+	previousMigrationIndex = (sort.IntSlice(datetimes).Search(int(version))) - 1
 	if previousMigrationIndex == -1 {
 		return 0, err
 	} else {

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -228,6 +228,7 @@ func httpClient(useCert bool) (http.Client, error) {
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{*cert},
 			RootCAs:      caCertPool,
+			MinVersion:   tls.VersionTLS12,
 		}
 
 		transport := &http.Transport{TLSClientConfig: tlsConfig, ResponseHeaderTimeout: timeout}

--- a/pkg/external_repos/store.go
+++ b/pkg/external_repos/store.go
@@ -31,7 +31,7 @@ func SaveToFile(repoUrls []string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(Filename, repoJson, 0644)
+	err = os.WriteFile(Filename, repoJson, 0644) //nolint:gosec
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/main_test.go
+++ b/pkg/handler/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	//open database connection
+	// open database connection
 	var err = db.Connect()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to open DB")

--- a/pkg/models/main_test.go
+++ b/pkg/models/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	//open database connection
+	// open database connection
 	var err = db.Connect()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to open DB")

--- a/pkg/pulp_client/client.go
+++ b/pkg/pulp_client/client.go
@@ -96,7 +96,7 @@ func errorWithResponseBody(message string, httpResp *http.Response, err error) e
 		if readErr != nil {
 			log.Logger.Error().Err(readErr).Msg("could not read http body")
 		}
-		return fmt.Errorf("%v: %w: %v", message, err, string(body[:]))
+		return fmt.Errorf("%v: %w: %v", message, err, string(body))
 	} else {
 		return fmt.Errorf("%w: no body", err)
 	}

--- a/pkg/pulp_client/package.go
+++ b/pkg/pulp_client/package.go
@@ -57,9 +57,9 @@ func (r *pulpDaoImpl) LookupPackage(ctx context.Context, sha256sum string) (*str
 	}
 }
 
-func (r *pulpDaoImpl) ListVersionPackages(ctx context.Context, versionHref string, offset int, limit int) (pkgs []zest.RpmPackageResponse, total int, err error) {
+func (r *pulpDaoImpl) ListVersionPackages(ctx context.Context, versionHref string, offset, limit int32) (pkgs []zest.RpmPackageResponse, total int, err error) {
 	ctx, client := getZestClient(ctx)
-	resp, httpResp, err := client.ContentPackagesAPI.ContentRpmPackagesList(ctx, r.domainName).RepositoryVersion(versionHref).Limit(int32(limit)).Fields(RpmFields).Offset(int32(offset)).Execute()
+	resp, httpResp, err := client.ContentPackagesAPI.ContentRpmPackagesList(ctx, r.domainName).RepositoryVersion(versionHref).Limit(limit).Fields(RpmFields).Offset(offset).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -70,8 +70,8 @@ func (r *pulpDaoImpl) ListVersionPackages(ctx context.Context, versionHref strin
 }
 
 func (r *pulpDaoImpl) ListVersionAllPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error) {
-	initial := 0
-	limit := 300
+	initial := int32(0)
+	limit := int32(300)
 	pkgs, total, err := r.ListVersionPackages(ctx, versionHref, initial, limit)
 	if err != nil {
 		return nil, err

--- a/pkg/tasks/queue/main_test.go
+++ b/pkg/tasks/queue/main_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	//open database connection
+	// open database connection
 	var err = db.Connect()
 	config.ConfigureLogging()
 	if err != nil {

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -197,7 +198,11 @@ func (d *dequeuers) notifyAll() {
 
 func NewPgxPool(url string) (*pgxpool.Pool, error) {
 	pxConfig, err := pgxpool.ParseConfig(url)
-	pxConfig.MaxConns = int32(config.Get().Database.PoolLimit)
+	poolLimit := config.Get().Database.PoolLimit
+	if poolLimit < math.MinInt32 || poolLimit > math.MaxInt32 {
+		return nil, errors.New("invalid pool limit size")
+	}
+	pxConfig.MaxConns = int32(poolLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/health_check_test.go
+++ b/test/integration/health_check_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/handler"
@@ -53,13 +54,21 @@ func (s *HealthCheckSuite) SetupTest() {
 	)))
 
 	s.pingServer = &http.Server{
-		Addr:    "127.0.0.1:8005",
-		Handler: pingRouter,
+		Addr:              "127.0.0.1:8005",
+		Handler:           pingRouter,
+		IdleTimeout:       1 * time.Minute,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 
 	s.metricsServer = &http.Server{
-		Addr:    "127.0.0.1:9005",
-		Handler: metricsRouter,
+		Addr:              "127.0.0.1:9005",
+		Handler:           metricsRouter,
+		IdleTimeout:       1 * time.Minute,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 }
 

--- a/test/integration/import_export_repository_test.go
+++ b/test/integration/import_export_repository_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -49,8 +50,12 @@ func (s *ImportExportRepoSuite) SetupTest() {
 	handler.RegisterRoutes(router)
 
 	s.server = &http.Server{
-		Addr:    "127.0.0.1:8100",
-		Handler: router,
+		Addr:              "127.0.0.1:8100",
+		Handler:           router,
+		IdleTimeout:       1 * time.Minute,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 
 	// force local storage for integration tests

--- a/test/integration/pulp_upload_test.go
+++ b/test/integration/pulp_upload_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -58,8 +59,12 @@ func (s *UploadSuite) SetupTest() {
 	handler.RegisterRoutes(router)
 
 	s.server = &http.Server{
-		Addr:    "127.0.0.1:8100",
-		Handler: router,
+		Addr:              "127.0.0.1:8100",
+		Handler:           router,
+		IdleTimeout:       1 * time.Minute,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
 	}
 
 	// force local storage for integration tests


### PR DESCRIPTION
## Summary
This PR addresses all problems currently reported by the `gosec` security checker and adds `gosec` to the list of checkers used in `golangci-lint`. Also fixes a problem with miss-matched Go versions for our pre-commit hooks.


