### PR TITLE
Fixes 4962: remove content from product on delete

### DIFF
--- a/pkg/candlepin_client/candlepin_client_mock.go
+++ b/pkg/candlepin_client/candlepin_client_mock.go
@@ -628,6 +628,24 @@ func (_m *MockCandlepinClient) PromoteContentToEnvironment(ctx context.Context, 
 	return r0
 }
 
+// RemoveContentFromProduct provides a mock function with given fields: ctx, ownerKey, repoConfigUUID
+func (_m *MockCandlepinClient) RemoveContentFromProduct(ctx context.Context, ownerKey string, repoConfigUUID string) error {
+	ret := _m.Called(ctx, ownerKey, repoConfigUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveContentFromProduct")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, ownerKey, repoConfigUUID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RemoveContentOverrides provides a mock function with given fields: ctx, templateUUID, toRemove
 func (_m *MockCandlepinClient) RemoveContentOverrides(ctx context.Context, templateUUID string, toRemove []caliri.ContentOverrideDTO) error {
 	ret := _m.Called(ctx, templateUUID, toRemove)

--- a/pkg/candlepin_client/interface.go
+++ b/pkg/candlepin_client/interface.go
@@ -24,6 +24,7 @@ type CandlepinClient interface {
 	CreateContentBatch(ctx context.Context, orgID string, content []caliri.ContentDTO) error
 	CreateContent(ctx context.Context, orgID string, content caliri.ContentDTO) error
 	AddContentBatchToProduct(ctx context.Context, orgID string, contentIDs []string) error
+	RemoveContentFromProduct(ctx context.Context, ownerKey, repoConfigUUID string) error
 	UpdateContent(ctx context.Context, orgID string, repoConfigUUID string, content caliri.ContentDTO) error
 	FetchContent(ctx context.Context, orgID string, repoConfigUUID string) (*caliri.ContentDTO, error)
 	FetchContentsByLabel(ctx context.Context, orgID string, labels []string) ([]caliri.ContentDTO, error)

--- a/pkg/candlepin_client/product.go
+++ b/pkg/candlepin_client/product.go
@@ -74,6 +74,29 @@ func (c *cpClientImpl) AddContentBatchToProduct(ctx context.Context, orgID strin
 	return nil
 }
 
+func (c *cpClientImpl) RemoveContentFromProduct(ctx context.Context, orgID, repoConfigUUID string) error {
+	ctx, client, err := getCandlepinClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	ownerKey := OwnerKey(orgID)
+	productID := GetProductID(ownerKey)
+	contentID := GetContentID(repoConfigUUID)
+
+	_, httpResp, err := client.OwnerProductAPI.RemoveContentFromProduct(ctx, ownerKey, productID, contentID).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		if httpResp != nil && httpResp.StatusCode == 404 {
+			return nil
+		}
+		return errorWithResponseBody("couldn't remove content from product", httpResp, err)
+	}
+	return nil
+}
+
 func (c *cpClientImpl) ListProducts(ctx context.Context, orgID string, productIDs []string) ([]caliri.ProductDTO, error) {
 	ctx, client, err := getCandlepinClient(ctx)
 	if err != nil {

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -212,7 +212,12 @@ func (d *DeleteRepositorySnapshots) deleteCandlepinContent() error {
 		return nil
 	}
 
-	err := d.cpClient.DeleteContent(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
+	err := d.cpClient.RemoveContentFromProduct(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
+	if err != nil {
+		return err
+	}
+
+	err = d.cpClient.DeleteContent(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -99,6 +99,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithoutClient() {
 
 	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID).Return([]models.Snapshot{}, nil).Once()
 	s.mockDaoRegistry.RepositoryConfig.On("Delete", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
+	s.mockCpClient.On("RemoveContentFromProduct", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
@@ -135,6 +136,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithClient() {
 	s.MockPulpClient.On("GetRpmRemoteByName", ctx, repoConfig.UUID).Return(nil).Return(nil, nil).Once()
 	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(nil, nil).Once()
 
+	s.mockCpClient.On("RemoveContentFromProduct", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
@@ -200,6 +202,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 	s.MockPulpClient.On("DeleteRpmRepository", ctx, *repoResp.PulpHref).Return("taskHref", nil).Once()
 	s.MockPulpClient.On("DeleteRpmRemote", ctx, *remoteResp.PulpHref).Return("taskHref", nil).Once()
 
+	s.mockCpClient.On("RemoveContentFromProduct", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 


### PR DESCRIPTION
## Summary
This PR fixes an issues caused by a recent candlepin update which removed the convenience feature of auto-unlink content on deletion from products, now a separate call to remove content from the product has to be done before deleting the content.

## Testing steps
Tests and pipeline passes successfully.
