### PR TITLE
Build: set longer pipeline timeout

### DIFF
--- a/.tekton/content-sources-backend-pull-request.yaml
+++ b/.tekton/content-sources-backend-pull-request.yaml
@@ -36,6 +36,10 @@ spec:
 
       _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
       This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+    # IQE Merge Request smoke-test job needs more than the default one hour to build the image and run the tests.
+    # See https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-failure-timeout
+    timeouts:
+      pipeline: 3h
     finally:
     - name: show-sbom
       params:


### PR DESCRIPTION
## Summary

    IQE Merge Request smoke-test job needs more than the default one hour to build the image and run the tests.
    This doc suggested adding a longer timeout for the whole pipeline as a start: https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-failure-timeout


## Testing steps

 pr checks pass

