### PR TITLE
Refs 4863: Revert "remove support for YYYY-MM-DD formats"

### DIFF
--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -17,8 +18,39 @@ type SnapshotResponse struct {
 }
 
 type ListSnapshotByDateRequest struct {
-	RepositoryUUIDS []string  `json:"repository_uuids"` // Repository UUIDs to find snapshots for
-	Date            time.Time `json:"date"`             // Exact date to search by.
+	RepositoryUUIDS []string `json:"repository_uuids"` // Repository UUIDs to find snapshots for
+	Date            Date     `json:"date"`             // Exact date to search by.
+}
+
+type Date time.Time
+
+func (d Date) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(d).Format(time.RFC3339))
+}
+
+func (d *Date) UnmarshalJSON(b []byte) error {
+	// try parsing as YYYY-MM-DD first
+	t, err := time.Parse(`"2006-01-02"`, string(b))
+	if err == nil {
+		*d = Date(t)
+		return nil
+	}
+
+	// if parsing as YYYY-MM-DD fails, try parsing as RFC3339
+	var t2 time.Time
+	if err := json.Unmarshal(b, &t2); err != nil {
+		return err
+	}
+	*d = Date(t2)
+	return nil
+}
+
+func (d *Date) Format(layout string) string {
+	return time.Time(*d).Format(layout)
+}
+
+func (d *Date) UTC() time.Time {
+	return time.Time(*d).UTC()
 }
 
 type ListSnapshotByDateResponse struct {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -744,7 +744,7 @@ func (r *rpmDaoImpl) fetchSnapshotsForTemplate(ctx context.Context, orgId string
 		templateDate = template.Date
 	}
 
-	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: templateDate})
+	snapshots, err := GetSnapshotDao(r.db).FetchSnapshotsModelByDateAndRepository(ctx, orgId, api.ListSnapshotByDateRequest{RepositoryUUIDS: repoUuids, Date: api.Date(templateDate)})
 	if err != nil {
 		return []models.Snapshot{}, err
 	}

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -483,7 +483,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 
 	request := api.ListSnapshotByDateRequest{}
 
-	request.Date = second.Base.CreatedAt.Add(time.Minute * 31)
+	request.Date = api.Date(second.Base.CreatedAt.Add(time.Minute * 31))
 
 	request.RepositoryUUIDS = []string{repoConfig.UUID}
 
@@ -511,7 +511,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	// Exact match to second
 	response, err := sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},
-		Date:            second.Base.CreatedAt.Add(time.Second * 1),
+		Date:            api.Date(second.Base.CreatedAt.Add(time.Second * 1)),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(response))
@@ -520,7 +520,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	// 31 minutes after should still use second
 	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},
-		Date:            second.Base.CreatedAt.Add(time.Minute * 31),
+		Date:            api.Date(second.Base.CreatedAt.Add(time.Minute * 31)),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(response))
@@ -531,7 +531,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	require.NoError(t, err)
 	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},
-		Date:            second.Base.CreatedAt.Add(time.Minute * 31).In(tz),
+		Date:            api.Date(second.Base.CreatedAt.Add(time.Minute * 31).In(tz)),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(response))
@@ -540,7 +540,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	// 1 minute before should use first
 	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},
-		Date:            second.Base.CreatedAt.Add(time.Minute * -1),
+		Date:            api.Date(second.Base.CreatedAt.Add(time.Minute * -1)),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(response))
@@ -549,7 +549,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsModelByDateAndRepositoryNew() {
 	// 2 hours after should use third
 	response, err = sDao.FetchSnapshotsModelByDateAndRepository(context.Background(), repoConfig.OrgID, api.ListSnapshotByDateRequest{
 		RepositoryUUIDS: []string{repoConfig.UUID},
-		Date:            second.Base.CreatedAt.Add(time.Minute * 120),
+		Date:            api.Date(second.Base.CreatedAt.Add(time.Minute * 120)),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(response))
@@ -582,7 +582,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 	target3 := s.createSnapshotAtSpecifiedTime(redhatRepo, baseTime.Add(-time.Hour*100)) // Closest to Target Date
 
 	request := api.ListSnapshotByDateRequest{}
-	request.Date = target1.Base.CreatedAt
+	request.Date = api.Date(target1.Base.CreatedAt)
 
 	// Intentionally not found ID
 	randomUUID, _ := uuid2.NewUUID()

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -139,7 +139,7 @@ func (t templateDaoImpl) insertTemplateRepoConfigsAndSnapshots(tx *gorm.DB, ctx 
 	}
 
 	sDao := snapshotDaoImpl{db: tx}
-	req := api.ListSnapshotByDateRequest{Date: templateDate, RepositoryUUIDS: repoUUIDs}
+	req := api.ListSnapshotByDateRequest{Date: api.Date(templateDate), RepositoryUUIDS: repoUUIDs}
 	snapshots, err := sDao.FetchSnapshotsModelByDateAndRepository(ctx, orgId, req)
 	if err != nil {
 		return err

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -64,7 +63,7 @@ func (suite *SnapshotSuite) serveSnapshotsRouter(req *http.Request) (int, []byte
 func (suite *SnapshotSuite) TestListSnapshotsByDate() {
 	t := suite.T()
 	repoUUID := "abcadaba"
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: []string{repoUUID}}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: []string{repoUUID}}
 	response := api.ListSnapshotByDateResponse{Data: []api.SnapshotForDate{{RepositoryUUID: repoUUID}}}
 
 	suite.reg.Snapshot.On("FetchSnapshotsByDateAndRepository", test.MockCtx(), test_handler.MockOrgId, request).Return(response, nil)
@@ -85,7 +84,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateBadRequestError() {
 	t := suite.T()
 	RepositoryUUIDS := []string{}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)
@@ -106,7 +105,7 @@ func (suite *SnapshotSuite) TestListSnapshotsByDateExceedLimitError() {
 		RepositoryUUIDS = append(RepositoryUUIDS, seeds.RandomOrgId())
 	}
 
-	request := api.ListSnapshotByDateRequest{Date: time.Time{}, RepositoryUUIDS: RepositoryUUIDS}
+	request := api.ListSnapshotByDateRequest{Date: api.Date{}, RepositoryUUIDS: RepositoryUUIDS}
 
 	body, err := json.Marshal(request)
 	assert.NoError(t, err)

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -136,7 +136,7 @@ func (t *UpdateTemplateContent) RunPulp() error {
 		templateDate = t.template.Date
 	}
 
-	l := api.ListSnapshotByDateRequest{Date: templateDate, RepositoryUUIDS: allRepos}
+	l := api.ListSnapshotByDateRequest{Date: api.Date(templateDate), RepositoryUUIDS: allRepos}
 	snapshots, err := t.daoReg.Snapshot.FetchSnapshotsModelByDateAndRepository(t.ctx, t.orgId, l)
 	if err != nil {
 		return err


### PR DESCRIPTION
This reverts commit 533684ffc8622ffb551bbde1952aa344197e72af.

## Summary

More changes are needed in IB so this doesn't break things, so reverting this until those are in place. 

## Testing steps

Requests with date formats of YYYY-MM-DD or RFC3339 should be accepted to `/snapshots/for_date/`:

```
{
  "date": "2024-10-23T00:00:00Z",
  "repository_uuids": ["94c19c10-c5e1-4a65-8909-75e90baa4080"]
}

{
  "date": "2024-10-23",
  "repository_uuids": ["94c19c10-c5e1-4a65-8909-75e90baa4080"]
}
```


