### PR TITLE
Fixes 4928: fix worker task requeuing on start/stop

### DIFF
--- a/cmd/content-sources/main.go
+++ b/cmd/content-sources/main.go
@@ -106,6 +106,7 @@ func kafkaConsumer(ctx context.Context, wg *sync.WaitGroup, metrics *m.Metrics) 
 		if err != nil {
 			panic(err)
 		}
+		defer pgqueue.Close()
 		wrk := worker.NewTaskWorkerPool(&pgqueue, metrics)
 		wrk.RegisterHandler(config.IntrospectTask, tasks.IntrospectHandler)
 		wrk.RegisterHandler(config.RepositorySnapshotTask, tasks.SnapshotHandler)

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -205,6 +205,7 @@ func enqueueIntrospectAllRepos(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error getting new task queue: %w", err)
 	}
+	defer q.Close()
 	c := client.NewTaskClient(&q)
 
 	repoDao := dao.GetRepositoryDao(db.DB)
@@ -244,6 +245,7 @@ func enqueueSnapshotRepos(ctx context.Context, urls *[]string, interval *int) er
 	if err != nil {
 		return fmt.Errorf("error getting new task queue: %w", err)
 	}
+	defer q.Close()
 	c := client.NewTaskClient(&q)
 
 	repoConfigDao := dao.GetRepositoryConfigDao(db.DB, pulp_client.GetPulpClientWithDomain(""))

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -64,6 +64,7 @@ func RegisterRoutes(ctx context.Context, engine *echo.Echo) {
 	if err != nil {
 		panic(err)
 	}
+	defer pgqueue.Close()
 	taskClient := client.NewTaskClient(&pgqueue)
 	cpClient := candlepin_client.NewCandlepinClient()
 	ch := cache.Initialize()

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -64,7 +64,6 @@ func RegisterRoutes(ctx context.Context, engine *echo.Echo) {
 	if err != nil {
 		panic(err)
 	}
-	defer pgqueue.Close()
 	taskClient := client.NewTaskClient(&pgqueue)
 	cpClient := candlepin_client.NewCandlepinClient()
 	ch := cache.Initialize()

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -226,11 +226,6 @@ func NewPgxPool(ctx context.Context, url string) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("error establishing connection: %w", err)
 	}
 
-	// Allow for context cancellation to release the pool
-	go func() {
-		<-ctx.Done()
-	}()
-
 	return pool, nil
 }
 

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -131,6 +131,7 @@ const (
 type Pool interface {
 	Transaction
 	Acquire(ctx context.Context) (Connection, error)
+	Close()
 }
 
 // Transaction mimics the pgx.Tx struct
@@ -228,7 +229,6 @@ func NewPgxPool(ctx context.Context, url string) (*pgxpool.Pool, error) {
 	// Allow for context cancellation to release the pool
 	go func() {
 		<-ctx.Done()
-		pool.Close()
 	}()
 
 	return pool, nil
@@ -883,6 +883,10 @@ func (p *PgQueue) ListenForCancel(ctx context.Context, taskID uuid.UUID, cancelF
 		logger.Debug().Msg("[Canceled Task]")
 		cancelFunc(ErrTaskCanceled)
 	}
+}
+
+func (p *PgQueue) Close() {
+	p.Pool.Close()
 }
 
 func isContextCancelled(ctx context.Context) bool {

--- a/pkg/tasks/queue/pgx_pool_wrapper.go
+++ b/pkg/tasks/queue/pgx_pool_wrapper.go
@@ -13,6 +13,10 @@ type PgxPoolWrapper struct {
 	pool *pgxpool.Pool
 }
 
+func (p *PgxPoolWrapper) Close() {
+	p.pool.Close()
+}
+
 func (p *PgxPoolWrapper) Begin(ctx context.Context) (pgx.Tx, error) {
 	return p.pool.Begin(ctx)
 }
@@ -70,6 +74,8 @@ type FakePgxPoolWrapper struct {
 	tx   *pgx.Tx
 	conn *pgxpool.Conn
 }
+
+func (p *FakePgxPoolWrapper) Close() {}
 
 func (p *FakePgxPoolWrapper) Release() {
 	// This isn't a real pool so ignore

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -91,7 +91,7 @@ func (s *Suite) SetupTest() {
 	go func() {
 		<-wkrCtx.Done()
 		wrk.Stop()
-		defer wkrQueue.Close()
+		wkrQueue.Close()
 	}()
 }
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -91,6 +91,7 @@ func (s *Suite) SetupTest() {
 	go func() {
 		<-wkrCtx.Done()
 		wrk.Stop()
+		defer wkrQueue.Close()
 	}()
 }
 


### PR DESCRIPTION
## Summary
This PR fixes the problems introduced with the changes made to how we close the pg pool, which were required to prevent leaving hanging connections. The introduced problem was when workers tried requeuing tasks on the context stop, but the pool was already closed at that point, so the requeuing was moved to when the workers start.

## Testing steps
1. Enqueue a bunch of tasks.
2. CTRL+C to close the server.
3. Start the server again.
4. Verify that there are no errors:
    - error requeuing task with task_id: 959ae228-6974-499b-b049-8600832355a7
    - error starting database transaction: closed pool