### PR TITLE
Fixes 4963: add package summary to rpm precense api

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3458,6 +3458,13 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "found_packages": {
+                    "description": "Found packages with their summary",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SearchRpmResponse"
+                    }
+                },
                 "missing": {
                     "description": "List of rpm names not found in given repositories",
                     "type": "array",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -108,6 +108,13 @@
                         },
                         "type": "array"
                     },
+                    "found_packages": {
+                        "description": "Found packages with their summary",
+                        "items": {
+                            "$ref": "#/components/schemas/api.SearchRpmResponse"
+                        },
+                        "type": "array"
+                    },
                     "missing": {
                         "description": "List of rpm names not found in given repositories",
                         "items": {

--- a/pkg/api/rpms.go
+++ b/pkg/api/rpms.go
@@ -93,8 +93,9 @@ type SearchRpmResponse struct {
 }
 
 type DetectRpmsResponse struct {
-	Found   []string `json:"found"`   // List of rpm names found in given repositories
-	Missing []string `json:"missing"` // List of rpm names not found in given repositories
+	Found         []string            `json:"found"`          // List of rpm names found in given repositories
+	Missing       []string            `json:"missing"`        // List of rpm names not found in given repositories
+	FoundPackages []SearchRpmResponse `json:"found_packages"` // Found packages with their summary
 }
 
 // SetMetadata Map metadata to the collection.

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -1062,8 +1062,9 @@ func (s *RpmSuite) TestDetectRpms() {
 				},
 			},
 			expected: api.DetectRpmsResponse{
-				Found:   []string{"demo-package", "test-package"},
-				Missing: []string{"fake-package"},
+				Found:         []string{"demo-package", "test-package"},
+				FoundPackages: []api.SearchRpmResponse{{PackageName: "demo-package", Summary: "demo-package Epoch 1"}, {PackageName: "test-package", Summary: "test-package Epoch 1"}},
+				Missing:       []string{"fake-package"},
 			},
 		},
 		{
@@ -1079,8 +1080,9 @@ func (s *RpmSuite) TestDetectRpms() {
 				},
 			},
 			expected: api.DetectRpmsResponse{
-				Found:   []string{"demo-package", "test-package"},
-				Missing: []string{"fake-package"},
+				Found:         []string{"demo-package", "test-package"},
+				FoundPackages: []api.SearchRpmResponse{{PackageName: "demo-package", Summary: "demo-package Epoch 0"}, {PackageName: "test-package", Summary: "test-package Epoch 0"}},
+				Missing:       []string{"fake-package"},
 			},
 		},
 		{
@@ -1100,8 +1102,9 @@ func (s *RpmSuite) TestDetectRpms() {
 				},
 			},
 			expected: api.DetectRpmsResponse{
-				Found:   []string{"demo-package", "test-package"},
-				Missing: []string{"fake-package"},
+				Found:         []string{"demo-package", "test-package"},
+				FoundPackages: []api.SearchRpmResponse{{PackageName: "demo-package", Summary: "demo-package Epoch 0"}, {PackageName: "test-package", Summary: "test-package Epoch 0"}},
+				Missing:       []string{"fake-package"},
 			},
 		},
 		{
@@ -1117,8 +1120,9 @@ func (s *RpmSuite) TestDetectRpms() {
 				},
 			},
 			expected: api.DetectRpmsResponse{
-				Found:   []string{"demo-package", "test-package"},
-				Missing: []string{},
+				Found:         []string{"demo-package", "test-package"},
+				FoundPackages: []api.SearchRpmResponse{{PackageName: "demo-package", Summary: "demo-package Epoch 0"}, {PackageName: "test-package", Summary: "test-package Epoch 0"}},
+				Missing:       []string{},
 			},
 		},
 		{
@@ -1147,8 +1151,9 @@ func (s *RpmSuite) TestDetectRpms() {
 		detectRpmsResponse, err = dao.DetectRpms(ctx, test.given.orgId, test.given.input)
 		require.NoError(t, err)
 		if detectRpmsResponse != nil {
-			assert.Equal(t, test.expected.Found, detectRpmsResponse.Found)
-			assert.Equal(t, test.expected.Missing, detectRpmsResponse.Missing)
+			assert.Equal(t, test.expected.Found, detectRpmsResponse.Found, test.name)
+			assert.Equal(t, test.expected.FoundPackages, detectRpmsResponse.FoundPackages, test.name)
+			assert.Equal(t, test.expected.Missing, detectRpmsResponse.Missing, test.name)
 		}
 	}
 


### PR DESCRIPTION
## Summary


## Testing steps

Create a repo for introspection (such as "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/")


call presence api with a package in it:

```
####
POST http://localhost:8000/api/content-sources/v1.0/rpms/presence
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
Content-Type: application/json

{
  "urls": [ "https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/"],
  "rpm_names": ["walrus"]
}


```


see response:

```

{
  "found": [
    "ruby-solv"
  ],
  "missing": [],
  "found_packages": [
    {
      "package_name": "ruby-solv",
      "summary": "Ruby bindings for the libsolv library"
    }
  ]
}
```
