### PR TITLE
Fixes 4958: add rpm exact name search

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1996,6 +1996,7 @@ const docTemplate = `{
                 ],
                 "summary": "Detect RPMs presence",
                 "operationId": "detectRpm",
+                "deprecated": true,
                 "parameters": [
                     {
                         "description": "request body",
@@ -3385,6 +3386,13 @@ const docTemplate = `{
         "api.ContentUnitSearchRequest": {
             "type": "object",
             "properties": {
+                "exact_names": {
+                    "description": "List of names to search using an exact match",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "limit": {
                     "description": "Maximum number of records to return for the search",
                     "type": "integer"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -35,6 +35,13 @@
             },
             "api.ContentUnitSearchRequest": {
                 "properties": {
+                    "exact_names": {
+                        "description": "List of names to search using an exact match",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "limit": {
                         "description": "Maximum number of records to return for the search",
                         "type": "integer"
@@ -4198,6 +4205,7 @@
         },
         "/rpms/presence": {
             "post": {
+                "deprecated": true,
                 "description": "This enables users to detect presence of RPMs (Red Hat Package Manager) in a given list of repositories.",
                 "operationId": "detectRpm",
                 "requestBody": {

--- a/pkg/api/content_units.go
+++ b/pkg/api/content_units.go
@@ -7,10 +7,11 @@ type ContentUnitListRequest struct {
 }
 
 type ContentUnitSearchRequest struct {
-	URLs   []string `json:"urls,omitempty"`  // URLs of repositories to search
-	UUIDs  []string `json:"uuids,omitempty"` // List of repository UUIDs to search
-	Search string   `json:"search"`          // Search string to search content unit names
-	Limit  *int     `json:"limit,omitempty"` // Maximum number of records to return for the search
+	URLs       []string `json:"urls,omitempty"`        // URLs of repositories to search
+	UUIDs      []string `json:"uuids,omitempty"`       // List of repository UUIDs to search
+	Search     string   `json:"search"`                // Search string to search content unit names
+	ExactNames []string `json:"exact_names,omitempty"` // List of names to search using an exact match
+	Limit      *int     `json:"limit,omitempty"`       // Maximum number of records to return for the search
 }
 
 const ContentUnitSearchRequestLimitDefault int = 100

--- a/pkg/dao/environments_test.go
+++ b/pkg/dao/environments_test.go
@@ -415,6 +415,27 @@ func (s *EnvironmentSuite) TestEnvironmentSearch() {
 				},
 			},
 		},
+		{
+			name: "Exact match items are returned",
+			given: TestCaseGiven{
+				orgId: orgIDTest,
+				input: api.ContentUnitSearchRequest{
+					URLs: []string{
+						urls[0],
+						urls[1],
+					},
+					Search:     "environment",
+					ExactNames: []string{"demo-environment", "test"},
+					Limit:      utils.Ptr(1),
+				},
+			},
+			expected: []api.SearchEnvironmentResponse{
+				{
+					EnvironmentName: "demo-environment",
+					Description:     "demo-environment description",
+				},
+			},
+		},
 	}
 
 	// Running all the test cases

--- a/pkg/dao/package_groups_test.go
+++ b/pkg/dao/package_groups_test.go
@@ -454,6 +454,28 @@ func (s *PackageGroupSuite) TestPackageGroupSearch() {
 				},
 			},
 		},
+		{
+			name: "Exact matched items are returned",
+			given: TestCaseGiven{
+				orgId: orgIDTest,
+				input: api.ContentUnitSearchRequest{
+					URLs: []string{
+						urls[0],
+						urls[1],
+					},
+					Search:     "package",
+					ExactNames: []string{"demo-package-group", "test"},
+					Limit:      utils.Ptr(1),
+				},
+			},
+			expected: []api.SearchPackageGroupResponse{
+				{
+					PackageGroupName: "demo-package-group",
+					Description:      "demo-package-group description",
+					PackageList:      []string{"package1", "package2", "package3"},
+				},
+			},
+		},
 	}
 
 	// Running all the test cases

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -200,9 +200,15 @@ func (r rpmDaoImpl) Search(ctx context.Context, orgID string, request api.Conten
 		Select("DISTINCT ON(rpms.name) rpms.name as package_name", "rpms.summary").
 		Table(models.TableNameRpm).
 		Joins("inner join repositories_rpms on repositories_rpms.rpm_uuid = rpms.uuid").
-		Where("repositories_rpms.repository_uuid in ?", repoUuids).
-		Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search)).
-		Order("rpms.name ASC").
+		Where("repositories_rpms.repository_uuid in ?", repoUuids)
+
+	if len(request.ExactNames) != 0 {
+		db = db.Where("rpms.name in (?)", request.ExactNames)
+	} else {
+		db = db.Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search))
+	}
+
+	db = db.Order("rpms.name ASC").
 		Limit(*request.Limit).
 		Scan(&dataResponse)
 

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -467,6 +467,27 @@ func (s *RpmSuite) TestRpmSearch() {
 				},
 			},
 		},
+		{
+			name: "Exact matched items are returned",
+			given: TestCaseGiven{
+				orgId: orgIDTest,
+				input: api.ContentUnitSearchRequest{
+					URLs: []string{
+						urls[0],
+						urls[1],
+					},
+					Search:     "package",
+					ExactNames: []string{"demo-package"},
+					Limit:      utils.Ptr(50),
+				},
+			},
+			expected: []api.SearchRpmResponse{
+				{
+					PackageName: "demo-package",
+					Summary:     "demo-package Epoch",
+				},
+			},
+		},
 	}
 
 	// Running all the test cases

--- a/pkg/handler/rpms.go
+++ b/pkg/handler/rpms.go
@@ -188,6 +188,7 @@ func (rh *RpmHandler) listSnapshotRpm(c echo.Context) error {
 // @Failure      415 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /rpms/presence [post]
+// @Deprecated
 func (rh *RpmHandler) detectRpmsPresence(c echo.Context) error {
 	_, orgId := getAccountIdOrgId(c)
 	dataInput := api.DetectRpmsRequest{}


### PR DESCRIPTION
## Summary
Adds new parameter to the request body of name search for rpms, package groups, and environments, "exact_names", to search for content units that exactly match the given names.

Also, the RPM presence API will now show as deprecated in the API spec

## Testing steps
Example request
```
POST http://localhost:8000/api/content-sources/v1.0/rpms/names
Content-Type: application/json
x-Rh-Identity: {{identity-17791560}}

{
  "urls": ["https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/", "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/"],
  "search": "",
  "exact_names": ["penguin", "bear"]
}
```
1. With ["penguin", "bear"] as the value for "exact_names", both will be returned by the response
2. With ["penguin", "be"] as the value for "exact_names", only penguin will show, because "be" is not an exact match
