### PR TITLE
Fixes 5034: update latest snapshot after uploading content

### DIFF
--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -881,6 +881,7 @@ func (rh *RepositoryHandler) enqueueAddUploadsEvent(c echo.Context, response api
 		if err := rh.DaoRegistry.RepositoryConfig.UpdateLastSnapshotTask(c.Request().Context(), taskID.String(), response.OrgID, response.RepositoryUUID); err != nil {
 			logger.Error().Err(err).Msgf("error UpdatingLastSnapshotTask task for AddUploads")
 		}
+		rh.enqueueUpdateLatestSnapshotEvent(c, response.OrgID, taskID, response)
 	}
 
 	return taskID.String()

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -176,6 +176,15 @@ func mockTaskClientEnqueueAddUploads(repoSuite *ReposSuite, repo api.RepositoryR
 		repo.OrgID,
 		repo.RepositoryUUID,
 	).Return(nil)
+	repo.LastSnapshotTaskUUID = "00000000-0000-0000-0000-000000000000"
+	repoSuite.tcMock.On("Enqueue", queue.Task{
+		Typename:     config.UpdateLatestSnapshotTask,
+		Payload:      tasks.UpdateLatestSnapshotPayload{RepositoryConfigUUID: repo.UUID},
+		Dependencies: []uuid.UUID{dao.UuidifyString(repo.LastSnapshotTaskUUID)},
+		ObjectUUID:   &repo.RepositoryUUID,
+		ObjectType:   utils.Ptr(config.ObjectTypeRepository),
+		OrgId:        repo.OrgID,
+	}).Return(nil, nil)
 }
 
 func mockSnapshotDeleteEvent(tcMock *client.MockTaskClient, repoConfigUUID string) {


### PR DESCRIPTION
## Summary

Triggers the update-latest-snapshot task after uploading content to a repo. Without this, use_latest templates with upload repos wouldn't get updated with the latest content.

## Testing steps

(It's probably easiest to do most of this in the UI)

1. Add a RH repo and an upload repo with 1 rpm, let them snapshot
2. Create a template using those repos and set it to use latest content
3. Upload another rpm to the upload repo
4. Check the template's packages via the UI or the API (`/templates/:uuid/rpms?search=<uploaded_rpm_name>`). They should include all the uploaded packages
