### PR TITLE
Fixes 4860: use timestamptz for date comparisons

### DIFF
--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -359,7 +359,7 @@ func (sDao *snapshotDaoImpl) FetchSnapshotByVersionHref(ctx context.Context, rep
 
 func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) ([]models.Snapshot, error) {
 	snaps := []models.Snapshot{}
-	date := request.Date.Format(time.RFC3339)
+	date := request.Date.UTC().Format(time.RFC3339)
 
 	// finds the snapshot for each repo that is just before (or equal to) our date
 	beforeQuery := sDao.db.WithContext(ctx).Raw(`
@@ -368,7 +368,7 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 			INNER JOIN repository_configurations ON s.repository_configuration_uuid = repository_configurations.uuid
 			WHERE s.repository_configuration_uuid IN ?
 			AND repository_configurations.org_id IN ?
-			AND date_trunc('second', s.created_at::timestamp) <= ? 			
+			AND date_trunc('second', s.created_at::timestamptz) <= ?
 			ORDER BY s.repository_configuration_uuid,  s.created_at DESC
 	`, request.RepositoryUUIDS, []string{orgID, config.RedHatOrg}, date)
 
@@ -378,7 +378,7 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 			INNER JOIN repository_configurations ON s.repository_configuration_uuid = repository_configurations.uuid
 			WHERE s.repository_configuration_uuid IN ?
 			AND repository_configurations.org_id IN ?
-			AND date_trunc('second', s.created_at::timestamp)  > ?
+			AND date_trunc('second', s.created_at::timestamptz)  > ?
 			ORDER BY s.repository_configuration_uuid, s.created_at ASC
 	`, request.RepositoryUUIDS, []string{orgID, config.RedHatOrg}, date)
 	// For each repo, pick the oldest of this combined set (ideally the one just before our date, if that doesn't exist, the one after)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -525,6 +525,17 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	assert.Equal(t, 1, len(response))
 	assert.Equal(t, second.Base.UUID, response[0].UUID)
 
+	// 31 minutes after should still use second, but specify EDT time
+	tz, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
+		RepositoryUUIDS: []string{repoConfig.UUID},
+		Date:            second.Base.CreatedAt.Add(time.Minute * 31).In(tz),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(response))
+	assert.Equal(t, second.Base.UUID, response[0].UUID)
+
 	// 1 minute before should use first
 	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},


### PR DESCRIPTION
## Summary

Previously the change to this query improperly used the timestamp postgresql type which ignores timezones, by using timestamptz, the query now works properly.  We'll also just convert the date to UTC to be more consistent with using UTC dates.

## Testing steps

Fly to somewhere that doesn't use UTC.

Run the TestUseLatest integration test in test/integration/update_template_content_test.go
