### PR TITLE
Fixes 4610: don't trigger snapshot on adding slash to url

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -636,7 +636,7 @@ func (r repositoryConfigDaoImpl) Update(ctx context.Context, orgID, uuid string,
 				return DBErrorToApi(err)
 			}
 			repoConfig.RepositoryUUID = repo.UUID
-			updatedUrl = repoConfig.Repository.URL != *repoParams.URL
+			updatedUrl = repoConfig.Repository.URL != cleanedUrl
 		}
 
 		repoConfig.Repository = models.Repository{}


### PR DESCRIPTION
## Summary

Adjusts comparison to check formatted url to keep from triggering snapshots if only a slash was added or removed.

## Testing steps

1. Create a repository and let it snapshot
2. Update the repository URL by adding an extra slash or removing a slash. Snapshots should not be triggered with either PUT or PATCH