### PR TITLE
HMS-5202: don't always rerun failed snaps

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -269,6 +269,7 @@ func enqueueSnapshotRepos(ctx context.Context, urls *[]string, interval *int) er
 		}
 		taskUuid, err := c.Enqueue(t)
 		if err == nil {
+			log.Info().Msgf("enqueued snapshot for repository config %v", repo.UUID)
 			if err := repoConfigDao.UpdateLastSnapshotTask(ctx, taskUuid.String(), repo.OrgID, repo.RepositoryUUID); err != nil {
 				log.Error().Err(err).Msgf("error UpdatingLastSnapshotTask task during nightly job")
 			}

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -2456,11 +2456,11 @@ func (suite *RepositoryConfigSuite) TestListReposToSnapshot() {
 		{
 			Name:     "Previous Snapshot Failed",
 			Opts:     &seeds.TaskSeedOptions{RepoConfigUUID: repo.UUID, OrgID: repo.OrgID, Status: config.TaskStatusFailed},
-			Included: true,
+			Included: false,
 		},
 		{
-			Name:     "Previous Snapshot Failed, and url specified",
-			Opts:     &seeds.TaskSeedOptions{RepoConfigUUID: repo.UUID, OrgID: repo.OrgID, Status: config.TaskStatusFailed},
+			Name:     "Previous Snapshot Failed, yesterday",
+			Opts:     &seeds.TaskSeedOptions{RepoConfigUUID: repo.UUID, OrgID: repo.OrgID, Status: config.TaskStatusFailed, QueuedAt: &yesterday},
 			Included: true,
 			Filter:   &ListRepoFilter{URLs: &[]string{repo.URL}},
 		},


### PR DESCRIPTION
## Summary

After some investigation it was discovered that currently all failed snapshots are being re-run every hour.  This results in no 'extra' repos being synced.   This change results in failed snapshots only being re-run every day.  

This also fixes a couple of things, such as sorting by finished_at (instead of queued_at), and re-snapshotting every 25 hours instead of 24 (need to subtract one from the query)

## Testing steps

1.   Create 3 repos with snapshotting, two that are real and one that isn't:

https://fixtures.pulpproject.org/rpm-unsigned/
https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/
https://redhat.com/notarepo

2.  on main, run `go run cmd/external-repos/main.go nightly-jobs 24`

for consistentcy do not re-run it until snapshots are done
everytime you run it, you'll see one snapshot get run and its always the same one, the one that failed

3.  re run `go run cmd/external-repos/main.go nightly-jobs 24`  on this PR, 
now everytime you run it, you'll get a different  one of the repos which should alternate between all 3:

i added some logging to make this easier to see: ```enqueued snapshot for repository config 147df40e-e1be-40a5-bcb2-726b6e63818c```
