### PR TITLE
Fixes 4964: add support for docker and importing arm repos

### DIFF
--- a/mk/compose.mk
+++ b/mk/compose.mk
@@ -31,7 +31,7 @@ compose-down: ## Shut down service  depdencies using podman(docker)-compose
 compose-clean: compose-down
 	if [ "$(DOCKER)" == "docker" ]; then \
 		$(DOCKER) volume prune --force --all; \
-    elif [ "$(DOCKER)" == "podman" ]; then \
+	elif [ "$(DOCKER)" == "podman" ]; then \
 		$(DOCKER) volume prune --force; \
 	fi
 

--- a/mk/compose.mk
+++ b/mk/compose.mk
@@ -29,7 +29,7 @@ compose-down: ## Shut down service  depdencies using podman(docker)-compose
 
 .PHONY: compose-clean ## Clear out data (dbs, files) for service dependencies
 compose-clean: compose-down
-	$(DOCKER) volume prune --force
+	$(DOCKER) volume prune --force --all
 
 .PHONY: compose-build
 compose-build: ## Build service dependencies using podman(docker)-compose

--- a/mk/compose.mk
+++ b/mk/compose.mk
@@ -29,7 +29,11 @@ compose-down: ## Shut down service  depdencies using podman(docker)-compose
 
 .PHONY: compose-clean ## Clear out data (dbs, files) for service dependencies
 compose-clean: compose-down
-	$(DOCKER) volume prune --force --all
+	if [ "$(DOCKER)" == "docker" ]; then \
+		$(DOCKER) volume prune --force --all; \
+    elif [ "$(DOCKER)" == "podman" ]; then \
+		$(DOCKER) volume prune --force; \
+	fi
 
 .PHONY: compose-build
 compose-build: ## Build service dependencies using podman(docker)-compose

--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -80,21 +80,24 @@
         "content_label": "rhel-9-for-aarch64-appstream-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os",
         "arch": "aarch64",
-        "distribution_version": "9"
+        "distribution_version": "9",
+        "selector": "arm"
     },
     {
         "name": "Red Hat Enterprise Linux 9 for ARM 64 - BaseOS (RPMs)",
         "content_label": "rhel-9-for-aarch64-baseos-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os",
         "arch": "aarch64",
-        "distribution_version": "9"
+        "distribution_version": "9",
+        "selector": "arm"
     },
     {
         "name": "Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)",
         "content_label": "codeready-builder-for-rhel-9-aarch64-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os",
         "arch": "aarch64",
-        "distribution_version": "9"
+        "distribution_version": "9",
+        "selector": "arm"
     },
     {
         "name": "Red Hat CodeReady Linux Builder for RHEL 8 ARM 64 (RPMs)",


### PR DESCRIPTION
## Summary

- Adjusts the make command for container volume removal to add support for docker
- Adds a selector to RHEL9 arm repos so it's easier to import those repos

## Testing steps

1. Using docker, `make compose-clean` should clear out all unused volumes
2. Using podman, `make compose-clean` should still work as before
3. Running `OPTIONS_REPOSITORY_IMPORT_FILTER=arm go run cmd/external-repos/main.go import && go run cmd/external-repos/main.go nightly-jobs` should import and snapshot RHEL9 arm repos
