### PR TITLE
HMS-5380: create_upload fixes

### DIFF
--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -588,6 +588,10 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusBadRequest, "Error binding parameters", err.Error())
 	}
 
+	if req.ChunkSize <= 0 {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Error creating upload", "Chunk size must be greater than 0")
+	}
+
 	domainName, err := ph.DaoRegistry.Domain.FetchOrCreateDomain(c.Request().Context(), orgId)
 
 	if err != nil {
@@ -621,6 +625,7 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 			UploadUuid:         &existingUUID,
 			Size:               req.ChunkSize,
 			CompletedChecksums: completedChunks,
+			ArtifactHref:       utils.Ptr(""),
 		}
 
 		return c.JSON(http.StatusCreated, resp)
@@ -638,11 +643,13 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 	}
 
 	resp := &api.UploadResponse{
-		UploadUuid:  &uploadUuid,
-		Created:     pulpResp.PulpCreated,
-		LastUpdated: pulpResp.PulpLastUpdated,
-		Size:        pulpResp.Size,
-		Completed:   pulpResp.Completed,
+		UploadUuid:         &uploadUuid,
+		Created:            pulpResp.PulpCreated,
+		LastUpdated:        pulpResp.PulpLastUpdated,
+		Size:               pulpResp.Size,
+		Completed:          pulpResp.Completed,
+		ArtifactHref:       utils.Ptr(""),
+		CompletedChecksums: make([]string, 0),
 	}
 
 	return c.JSON(http.StatusCreated, resp)


### PR DESCRIPTION
## Summary

Fixes some issues when creating an upload:
- changes artifact href to be a string instead of null if empty (this is blocking IQE from calling this api)
- rejects request if chunk_size is 0 

## Testing steps

1. Artifact href should be set to an empty string if it doesn't exist
2. Request should be rejected if chunk size is 0 or less

