### PR TITLE
HMS-5390: omit null values in upload response

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3669,9 +3669,6 @@ const docTemplate = `{
     "definitions": {
         "api.AddUploadsRequest": {
             "type": "object",
-            "required": [
-                "uploads"
-            ],
             "properties": {
                 "artifacts": {
                     "description": "List of created artifacts",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -18,9 +18,6 @@
                         "type": "array"
                     }
                 },
-                "required": [
-                    "uploads"
-                ],
                 "type": "object"
             },
             "api.Artifact": {

--- a/pkg/api/uploads.go
+++ b/pkg/api/uploads.go
@@ -25,12 +25,12 @@ type UploadChunkRequest struct {
 }
 
 type UploadResponse struct {
-	ArtifactHref       *string    `json:"artifact_href"`          // Artifact href if one exists (on create only)
-	CompletedChecksums []string   `json:"completed_checksums"`    // A list of already completed checksums
-	UploadUuid         *string    `json:"upload_uuid"`            // Upload UUID
-	Created            *time.Time `json:"created,omitempty"`      // Timestamp of creation
-	LastUpdated        *time.Time `json:"last_updated,omitempty"` // Timestamp of last update
-	Size               int64      `json:"size"`                   // Size of the upload in bytes
-	Completed          *time.Time `json:"completed,omitempty"`    // Timestamp when upload is committed
+	ArtifactHref       *string    `json:"artifact_href,omitempty"`       // Artifact href if one exists (on create only)
+	CompletedChecksums []string   `json:"completed_checksums,omitempty"` // A list of already completed checksums
+	UploadUuid         *string    `json:"upload_uuid"`                   // Upload UUID
+	Created            *time.Time `json:"created,omitempty"`             // Timestamp of creation
+	LastUpdated        *time.Time `json:"last_updated,omitempty"`        // Timestamp of last update
+	Size               int64      `json:"size"`                          // Size of the upload in bytes
+	Completed          *time.Time `json:"completed,omitempty"`           // Timestamp when upload is committed
 
 }

--- a/pkg/api/uploads.go
+++ b/pkg/api/uploads.go
@@ -25,12 +25,12 @@ type UploadChunkRequest struct {
 }
 
 type UploadResponse struct {
-	ArtifactHref       *string    `json:"artifact_href"`       // Artifact href if one exists (on create only)
-	CompletedChecksums []string   `json:"completed_checksums"` // A list of already completed checksums
-	UploadUuid         *string    `json:"upload_uuid"`         // Upload UUID
-	Created            *time.Time `json:"created"`             // Timestamp of creation
-	LastUpdated        *time.Time `json:"last_updated"`        // Timestamp of last update
-	Size               int64      `json:"size"`                // Size of the upload in bytes
-	Completed          *time.Time `json:"completed,omitempty"` // Timestamp when upload is committed
+	ArtifactHref       *string    `json:"artifact_href"`          // Artifact href if one exists (on create only)
+	CompletedChecksums []string   `json:"completed_checksums"`    // A list of already completed checksums
+	UploadUuid         *string    `json:"upload_uuid"`            // Upload UUID
+	Created            *time.Time `json:"created,omitempty"`      // Timestamp of creation
+	LastUpdated        *time.Time `json:"last_updated,omitempty"` // Timestamp of last update
+	Size               int64      `json:"size"`                   // Size of the upload in bytes
+	Completed          *time.Time `json:"completed,omitempty"`    // Timestamp when upload is committed
 
 }

--- a/pkg/api/uploads.go
+++ b/pkg/api/uploads.go
@@ -3,8 +3,8 @@ package api
 import "time"
 
 type AddUploadsRequest struct {
-	Uploads   []Upload   `json:"uploads" validate:"required"` // List of unfinished uploads
-	Artifacts []Artifact `json:"artifacts"`                   // List of created artifacts
+	Uploads   []Upload   `json:"uploads"`   // List of unfinished uploads
+	Artifacts []Artifact `json:"artifacts"` // List of created artifacts
 }
 
 type Upload struct {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -606,24 +606,28 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 		return err
 	}
 
-	if artifactHref != nil {
+	existingUUID, completedChunks, err := ph.DaoRegistry.Uploads.GetExistingUploadIDAndCompletedChunks(c.Request().Context(), orgId, req.Sha256, req.ChunkSize)
+	if err != nil {
+		return err
+	}
+
+	// pulp artifact has already been created and uploaded content is being reused
+	if artifactHref != nil && existingUUID != "" {
 		resp := &api.UploadResponse{
-			ArtifactHref: artifactHref,
+			UploadUuid:         &existingUUID,
+			ArtifactHref:       artifactHref,
+			Size:               req.Size,
+			CompletedChecksums: completedChunks,
 		}
 
 		return c.JSON(http.StatusCreated, resp)
 	}
 
-	existingUUID, completedChunks, err := ph.DaoRegistry.Uploads.GetExistingUploadIDAndCompletedChunks(c.Request().Context(), orgId, req.Sha256, req.ChunkSize)
-
-	if err != nil {
-		return err
-	}
-
+	// pulp artifact has not been created yet, but uploaded content has been saved in our db and can be reused
 	if existingUUID != "" {
 		resp := &api.UploadResponse{
 			UploadUuid:         &existingUUID,
-			Size:               req.ChunkSize,
+			Size:               req.Size,
 			CompletedChecksums: completedChunks,
 			ArtifactHref:       utils.Ptr(""),
 		}
@@ -632,7 +636,6 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 	}
 
 	pulpResp, err := ph.createUploadInternal(c, req)
-
 	if err != nil {
 		return err
 	}
@@ -642,6 +645,7 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 		uploadUuid = extractUploadUuid(*pulpResp.PulpHref)
 	}
 
+	// new content to upload
 	resp := &api.UploadResponse{
 		UploadUuid:         &uploadUuid,
 		Created:            pulpResp.PulpCreated,
@@ -700,11 +704,13 @@ func (rh *RepositoryHandler) uploadChunk(c echo.Context) error {
 	}
 
 	resp := &api.UploadResponse{
-		UploadUuid:  &uploadUuid,
-		Created:     pulpResp.PulpCreated,
-		LastUpdated: pulpResp.PulpLastUpdated,
-		Size:        pulpResp.Size,
-		Completed:   pulpResp.Completed,
+		UploadUuid:         &uploadUuid,
+		Created:            pulpResp.PulpCreated,
+		LastUpdated:        pulpResp.PulpLastUpdated,
+		Size:               pulpResp.Size,
+		Completed:          pulpResp.Completed,
+		ArtifactHref:       utils.Ptr(""),
+		CompletedChecksums: make([]string, 0),
 	}
 
 	err = ph.DaoRegistry.Uploads.StoreChunkUpload(c.Request().Context(), orgId, uploadUuid, req.Sha256)

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -629,7 +629,6 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 			UploadUuid:         &existingUUID,
 			Size:               req.Size,
 			CompletedChecksums: completedChunks,
-			ArtifactHref:       utils.Ptr(""),
 		}
 
 		return c.JSON(http.StatusCreated, resp)
@@ -647,13 +646,11 @@ func (rh *RepositoryHandler) createUpload(c echo.Context) error {
 
 	// new content to upload
 	resp := &api.UploadResponse{
-		UploadUuid:         &uploadUuid,
-		Created:            pulpResp.PulpCreated,
-		LastUpdated:        pulpResp.PulpLastUpdated,
-		Size:               pulpResp.Size,
-		Completed:          pulpResp.Completed,
-		ArtifactHref:       utils.Ptr(""),
-		CompletedChecksums: make([]string, 0),
+		UploadUuid:  &uploadUuid,
+		Created:     pulpResp.PulpCreated,
+		LastUpdated: pulpResp.PulpLastUpdated,
+		Size:        pulpResp.Size,
+		Completed:   pulpResp.Completed,
 	}
 
 	return c.JSON(http.StatusCreated, resp)
@@ -704,13 +701,11 @@ func (rh *RepositoryHandler) uploadChunk(c echo.Context) error {
 	}
 
 	resp := &api.UploadResponse{
-		UploadUuid:         &uploadUuid,
-		Created:            pulpResp.PulpCreated,
-		LastUpdated:        pulpResp.PulpLastUpdated,
-		Size:               pulpResp.Size,
-		Completed:          pulpResp.Completed,
-		ArtifactHref:       utils.Ptr(""),
-		CompletedChecksums: make([]string, 0),
+		UploadUuid:  &uploadUuid,
+		Created:     pulpResp.PulpCreated,
+		LastUpdated: pulpResp.PulpLastUpdated,
+		Size:        pulpResp.Size,
+		Completed:   pulpResp.Completed,
 	}
 
 	err = ph.DaoRegistry.Uploads.StoreChunkUpload(c.Request().Context(), orgId, uploadUuid, req.Sha256)


### PR DESCRIPTION
## Summary

- Omits null values for `created`, `last_updated`, `artifact_href`, and `completed_checksums` from the upload response (used when creating an upload or uploading a chunk). These values are not always needed and null values here prevent the generated IQE client from calling these APIs
- Adds the upload uuid to the response when an artifact href is found (i'm not sure this should be null or omitted)

## Testing steps

1. Responses from creating an upload and uploading a chunk shouldn't have any null values
2. Uploading rpms in the UI should still work the same (existing uploads should be reused)
3. IQE: Go through the uploading flow using the IQE environment, let me know if there are any other API type errors etc and I'll make the changes here

