### PR TITLE
HMS-5293: add list feature content

### DIFF
--- a/pkg/api/admin_task.go
+++ b/pkg/api/admin_task.go
@@ -84,6 +84,21 @@ type ListFeaturesResponse struct {
 	Features []string `json:"features"`
 }
 
+type FeatureServiceContentResponse struct {
+	Name                string              `json:"name"`
+	URL                 string              `json:"url"`
+	RedHatRepoStructure RedHatRepoStructure `json:"red_hat_repo_structure"`
+}
+
+type RedHatRepoStructure struct {
+	Name                string `json:"name"`
+	ContentLabel        string `json:"content_label"`
+	URL                 string `json:"url"`
+	Arch                string `json:"arch"`
+	DistributionVersion string `json:"distribution_version"`
+	FeatureName         string `json:"feature_name"`
+}
+
 func (a *AdminTaskInfoCollectionResponse) SetMetadata(meta ResponseMetadata, links Links) {
 	a.Meta = meta
 	a.Links = links

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -84,7 +84,7 @@ func RegisterRoutes(ctx context.Context, engine *echo.Echo) {
 		RegisterPopularRepositoriesRoutes(group, daoReg)
 		RegisterTaskInfoRoutes(group, daoReg, &taskClient)
 		RegisterSnapshotRoutes(group, daoReg, &taskClient)
-		RegisterAdminTaskRoutes(group, daoReg, &fsClient)
+		RegisterAdminTaskRoutes(group, daoReg, &fsClient, &cpClient)
 		RegisterFeaturesRoutes(group)
 		RegisterPublicRepositoriesRoutes(group, daoReg)
 		RegisterPackageGroupRoutes(group, daoReg)


### PR DESCRIPTION
## Summary
This adds an API to list the content if a feature from the feature service API

## Testing steps
1. Add the correct certs path to the clients.feature_service option in the config.yaml
2. Use the `GET /api/content-sources/v1/admin/features/` endpoint list the features
3. Choose one and use the name with `GET /api/content-sources/v1/admin/features/:name/content/` to list the content
4. Check that the fields match what is described by the JIRA ticket

