### PR TITLE
HMS-5063: create job to cleanup missing domains

### DIFF
--- a/cmd/jobs/main.go
+++ b/cmd/jobs/main.go
@@ -17,6 +17,7 @@ func loadJobs() map[string]jobFunc {
 	return map[string]jobFunc{
 		"retry-failed-tasks":          jobs.RetryFailedTasks,
 		"create-latest-distributions": jobs.CreateLatestDistributions,
+		"cleanup-missing-domains":     jobs.CleanupMissingDomains,
 	}
 }
 

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -624,6 +624,82 @@ objects:
                     name: content-sources-candlepin
                     key: key
                     optional: true
+        - name: cleanup-missing-domains
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /jobs
+              - cleanup-missing-domains
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: RH_CDN_CERT_PAIR
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-certs
+                    key: cdn.redhat.com
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-sentry
+                    key: dsn
+                    optional: true
+              - name: CLIENTS_PULP_SERVER
+                value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
+              - name: CLIENTS_PULP_GUARD_SUBJECT_DN
+                value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
+              - name: CLIENTS_PULP_USERNAME
+                value: ${{CLIENTS_PULP_USERNAME}}
+              - name: CLIENTS_PULP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-content-sources-password
+                    key: password
+                    optional: true
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: OPTIONS_EXTERNAL_URL
+                value: ${OPTIONS_EXTERNAL_URL}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
+              - name: FEATURES_ADMIN_TASKS_ENABLED
+                value: ${FEATURES_ADMIN_TASKS_ENABLED}
+              - name: FEATURES_ADMIN_TASKS_ACCOUNTS
+                value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
+              - name: CLIENTS_RBAC_BASE_URL
+                value: ${{CLIENTS_RBAC_BASE_URL}}
+              - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
+                value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
       database:
         name: content-sources
         version: 15

--- a/deployments/jobs.yaml
+++ b/deployments/jobs.yaml
@@ -43,3 +43,13 @@ objects:
     appName: content-sources-backend
     jobs:
       - create-latest-distributions
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: content-sources-backend
+    name: cleanup-missing-domains-2024-12-03
+  spec:
+    appName: content-sources-backend
+    jobs:
+      - cleanup-missing-domains

--- a/pkg/dao/domain_dao_mock.go
+++ b/pkg/dao/domain_dao_mock.go
@@ -14,6 +14,24 @@ type MockDomainDao struct {
 	mock.Mock
 }
 
+// Delete provides a mock function with given fields: ctx, orgId, domainName
+func (_m *MockDomainDao) Delete(ctx context.Context, orgId string, domainName string) error {
+	ret := _m.Called(ctx, orgId, domainName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, orgId, domainName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Fetch provides a mock function with given fields: ctx, orgId
 func (_m *MockDomainDao) Fetch(ctx context.Context, orgId string) (string, error) {
 	ret := _m.Called(ctx, orgId)

--- a/pkg/dao/domains.go
+++ b/pkg/dao/domains.go
@@ -82,3 +82,12 @@ func (dDao domainDaoImpl) List(ctx context.Context) ([]models.Domain, error) {
 	}
 	return domains, nil
 }
+
+func (dDao domainDaoImpl) Delete(ctx context.Context, orgID string, domainName string) error {
+	var domain models.Domain
+	result := dDao.db.WithContext(ctx).Where("domain_name = ? AND org_id = ?", domainName, orgID).Delete(&domain)
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}

--- a/pkg/dao/domains_test.go
+++ b/pkg/dao/domains_test.go
@@ -87,3 +87,23 @@ func TestConcurrentGetDomainName(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func (ds *DomainSuite) TestDelete() {
+	orgId := "DomainSuiteTest"
+	dd := domainDaoImpl{db: ds.tx}
+
+	name, err := dd.Create(context.Background(), orgId)
+	assert.NoError(ds.T(), err)
+	assert.NotEmpty(ds.T(), name)
+
+	name, err = dd.Fetch(context.Background(), orgId)
+	assert.NoError(ds.T(), err)
+	assert.NotEmpty(ds.T(), name)
+
+	err = dd.Delete(context.Background(), orgId, name)
+	assert.NoError(ds.T(), err)
+
+	name, err = dd.Fetch(context.Background(), orgId)
+	assert.NoError(ds.T(), err)
+	assert.Empty(ds.T(), name)
+}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -146,6 +146,7 @@ type DomainDao interface {
 	FetchOrCreateDomain(ctx context.Context, orgId string) (string, error)
 	Fetch(ctx context.Context, orgId string) (string, error)
 	List(ctx context.Context) ([]models.Domain, error)
+	Delete(ctx context.Context, orgId string, domainName string) error
 }
 
 type PackageGroupDao interface {

--- a/pkg/jobs/cleanup_missing_domains.go
+++ b/pkg/jobs/cleanup_missing_domains.go
@@ -27,22 +27,20 @@ func CleanupMissingDomains() {
 		pulpHref, err := pulp_client.GetGlobalPulpClient().LookupDomain(ctx, domain.DomainName)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to lookup pulp domain")
-		} else {
-			if pulpHref == "" {
-				var snapCount int64 = 0
-				result := db.DB.Model(models.Snapshot{}).
-					Joins("inner join repository_configurations on repository_configurations.uuid = snapshots.repository_configuration_uuid").
-					Where("org_id = ?", domain.OrgId).Count(&snapCount)
-				if result.Error != nil {
-					log.Fatal().Err(err).Msg("failed to fetch snapshots for org")
-				}
-				if snapCount > 0 {
-					log.Error().Err(err).Msg("skipping domain deletion, snapshots exist in this org")
-				} else {
-					err := daoReg.Domain.Delete(ctx, domain.OrgId, domain.DomainName)
-					if err != nil {
-						log.Error().Err(err).Msg("failed to delete domain")
-					}
+		} else if pulpHref == "" {
+			var snapCount int64 = 0
+			result := db.DB.Model(models.Snapshot{}).
+				Joins("inner join repository_configurations on repository_configurations.uuid = snapshots.repository_configuration_uuid").
+				Where("org_id = ?", domain.OrgId).Count(&snapCount)
+			if result.Error != nil {
+				log.Fatal().Err(err).Msg("failed to fetch snapshots for org")
+			}
+			if snapCount > 0 {
+				log.Error().Err(err).Msg("skipping domain deletion, snapshots exist in this org")
+			} else {
+				err := daoReg.Domain.Delete(ctx, domain.OrgId, domain.DomainName)
+				if err != nil {
+					log.Error().Err(err).Msg("failed to delete domain")
 				}
 			}
 		}

--- a/pkg/jobs/cleanup_missing_domains.go
+++ b/pkg/jobs/cleanup_missing_domains.go
@@ -1,0 +1,50 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/pulp_client"
+	"github.com/rs/zerolog/log"
+)
+
+func CleanupMissingDomains() {
+	err := db.Connect()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to connect to database")
+	}
+
+	daoReg := dao.GetDaoRegistry(db.DB)
+	ctx := context.Background()
+
+	domains, err := daoReg.Domain.List(ctx)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to list domains")
+	}
+	for _, domain := range domains {
+		pulpHref, err := pulp_client.GetGlobalPulpClient().LookupDomain(ctx, domain.DomainName)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to lookup pulp domain")
+		} else {
+			if pulpHref == "" {
+				var snapCount int64 = 0
+				result := db.DB.Model(models.Snapshot{}).
+					Joins("inner join repository_configurations on repository_configurations.uuid = snapshots.repository_configuration_uuid").
+					Where("org_id = ?", domain.OrgId).Count(&snapCount)
+				if result.Error != nil {
+					log.Fatal().Err(err).Msg("failed to fetch snapshots for org")
+				}
+				if snapCount > 0 {
+					log.Error().Err(err).Msg("skipping domain deletion, snapshots exist in this org")
+				} else {
+					err := daoReg.Domain.Delete(ctx, domain.OrgId, domain.DomainName)
+					if err != nil {
+						log.Error().Err(err).Msg("failed to delete domain")
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a job to clean up the domains in our DB that are not in pulp

## Testing steps

You can use the pulp CLI to test this, setup docs [here](https://pulpproject.org/pulp-cli/)

1. Create 2 repos in different orgs and let them snapshot
2. List domains in pulp via the pulp CLI: `pulp domain list | jq '.[].name'`
3. Delete one of the repos
4. Delete the domain associated to the deleted repo's org ID in pulp via the pulp CLI: `pulp domain destroy --name <domain_name>`
5. List the domains in pulp again to confirm the domains that are left
6. Run this job to clean up the domains in our DB: `go run cmd/jobs/main.go cleanup-missing-domains`
7. List the domains in our DB. They should now match pulp's cs-prefixed domains
