### PR TITLE
HMS-4987: fix 500s on invalid input syntax

### DIFF
--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -508,10 +508,10 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Conte
 	var count int64
 	resp := sDao.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).Where("org_id = ? or org_id = ?", orgID, config.RedHatOrg).Where("uuid in ?", UuidifyStrings(request.RepositoryUUIDS)).Count(&count)
 	if resp.Error != nil {
-		return api.ListSnapshotByDateResponse{}, fmt.Errorf("could not query repository uuids: %w", resp.Error)
+		return api.ListSnapshotByDateResponse{}, fmt.Errorf("could not query repository UUIDs: %w", resp.Error)
 	}
 	if count != int64(len(request.RepositoryUUIDS)) {
-		return api.ListSnapshotByDateResponse{}, &ce.DaoError{NotFound: true, Message: "One or more repository uuids was invalid."}
+		return api.ListSnapshotByDateResponse{}, &ce.DaoError{NotFound: true, Message: "One or more repository UUIDs was invalid."}
 	}
 
 	snaps, err := sDao.FetchSnapshotsModelByDateAndRepository(ctx, orgID, request)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -628,7 +628,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryNotFound() {
 	sDao := GetSnapshotDao(tx)
 	_, err := sDao.FetchSnapshotsByDateAndRepository(context.Background(), orgIDTest, request)
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "One or more repository uuids was invalid.")
+	assert.Equal(t, err.Error(), "One or more repository UUIDs was invalid.")
 }
 
 func (s *SnapshotsSuite) TestListByTemplate() {


### PR DESCRIPTION
## Summary

- Fixes "invalid input syntax" errors when requesting to fetch the latest snapshot and list snapshots by date
- Adds validation to the repository uuids in requests to list snapshots by date

## Testing steps

1. Make a request to `/repositories/:uuid/config.repo` with the uuid set to something like "uuid". This should return a 404.
2. Make a request to `/snapshots/for_date/` with the repository_uuids set to something like ["uuid1", "uuid2"]. This should also return a 404.