### PR TITLE
Fixes 4775: add weekly cron for pulp orphan cleanup

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -578,6 +578,86 @@ objects:
                     name: content-sources-candlepin
                     key: key
                     optional: true
+        - name: pulp-orphan-cleanup
+          # https://crontab.guru/
+          schedule: ${WEEKLY_CRON_JOB}
+          suspend: ${{SUSPEND_CRON_JOB}}
+          concurrencyPolicy: "Forbid"
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /external-repos
+              - pulp-orphan-cleanup 5
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: RH_CDN_CERT_PAIR
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-certs
+                    key: cdn.redhat.com
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-sentry
+                    key: dsn
+                    optional: true
+              - name: CLIENTS_PULP_SERVER
+                value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
+              - name: CLIENTS_PULP_GUARD_SUBJECT_DN
+                value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
+              - name: CLIENTS_PULP_USERNAME
+                value: ${{CLIENTS_PULP_USERNAME}}
+              - name: CLIENTS_PULP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-content-sources-password
+                    key: password
+                    optional: true
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: OPTIONS_EXTERNAL_URL
+                value: ${OPTIONS_EXTERNAL_URL}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
+              - name: FEATURES_ADMIN_TASKS_ENABLED
+                value: ${FEATURES_ADMIN_TASKS_ENABLED}
+              - name: FEATURES_ADMIN_TASKS_ACCOUNTS
+                value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
+              - name: CLIENTS_RBAC_BASE_URL
+                value: ${{CLIENTS_RBAC_BASE_URL}}
+              - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
+                value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
       database:
         name: content-sources
         version: 15
@@ -631,6 +711,8 @@ parameters:
     required: true
   - name: IMAGE
     value: quay.io/cloudservices/content-sources-backend
+  - name: WEEKLY_CRON_JOB
+    value: "0 8 * * 3"
   - name: NIGHTLY_CRON_JOB
     value: "0 0/1 * * *"
   - name: SUSPEND_CRON_JOB

--- a/pkg/dao/domain_dao_mock.go
+++ b/pkg/dao/domain_dao_mock.go
@@ -5,6 +5,7 @@ package dao
 import (
 	context "context"
 
+	models "github.com/content-services/content-sources-backend/pkg/models"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -62,6 +63,36 @@ func (_m *MockDomainDao) FetchOrCreateDomain(ctx context.Context, orgId string) 
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, orgId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// List provides a mock function with given fields: ctx
+func (_m *MockDomainDao) List(ctx context.Context) ([]models.Domain, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for List")
+	}
+
+	var r0 []models.Domain
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]models.Domain, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []models.Domain); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Domain)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/domains.go
+++ b/pkg/dao/domains.go
@@ -59,3 +59,12 @@ func (dDao domainDaoImpl) Fetch(ctx context.Context, orgId string) (string, erro
 	}
 	return found[0].DomainName, nil
 }
+
+func (dDao domainDaoImpl) List(ctx context.Context) ([]models.Domain, error) {
+	var domains []models.Domain
+	result := dDao.db.WithContext(ctx).Table("domains").Find(&domains)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return domains, nil
+}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -147,6 +147,7 @@ type AdminTaskDao interface {
 type DomainDao interface {
 	FetchOrCreateDomain(ctx context.Context, orgId string) (string, error)
 	Fetch(ctx context.Context, orgId string) (string, error)
+	List(ctx context.Context) ([]models.Domain, error)
 }
 
 type PackageGroupDao interface {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,7 +34,7 @@ func Contains[T comparable](elems []T, v T) bool {
 	return false
 }
 
-// Converts any struct to a pointer to that struct
+// Ptr converts any value to a pointer to that value
 func Ptr[T any](item T) *T {
 	return &item
 }


### PR DESCRIPTION
## Summary
Adds a new command and weekly cron job to run orphan cleanup for pulp. Runs in batches of 5 orgs.

## Testing steps
1. You can use this script to create a bunch of orgs

```
TOTAL_ORGS=33

for ((i=0; i<$TOTAL_ORGS; ++i))
do

ORG_ID=`tr -dc A-Za-z0-9 </dev/urandom | head -c 13`

HEADER=`./scripts/header.sh $ORG_ID`

UUID=$(curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/repositories/" \
    -H "${HEADER}" \
    -H "Content-Type: application/json" \
    -d '{
          "name": "comps repo 2",
          "url": "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/",
          "snapshot": true
  }' | jq -r .uuid)

curl -X DELETE --location "http://localhost:8000/api/content-sources/v1.0/repositories/$UUID" \
    -H "${HEADER}" \
    -H "Content-Type: application/json"
done
```
2. Run `go cmd/external-repos/main.go pulp-orphan-cleanup`
3. In the logs you'll see the pulp tasks running in groups of 5
