### PR TITLE
HMS-5062: fix del-templ task fail if repo is deleted first

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -168,7 +168,7 @@ type TemplateDao interface {
 	Create(ctx context.Context, templateRequest api.TemplateRequest) (api.TemplateResponse, error)
 	Fetch(ctx context.Context, orgID string, uuid string, includeSoftDel bool) (api.TemplateResponse, error)
 	InternalOnlyFetchByName(ctx context.Context, name string) (models.Template, error)
-	List(ctx context.Context, orgID string, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error)
+	List(ctx context.Context, orgID string, includeSoftDel bool, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error)
 	SoftDelete(ctx context.Context, orgID string, uuid string) error
 	Delete(ctx context.Context, orgID string, uuid string) error
 	ClearDeletedAt(ctx context.Context, orgID string, uuid string) error

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -309,11 +309,14 @@ func (t templateDaoImpl) update(ctx context.Context, tx *gorm.DB, orgID string, 
 	return nil
 }
 
-func (t templateDaoImpl) List(ctx context.Context, orgID string, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error) {
+func (t templateDaoImpl) List(ctx context.Context, orgID string, includeSoftDel bool, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error) {
 	var totalTemplates int64
 	templates := make([]models.Template, 0)
 
 	filteredDB := t.filteredDbForList(orgID, t.db.WithContext(ctx), filterData)
+	if includeSoftDel {
+		filteredDB = filteredDB.Unscoped()
+	}
 
 	sortMap := map[string]string{
 		"name":    "name",

--- a/pkg/dao/templates_mock.go
+++ b/pkg/dao/templates_mock.go
@@ -286,9 +286,9 @@ func (_m *MockTemplateDao) InternalOnlyFetchByName(ctx context.Context, name str
 	return r0, r1
 }
 
-// List provides a mock function with given fields: ctx, orgID, paginationData, filterData
-func (_m *MockTemplateDao) List(ctx context.Context, orgID string, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error) {
-	ret := _m.Called(ctx, orgID, paginationData, filterData)
+// List provides a mock function with given fields: ctx, orgID, includeSoftDel, paginationData, filterData
+func (_m *MockTemplateDao) List(ctx context.Context, orgID string, includeSoftDel bool, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error) {
+	ret := _m.Called(ctx, orgID, includeSoftDel, paginationData, filterData)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -297,23 +297,23 @@ func (_m *MockTemplateDao) List(ctx context.Context, orgID string, paginationDat
 	var r0 api.TemplateCollectionResponse
 	var r1 int64
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, api.PaginationData, api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error)); ok {
-		return rf(ctx, orgID, paginationData, filterData)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool, api.PaginationData, api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error)); ok {
+		return rf(ctx, orgID, includeSoftDel, paginationData, filterData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, api.PaginationData, api.TemplateFilterData) api.TemplateCollectionResponse); ok {
-		r0 = rf(ctx, orgID, paginationData, filterData)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool, api.PaginationData, api.TemplateFilterData) api.TemplateCollectionResponse); ok {
+		r0 = rf(ctx, orgID, includeSoftDel, paginationData, filterData)
 	} else {
 		r0 = ret.Get(0).(api.TemplateCollectionResponse)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, api.PaginationData, api.TemplateFilterData) int64); ok {
-		r1 = rf(ctx, orgID, paginationData, filterData)
+	if rf, ok := ret.Get(1).(func(context.Context, string, bool, api.PaginationData, api.TemplateFilterData) int64); ok {
+		r1 = rf(ctx, orgID, includeSoftDel, paginationData, filterData)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, api.PaginationData, api.TemplateFilterData) error); ok {
-		r2 = rf(ctx, orgID, paginationData, filterData)
+	if rf, ok := ret.Get(2).(func(context.Context, string, bool, api.PaginationData, api.TemplateFilterData) error); ok {
+		r2 = rf(ctx, orgID, includeSoftDel, paginationData, filterData)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -241,7 +242,7 @@ func (s *TemplateSuite) TestList() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -268,7 +269,7 @@ func (s *TemplateSuite) TestListNoTemplates() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(0), total)
 
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(0), total)
 	assert.Len(s.T(), responses.Data, 0)
@@ -288,7 +289,7 @@ func (s *TemplateSuite) TestListPageLimit() {
 	assert.Equal(s.T(), int64(20), total)
 
 	paginationData := api.PaginationData{Limit: 10}
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, paginationData, api.TemplateFilterData{})
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, paginationData, api.TemplateFilterData{})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(20), total)
 	assert.Len(s.T(), responses.Data, 10)
@@ -323,7 +324,7 @@ func (s *TemplateSuite) TestListFilters() {
 
 	// Test filter by name
 	filterData := api.TemplateFilterData{Name: found[0].Name}
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -331,7 +332,7 @@ func (s *TemplateSuite) TestListFilters() {
 
 	// Test filter by version
 	filterData = api.TemplateFilterData{Version: found[0].Version}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -339,7 +340,7 @@ func (s *TemplateSuite) TestListFilters() {
 
 	// Test filter by arch
 	filterData = api.TemplateFilterData{Arch: found[0].Arch}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -348,7 +349,7 @@ func (s *TemplateSuite) TestListFilters() {
 	// Test Filter by RepositoryUUIDs
 	template, rcUUIDs := s.seedWithRepoConfig(orgIDTest, 2)
 	filterData = api.TemplateFilterData{RepositoryUUIDs: []string{rcUUIDs[0], rcUUIDs[1]}}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -371,14 +372,14 @@ func (s *TemplateSuite) TestListFilterSearch() {
 	assert.Equal(s.T(), int64(2), total)
 
 	filterData := api.TemplateFilterData{Search: found[0].Name[0:7]}
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
 }
 
 func (s *TemplateSuite) TestListBySnapshot() {
-	templateDao := templateDaoImpl{db: s.tx}
+	templateDao := s.templateDao()
 	var err error
 	var found []models.Template
 	var total int64
@@ -411,16 +412,39 @@ func (s *TemplateSuite) TestListBySnapshot() {
 	assert.Equal(s.T(), int64(2), total)
 
 	filterData := api.TemplateFilterData{SnapshotUUIDs: []string{r2snaps[0].UUID}}
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
 
 	filterData = api.TemplateFilterData{SnapshotUUIDs: []string{r1snaps[1].UUID}}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
+}
+
+func (s *TemplateSuite) TestListIncludeSoftDel() {
+	templateDao := s.templateDao()
+	var err error
+
+	_, err = seeds.SeedTemplates(s.tx, 1, seeds.TemplateSeedOptions{OrgID: orgIDTest})
+	assert.Nil(s.T(), err)
+
+	template := models.Template{}
+	err = s.tx.
+		First(&template, "org_id = ?", orgIDTest).
+		Error
+	require.NoError(s.T(), err)
+
+	err = templateDao.SoftDelete(context.Background(), template.OrgID, template.UUID)
+	assert.NoError(s.T(), err)
+
+	resp, _, err := templateDao.List(context.Background(), template.OrgID, true, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), slices.ContainsFunc(resp.Data, func(tr api.TemplateResponse) bool {
+		return tr.UUID == template.UUID
+	}))
 }
 
 func (s *TemplateSuite) TestDelete() {

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -141,7 +141,7 @@ func (th *TemplateHandler) listTemplates(c echo.Context) error {
 	pageData := ParsePagination(c)
 	filterData := ParseTemplateFilters(c)
 
-	templates, total, err := th.DaoRegistry.Template.List(c.Request().Context(), orgID, pageData, filterData)
+	templates, total, err := th.DaoRegistry.Template.List(c.Request().Context(), orgID, false, pageData, filterData)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing templates", err.Error())
 	}

--- a/pkg/handler/templates_test.go
+++ b/pkg/handler/templates_test.go
@@ -181,7 +181,7 @@ func (suite *TemplatesSuite) TestList() {
 	orgID := test_handler.MockOrgId
 	collection := createTemplateCollection(1, 10, 0)
 	paginationData := api.PaginationData{Limit: 10, Offset: DefaultOffset}
-	suite.reg.Template.On("List", test.MockCtx(), orgID, paginationData, api.TemplateFilterData{}).Return(collection, int64(1), nil)
+	suite.reg.Template.On("List", test.MockCtx(), orgID, false, paginationData, api.TemplateFilterData{}).Return(collection, int64(1), nil)
 
 	path := fmt.Sprintf("%s/templates/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -208,7 +208,7 @@ func (suite *TemplatesSuite) TestListNoTemplates() {
 
 	collection := api.TemplateCollectionResponse{}
 	paginationData := api.PaginationData{Limit: DefaultLimit, Offset: DefaultOffset}
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData, api.TemplateFilterData{}).Return(collection, int64(0), nil)
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData, api.TemplateFilterData{}).Return(collection, int64(0), nil)
 
 	req := httptest.NewRequest(http.MethodGet, api.FullRootPath()+"/templates/", nil)
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
@@ -235,8 +235,8 @@ func (suite *TemplatesSuite) TestTemplatePagedExtraRemaining() {
 	paginationData1 := api.PaginationData{Limit: 10, Offset: 0}
 	paginationData2 := api.PaginationData{Limit: 10, Offset: 100}
 
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData1, api.TemplateFilterData{}).Return(collection, int64(102), nil).Once()
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData2, api.TemplateFilterData{}).Return(collection, int64(102), nil).Once()
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData1, api.TemplateFilterData{}).Return(collection, int64(102), nil).Once()
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData2, api.TemplateFilterData{}).Return(collection, int64(102), nil).Once()
 
 	path := fmt.Sprintf("%s/templates/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -270,7 +270,7 @@ func (suite *TemplatesSuite) TestListWithFilters() {
 	t := suite.T()
 	collection := api.TemplateCollectionResponse{}
 
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, api.PaginationData{Limit: 100}, api.TemplateFilterData{Name: "template", Arch: "x86_64",
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, api.PaginationData{Limit: 100}, api.TemplateFilterData{Name: "template", Arch: "x86_64",
 		RepositoryUUIDs: []string{"abcd", "efgh"}}).Return(collection, int64(100), nil)
 
 	path := fmt.Sprintf("%s/templates/?name=%v&arch=%v&repository_uuids=%v", api.FullRootPath(), "template", "x86_64", "abcd,efgh")
@@ -288,8 +288,8 @@ func (suite *TemplatesSuite) TestListPagedNoRemaining() {
 	paginationData2 := api.PaginationData{Limit: 10, Offset: 90}
 
 	collection := api.TemplateCollectionResponse{}
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData1, api.TemplateFilterData{}).Return(collection, int64(100), nil)
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData2, api.TemplateFilterData{}).Return(collection, int64(100), nil)
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData1, api.TemplateFilterData{}).Return(collection, int64(100), nil)
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData2, api.TemplateFilterData{}).Return(collection, int64(100), nil)
 
 	path := fmt.Sprintf("%s/templates/?limit=%d", api.FullRootPath(), 10)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -327,7 +327,7 @@ func (suite *TemplatesSuite) TestListDaoError() {
 	}
 	paginationData := api.PaginationData{Limit: DefaultLimit}
 
-	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, paginationData, api.TemplateFilterData{}).
+	suite.reg.Template.On("List", test.MockCtx(), test_handler.MockOrgId, false, paginationData, api.TemplateFilterData{}).
 		Return(api.TemplateCollectionResponse{}, int64(0), &daoError)
 
 	path := fmt.Sprintf("%s/templates/", api.FullRootPath())

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -103,6 +103,11 @@ func (d *DeleteRepositorySnapshots) Run() error {
 			}
 		}
 
+		err = d.deleteTemplateRepoDistributions()
+		if err != nil {
+			return err
+		}
+
 		for _, snap := range snaps {
 			_, err = d.deleteRpmDistribution(snap.DistributionHref)
 			if err != nil {
@@ -222,7 +227,11 @@ func (d *DeleteRepositorySnapshots) deleteCandlepinContent() error {
 		return err
 	}
 
-	templates, _, err := d.daoReg.Template.List(d.ctx, d.task.OrgId, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{d.payload.RepoConfigUUID}})
+	return nil
+}
+
+func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() error {
+	templates, _, err := d.daoReg.Template.List(d.ctx, d.task.OrgId, true, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{d.payload.RepoConfigUUID}})
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -138,8 +138,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithClient() {
 
 	s.mockCpClient.On("RemoveContentFromProduct", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
-	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
-
+	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, true, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 	payload := DeleteRepositorySnapshotsPayload{
 		RepoConfigUUID: repoConfig.UUID,
 	}
@@ -204,7 +203,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 
 	s.mockCpClient.On("RemoveContentFromProduct", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockCpClient.On("DeleteContent", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
-	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
+	s.mockDaoRegistry.Template.On("List", ctx, repoConfig.OrgID, true, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{repoConfig.UUID}}).Return(api.TemplateCollectionResponse{}, int64(0), nil).Once()
 
 	payload := DeleteRepositorySnapshotsPayload{
 		RepoConfigUUID: repoConfig.UUID,

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -188,7 +188,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 
 func (ds *DeleteSnapshots) updateTemplatesUsingSnap(templateUpdateMap *map[string]models.Snapshot, snap models.Snapshot) error {
 	repoUUIDs := []string{snap.RepositoryConfigurationUUID}
-	templates, count, err := ds.daoReg.Template.List(ds.ctx, ds.orgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{
+	templates, count, err := ds.daoReg.Template.List(ds.ctx, ds.orgID, false, api.PaginationData{Limit: -1}, api.TemplateFilterData{
 		SnapshotUUIDs: []string{snap.UUID},
 	})
 	if err != nil {

--- a/pkg/tasks/delete_snapshots_test.go
+++ b/pkg/tasks/delete_snapshots_test.go
@@ -97,7 +97,7 @@ func (s *DeleteSnapshotsSuite) TestDeleteSnapshots() {
 	s.mockDaoRegistry.RepositoryConfig.On("Fetch", ctx, orgID, repo.UUID).Return(repo, nil)
 	s.mockDaoRegistry.Snapshot.On("FetchModel", ctx, snap.UUID, true).Return(snap, nil)
 	s.mockDaoRegistry.Snapshot.On("Delete", ctx, snap.UUID).Return(nil)
-	s.mockDaoRegistry.Template.On("List", ctx, orgID, mock.Anything, mock.Anything).Return(templateCollection, int64(1), nil)
+	s.mockDaoRegistry.Template.On("List", ctx, orgID, false, mock.Anything, mock.Anything).Return(templateCollection, int64(1), nil)
 	s.mockDaoRegistry.Snapshot.On("FetchSnapshotsModelByDateAndRepository", ctx, orgID, mock.Anything).Return([]models.Snapshot{snap2}, nil)
 	s.mockDaoRegistry.Template.On("UpdateSnapshots", ctx, template.UUID, []string{snap.RepositoryConfigurationUUID}, []models.Snapshot{snap2}).Return(nil)
 	s.mockDaoRegistry.Template.On("DeleteTemplateSnapshot", ctx, snap.UUID).Return(nil)

--- a/pkg/tasks/update_latest_snapshot.go
+++ b/pkg/tasks/update_latest_snapshot.go
@@ -69,7 +69,7 @@ type UpdateLatestSnapshot struct {
 func (t *UpdateLatestSnapshot) Run() error {
 	var err error
 	filterData := api.TemplateFilterData{UseLatest: true, RepositoryUUIDs: []string{t.payload.RepositoryConfigUUID}}
-	templates, _, err := t.daoReg.Template.List(t.ctx, t.orgID, api.PaginationData{Limit: -1}, filterData)
+	templates, _, err := t.daoReg.Template.List(t.ctx, t.orgID, false, api.PaginationData{Limit: -1}, filterData)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/update_repository.go
+++ b/pkg/tasks/update_repository.go
@@ -106,7 +106,7 @@ func (ur *UpdateRepository) UpdateCPContent(content caliri.ContentDTO) error {
 }
 
 func (ur *UpdateRepository) UpdateContentOverrides() error {
-	templates, _, err := ur.daoReg.Template.List(ur.ctx, ur.orgID, api.PaginationData{Limit: -1}, api.TemplateFilterData{
+	templates, _, err := ur.daoReg.Template.List(ur.ctx, ur.orgID, false, api.PaginationData{Limit: -1}, api.TemplateFilterData{
 		RepositoryUUIDs: []string{ur.repoConfig.UUID},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR fixes a bug that happens when a repository exists within a template, and both are deleted, but the repository config is deleted before the template is deleted, then the `delete-templates` task gives a "repository not found" error and if this happens the template-repository distribution doesn't get deleted and remains an orphan.

The ticket assumed that the `delete-repository-snapshots` task didn't try deleting the template-repository distribution, but it actually already was trying to do so, but that step just needed to be moved earlier in the task and also do that for soft deleted templates. The `delete-template` task just needed to be changed to ignore not found repository configs.

## Testing steps
1. Create a custom repository and add it to a new template.
2. Note down the template-repository distribution href (look it up by uuids in `SELECT * FROM templates_repository_configurations;`) and verify it exists (`http -a admin:password :8080/${DISTRIBUTION_HREF}`).
3. Change `retry_wait_upper_bound` in `config.yaml` to 3m.
4. Edit the `Run()` method of `delete_templates.go` to force a failure by returning an error (add `return errors.new("test error")` at the beginning).
5. Delete the template.
6. Delete the repository configuration.
7. Once the `delete-repository-snapshot` task finishes, stop the server.
8. Fix the `Run()` from step 3, so it runs correctly, then restart the server.
9. The `delete-templates` tasks will retry and it should be completed successfully.
10. Verify the template-repository distribution was deleted (`http -a admin:password :8080/${DISTRIBUTION_HREF}` -> `404`).
