### PR TITLE
Build: fix bad function call from commit conflicts

### DIFF
--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -427,7 +427,7 @@ func (s *TemplateSuite) TestListBySnapshot() {
 		RepositoryUUIDs: []string{r2.UUID},
 		SnapshotUUIDs:   []string{r1snaps[1].UUID},
 	}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -445,7 +445,7 @@ func (s *TemplateSuite) TestListToBeDeletedSnapshots() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, api.TemplateFilterData{})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)


### PR DESCRIPTION
## Summary

There was a conflict between two commits  https://github.com/content-services/content-sources-backend/pull/927 & https://github.com/content-services/content-sources-backend/commit/1ca2e121cff58800b4b6f6295105eaf7a269a650

## Testing steps

