### PR TITLE
Fixes 4991: introspect rhel 10 beta repositories

### DIFF
--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -196,5 +196,17 @@
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/beta/rhel10/10/x86_64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/beta/rhel10/10/x86_64/baseos/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/beta/rhel10/10/aarch64/appstream/os"
+    },
+    {
+        "base_url": "https://cdn.redhat.com/content/beta/rhel10/10/aarch64/baseos/os"
     }
 ]


### PR DESCRIPTION
As part of an effort of letting image builder build beta releases, we'll need the beta repositories introspected.

## Summary

Just rhel 10 beta content

## Testing steps

