### PR TITLE
Fixes 5145: remove epel 7 from migrations

### DIFF
--- a/db/migrations/20230215133838_RenameEpelUrls.up.sql
+++ b/db/migrations/20230215133838_RenameEpelUrls.up.sql
@@ -1,39 +1,61 @@
 BEGIN;
 
-INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
+INSERT INTO repositories (uuid, url, status) VALUES (
+    gen_random_uuid(),
+    'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/',
+    'Pending'
+) ON CONFLICT DO NOTHING;
 --- Update repo_configs and set the repo_uuid to the new url's repository, only if the repository_config is part of an org that does not also have the new url already
-UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/')
-    where repository_configurations.uuid in (
-        select rc.uuid from repository_configurations rc
-            inner join repositories on repositories.uuid = rc.repository_uuid
-            where repositories.url = 'https://download-i2.fedoraproject.org/pub/epel/9/Everything/x86_64/' and
-                  rc.org_id not in (select org_id
-                                            from repository_configurations rc2
-                                            inner join  repositories r2 on r2.uuid = rc2.repository_uuid
-                                            where r2.url = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'));
+UPDATE repository_configurations SET
+    repository_uuid
+    = (
+        SELECT uuid
+        FROM repositories
+        WHERE url = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'
+    )
+WHERE repository_configurations.uuid IN (
+    SELECT rc.uuid FROM repository_configurations AS rc
+    INNER JOIN repositories ON rc.repository_uuid = repositories.uuid
+    WHERE
+        repositories.url
+        = 'https://download-i2.fedoraproject.org/pub/epel/9/Everything/x86_64/'
+        AND rc.org_id NOT IN (
+            SELECT org_id
+            FROM repository_configurations AS rc2
+            INNER JOIN repositories AS r2 ON rc2.repository_uuid = r2.uuid
+            WHERE
+                r2.url
+                = 'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/'
+        )
+);
 
-INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
+INSERT INTO repositories (uuid, url, status) VALUES (
+    gen_random_uuid(),
+    'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/',
+    'Pending'
+) ON CONFLICT DO NOTHING;
 
-UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/')
-where repository_configurations.uuid in (
-    select rc.uuid from repository_configurations rc
-                            inner join repositories on repositories.uuid = rc.repository_uuid
-    where repositories.url = 'https://download-i2.fedoraproject.org/pub/epel/8/Everything/x86_64/' and
-            rc.org_id not in (select org_id
-                              from repository_configurations rc2
-                                       inner join  repositories r2 on r2.uuid = rc2.repository_uuid
-                              where r2.url = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/'));
-
-
-INSERT into repositories (uuid, url, status) values (gen_random_uuid(), 'https://dl.fedoraproject.org/pub/epel/7/x86_64/', 'Pending') ON CONFLICT DO NOTHING;
-UPDATE repository_configurations set repository_uuid = (select uuid from repositories where url = 'https://dl.fedoraproject.org/pub/epel/7/x86_64/')
-where repository_configurations.uuid in (
-    select rc.uuid from repository_configurations rc
-                            inner join repositories on repositories.uuid = rc.repository_uuid
-    where repositories.url = 'https://download-i2.fedoraproject.org/pub/epel/7/x86_64/' and
-            rc.org_id not in (select org_id
-                              from repository_configurations rc2
-                                       inner join  repositories r2 on r2.uuid = rc2.repository_uuid
-                              where r2.url = 'https://dl.fedoraproject.org/pub/epel/7/x86_64/'));
+UPDATE repository_configurations SET
+    repository_uuid
+    = (
+        SELECT uuid
+        FROM repositories
+        WHERE url = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/'
+    )
+WHERE repository_configurations.uuid IN (
+    SELECT rc.uuid FROM repository_configurations AS rc
+    INNER JOIN repositories ON rc.repository_uuid = repositories.uuid
+    WHERE
+        repositories.url
+        = 'https://download-i2.fedoraproject.org/pub/epel/8/Everything/x86_64/'
+        AND rc.org_id NOT IN (
+            SELECT org_id
+            FROM repository_configurations AS rc2
+            INNER JOIN repositories AS r2 ON rc2.repository_uuid = r2.uuid
+            WHERE
+                r2.url
+                = 'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/'
+        )
+);
 
 COMMIT;


### PR DESCRIPTION
## Summary
This PR removes the `epel 7` repo insert from our DB migrations, this is causing errors when newly created deployments (local, emphemeral) are spun up and it's attempted to introspect this repo, because it no longer exists. 

## Testing steps
1. Spin up a new local deployment with: `make compose-clean && make compose-up`
2. Run nightly jobs (`go run cmd/external-repos/main.go nightly-jobs`) and verify there are no errors concerning epel 7 introspection, like:
    `error introspecting https://dl.fedoraproject.org/pub/epel/7/x86_64/: Cannot fetch https://dl.fedoraproject.org/pub/epel/7/x86_64/repodata/repomd.xml: 404`
