### PR TITLE
HMS-5259: cleanup canceled tasks

### DIFF
--- a/pkg/config/tasks.go
+++ b/pkg/config/tasks.go
@@ -27,7 +27,7 @@ var CancellableTasks = []string{IntrospectTask, RepositorySnapshotTask, UpdateTe
 const ObjectTypeRepository = "repository"
 const ObjectTypeTemplate = "template"
 
-// TasksToCleanup tasks that will get deleted, completed or failed, if older than 20 days
+// TasksToCleanup tasks that will get deleted, completed, canceled or failed, if older than 20 days
 var TasksToCleanup = []string{
 	IntrospectTask,
 	RepositorySnapshotTask,

--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -126,13 +126,18 @@ func (t taskInfoDaoImpl) List(
 }
 
 func (t taskInfoDaoImpl) Cleanup(ctx context.Context) error {
-	// Delete all completed or failed specified tasks that are older than 10 days
+	// Delete all completed or failed specified tasks that are older than 20 days
+	// Delete all the canceled tasks that are older than 20 days (by queued time)
 	// Delete all finished delete tasks that are older 10 days
 	// Do not delete tasks if they are the last update-template-content task that updated a template
 	q := "delete from tasks where " +
-		"((type in (%v) and (status = 'completed' or status = 'failed') and finished_at < (current_date - interval '20' day)) OR" +
-		"(type in (%v) and status = 'completed' and  finished_at < (current_date - interval '10' day)))" +
-		"AND NOT EXISTS (SELECT 1 FROM templates WHERE templates.last_update_task_uuid = tasks.id)"
+		"(type in (%v) and " +
+		"((status = 'completed' or status = 'failed') and finished_at < (current_date - interval '20' day)) OR" +
+		"((status = 'canceled') and queued_at < (current_date - interval '20' day)))" +
+		"OR" +
+		"(type in (%v) and " +
+		"status = 'completed' and  finished_at < (current_date - interval '10' day)" +
+		"AND NOT EXISTS (SELECT 1 FROM templates WHERE templates.last_update_task_uuid = tasks.id))"
 	q = fmt.Sprintf(q, stringSliceToQueryList(config.TasksToCleanup), stringSliceToQueryList(config.TasksToCleanupIfCompleted))
 	result := t.db.WithContext(ctx).Exec(q)
 	if result.Error != nil {

--- a/pkg/dao/task_info_test.go
+++ b/pkg/dao/task_info_test.go
@@ -624,6 +624,18 @@ func (suite *TaskInfoSuite) TestTaskCleanup() {
 				config.TaskStatusCompleted, repoToKeep),
 			beDeleted: false,
 		},
+		{
+			name: "oldCanceledTask",
+			task: suite.NewTaskForCleanup(config.UpdateLatestSnapshotTask, time.Now().Add(-32*24*time.Hour),
+				config.TaskStatusCanceled, repoToKeep),
+			beDeleted: true,
+		},
+		{
+			name: "newCanceledTask",
+			task: suite.NewTaskForCleanup(config.UpdateLatestSnapshotTask, time.Now().Add(-1*24*time.Hour),
+				config.TaskStatusCanceled, repoToKeep),
+			beDeleted: false,
+		},
 	}
 	for _, testCase := range cases {
 		createErr := suite.tx.Create(&testCase.task).Error


### PR DESCRIPTION
## Summary
Adds canceled tasks to the query that cleans up all the old the tasks. Cleans up canceled with a queued_at time older than 20 days, not finished_at because canceled tasks do not have a finished_at time

## Testing steps
1. Create and then delete a repository so that the snapshot and/or update-latest-snapshot tasks get canceled
2. Manually edit the queued_at time so it is older than 20 days
3. Run nightly-jobs and the task should be cleaned up
