### PR TITLE
Build: update api spec for list snapshots by repo

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1755,6 +1755,24 @@ const docTemplate = `{
                         "name": "uuid",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort the response data based on specific repository parameters. Sort criteria can include ` + "`" + `created_at` + "`" + `.",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:` + "`" + `0` + "`" + `.",
+                        "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: ` + "`" + `100` + "`" + `.",
+                        "name": "limit",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3975,6 +3975,30 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Sort the response data based on specific repository parameters. Sort criteria can include `created_at`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "responses": {

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -99,8 +99,11 @@ func (sh *SnapshotHandler) listSnapshotsForTemplate(c echo.Context) error {
 // @Tags         snapshots
 // @Accept       json
 // @Produce      json
-// @Param  uuid  path  string    true  "Repository ID."
-// @Success      200   {object}  api.SnapshotCollectionResponse
+// @Param        uuid path string true "Repository ID."
+// @Param		 sort_by query string false "Sort the response data based on specific repository parameters. Sort criteria can include `created_at`."
+// @Param  		 offset query int false "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`."
+// @Param		 limit query int false "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`."
+// @Success      200 {object} api.SnapshotCollectionResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      401 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse


### PR DESCRIPTION
## Summary
This PR adds missing API spec filters for listing snapshots of a repository, needed in IQE for testing automatic snapshot deletion.
Related ticket: [HMS-4749](https://issues.redhat.com/browse/HMS-4749)

