### PR TITLE
HMS-5379: add metrics for templates

### DIFF
--- a/pkg/config/tasks.go
+++ b/pkg/config/tasks.go
@@ -20,6 +20,18 @@ const (
 	TaskStatusPending   = "pending"   // Task is waiting to be started
 )
 
+var TaskTypes = []string{
+	RepositorySnapshotTask,
+	DeleteRepositorySnapshotsTask,
+	DeleteSnapshotsTask,
+	IntrospectTask,
+	DeleteTemplatesTask,
+	UpdateTemplateContentTask,
+	UpdateRepositoryTask,
+	AddUploadsTask,
+	UpdateLatestSnapshotTask,
+}
+
 var RequeueableTasks = []string{DeleteTemplatesTask, DeleteRepositorySnapshotsTask, UpdateTemplateContentTask, DeleteSnapshotsTask}
 
 var CancellableTasks = []string{IntrospectTask, RepositorySnapshotTask, UpdateTemplateContentTask}

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -140,6 +140,11 @@ type MetricsDao interface {
 	PendingTasksCount(ctx context.Context) int64
 	PendingTasksOldestTask(ctx context.Context) float64
 	RHReposSnapshotNotCompletedInLast36HoursCount(ctx context.Context) int64
+	TemplatesUpdateTaskPendingTimeAverage(ctx context.Context) float64
+	TemplatesUseLatestCount(ctx context.Context) int
+	TemplatesUseDateCount(ctx context.Context) int
+	TemplatesUpdatedInLast24HoursCount(ctx context.Context) int
+	TemplatesAgeAverage(ctx context.Context) float64
 }
 
 type TaskInfoDao interface {

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -140,7 +140,7 @@ type MetricsDao interface {
 	PendingTasksCount(ctx context.Context) int64
 	PendingTasksOldestTask(ctx context.Context) float64
 	RHReposSnapshotNotCompletedInLast36HoursCount(ctx context.Context) int64
-	TemplatesUpdateTaskPendingTimeAverage(ctx context.Context) float64
+	TaskPendingTimeAverageByType(ctx context.Context) []TaskTypePendingTimeAverage
 	TemplatesUseLatestCount(ctx context.Context) int
 	TemplatesUseDateCount(ctx context.Context) int
 	TemplatesUpdatedInLast24HoursCount(ctx context.Context) int

--- a/pkg/dao/metrics_mock.go
+++ b/pkg/dao/metrics_mock.go
@@ -175,30 +175,32 @@ func (_m *MockMetricsDao) RepositoryConfigsCount(ctx context.Context) int {
 	return r0
 }
 
+// TaskPendingTimeAverageByType provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TaskPendingTimeAverageByType(ctx context.Context) []TaskTypePendingTimeAverage {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TaskPendingTimeAverageByType")
+	}
+
+	var r0 []TaskTypePendingTimeAverage
+	if rf, ok := ret.Get(0).(func(context.Context) []TaskTypePendingTimeAverage); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]TaskTypePendingTimeAverage)
+		}
+	}
+
+	return r0
+}
+
 // TemplatesAgeAverage provides a mock function with given fields: ctx
 func (_m *MockMetricsDao) TemplatesAgeAverage(ctx context.Context) float64 {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TemplatesAgeAverage")
-	}
-
-	var r0 float64
-	if rf, ok := ret.Get(0).(func(context.Context) float64); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(float64)
-	}
-
-	return r0
-}
-
-// TemplatesUpdateTaskPendingTimeAverage provides a mock function with given fields: ctx
-func (_m *MockMetricsDao) TemplatesUpdateTaskPendingTimeAverage(ctx context.Context) float64 {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for TemplatesUpdateTaskPendingTimeAverage")
 	}
 
 	var r0 float64

--- a/pkg/dao/metrics_mock.go
+++ b/pkg/dao/metrics_mock.go
@@ -175,6 +175,96 @@ func (_m *MockMetricsDao) RepositoryConfigsCount(ctx context.Context) int {
 	return r0
 }
 
+// TemplatesAgeAverage provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TemplatesAgeAverage(ctx context.Context) float64 {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TemplatesAgeAverage")
+	}
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(context.Context) float64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// TemplatesUpdateTaskPendingTimeAverage provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TemplatesUpdateTaskPendingTimeAverage(ctx context.Context) float64 {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TemplatesUpdateTaskPendingTimeAverage")
+	}
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(context.Context) float64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// TemplatesUpdatedInLast24HoursCount provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TemplatesUpdatedInLast24HoursCount(ctx context.Context) int {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TemplatesUpdatedInLast24HoursCount")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// TemplatesUseDateCount provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TemplatesUseDateCount(ctx context.Context) int {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TemplatesUseDateCount")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// TemplatesUseLatestCount provides a mock function with given fields: ctx
+func (_m *MockMetricsDao) TemplatesUseLatestCount(ctx context.Context) int {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TemplatesUseLatestCount")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context) int); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
 // NewMockMetricsDao creates a new instance of MockMetricsDao. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockMetricsDao(t interface {

--- a/pkg/dao/metrics_test.go
+++ b/pkg/dao/metrics_test.go
@@ -404,3 +404,138 @@ func (s *MetricsSuite) TestRHReposSnapshotNotCompletedInLast36HoursCount() {
 	count := s.dao.RHReposSnapshotNotCompletedInLast36HoursCount(context.Background())
 	assert.Equal(t, 2+initialCount, count)
 }
+
+func (s *MetricsSuite) TestTemplatesCount() {
+	t := s.T()
+
+	initialCountLatest := s.dao.TemplatesUseLatestCount(context.Background())
+	assert.NotEqual(t, -1, initialCountLatest)
+	initialCountDate := s.dao.TemplatesUseDateCount(context.Background())
+	assert.NotEqual(t, -1, initialCountDate)
+
+	_, err := seeds.SeedTemplates(s.tx, 2, seeds.TemplateSeedOptions{UseLatest: true})
+	assert.NoError(t, err)
+
+	_, err = seeds.SeedTemplates(s.tx, 4, seeds.TemplateSeedOptions{})
+	assert.NoError(t, err)
+
+	countLatest := s.dao.TemplatesUseLatestCount(context.Background())
+	assert.Equal(t, initialCountLatest+2, countLatest)
+	countDate := s.dao.TemplatesUseDateCount(context.Background())
+	assert.Equal(t, initialCountDate+4, countDate)
+}
+
+func (s *MetricsSuite) TestTemplatesUpdatedInLast24Hours() {
+	t := s.T()
+	tx := s.tx
+
+	initialUpdatedCount := s.dao.TemplatesUpdatedInLast24HoursCount(context.Background())
+	assert.NotEqual(t, -1, initialUpdatedCount)
+
+	_, err := seeds.SeedTemplates(s.tx, 2, seeds.TemplateSeedOptions{})
+	assert.NoError(t, err)
+
+	t1 := models.Template{
+		Base: models.Base{
+			UUID:      uuid2.NewString(),
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			UpdatedAt: time.Now().Add(-12 * time.Hour),
+		},
+		Name:    seeds.RandStringBytes(10),
+		OrgID:   orgIDTest,
+		Arch:    config.ANY_ARCH,
+		Version: config.ANY_VERSION,
+	}
+	err = tx.Create(&t1).Error
+	require.NoError(t, err)
+
+	t2 := models.Template{
+		Base: models.Base{
+			UUID:      uuid2.NewString(),
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			UpdatedAt: time.Now().Add(-48 * time.Hour),
+		},
+		Name:    seeds.RandStringBytes(10),
+		OrgID:   orgIDTest,
+		Arch:    config.ANY_ARCH,
+		Version: config.ANY_VERSION,
+	}
+	err = tx.Create(&t2).Error
+	require.NoError(t, err)
+
+	updatedCount := s.dao.TemplatesUpdatedInLast24HoursCount(context.Background())
+	assert.Equal(t, initialUpdatedCount+3, updatedCount)
+}
+
+func (s *MetricsSuite) TestTemplatesAgeAverage() {
+	t := s.T()
+	tx := s.tx
+
+	initialAgeAverage := s.dao.TemplatesAgeAverage(context.Background())
+
+	t1 := models.Template{
+		Base: models.Base{
+			UUID:      uuid2.NewString(),
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			UpdatedAt: time.Now().Add(-12 * time.Hour),
+		},
+		Name:      seeds.RandStringBytes(10),
+		OrgID:     orgIDTest,
+		Arch:      config.ANY_ARCH,
+		Version:   config.ANY_VERSION,
+		UseLatest: false,
+		Date:      time.Now().Add(time.Duration(-initialAgeAverage) * 24 * time.Hour).Add(-5 * 24 * time.Hour),
+	}
+	err := tx.Create(&t1).Error
+	require.NoError(t, err)
+
+	updatedAgeAverage := s.dao.TemplatesAgeAverage(context.Background())
+	assert.True(t, initialAgeAverage < updatedAgeAverage)
+
+	t2 := models.Template{
+		Base: models.Base{
+			UUID:      uuid2.NewString(),
+			CreatedAt: time.Now().Add(-48 * time.Hour),
+			UpdatedAt: time.Now().Add(-48 * time.Hour),
+		},
+		Name:      seeds.RandStringBytes(10),
+		OrgID:     orgIDTest,
+		Arch:      config.ANY_ARCH,
+		Version:   config.ANY_VERSION,
+		UseLatest: false,
+		Date:      time.Now().Add(time.Duration(-initialAgeAverage) * 24 * time.Hour).Add(10 * 24 * time.Hour),
+	}
+	err = tx.Create(&t2).Error
+	require.NoError(t, err)
+
+	updatedAgeAverage = s.dao.TemplatesAgeAverage(context.Background())
+	assert.True(t, initialAgeAverage > updatedAgeAverage)
+}
+
+func (s *MetricsSuite) TestTemplatesUpdateTaskPendingAverage() {
+	t := s.T()
+	tx := s.tx
+
+	queued := time.Now().Add(-61 * time.Second)
+	res := tx.Create(utils.Ptr(models.TaskInfo{
+		Id:       uuid2.New(),
+		Token:    uuid2.New(),
+		Typename: config.UpdateTemplateContentTask,
+		Queued:   &queued,
+		Status:   config.TaskStatusPending,
+	}))
+
+	queued = time.Now().Add(-100 * time.Second)
+	res = tx.Create(utils.Ptr(models.TaskInfo{
+		Id:       uuid2.New(),
+		Token:    uuid2.New(),
+		Typename: config.RepositorySnapshotTask,
+		Queued:   &queued,
+		Status:   config.TaskStatusPending,
+	}))
+
+	assert.NoError(t, res.Error)
+	pendingTimeAverage := s.dao.TemplatesUpdateTaskPendingTimeAverage(context.Background())
+	assert.True(t, pendingTimeAverage >= float64(60))
+	assert.True(t, pendingTimeAverage < float64(62))
+}

--- a/pkg/dao/metrics_test.go
+++ b/pkg/dao/metrics_test.go
@@ -524,6 +524,7 @@ func (s *MetricsSuite) TestTemplatesUpdateTaskPendingAverage() {
 		Queued:   &queued,
 		Status:   config.TaskStatusPending,
 	}))
+	assert.NoError(t, res.Error)
 
 	queued = time.Now().Add(-100 * time.Second)
 	res = tx.Create(utils.Ptr(models.TaskInfo{
@@ -533,8 +534,8 @@ func (s *MetricsSuite) TestTemplatesUpdateTaskPendingAverage() {
 		Queued:   &queued,
 		Status:   config.TaskStatusPending,
 	}))
-
 	assert.NoError(t, res.Error)
+
 	pendingTimeAverage := s.dao.TemplatesUpdateTaskPendingTimeAverage(context.Background())
 	assert.True(t, pendingTimeAverage >= float64(60))
 	assert.True(t, pendingTimeAverage < float64(62))

--- a/pkg/instrumentation/custom/collector.go
+++ b/pkg/instrumentation/custom/collector.go
@@ -87,6 +87,19 @@ func (c *Collector) iterate() {
 	} else {
 		c.metrics.PulpConnectivity.Set(1)
 	}
+
+	templatesPendingAverage := c.dao.TemplatesUpdateTaskPendingTimeAverage(ctx)
+	c.metrics.TemplatesUpdateTaskPendingTimeAverage.Set(templatesPendingAverage)
+	templatesUseLatestCount := c.dao.TemplatesUseLatestCount(ctx)
+	c.metrics.TemplatesUseLatestCount.Set(float64(templatesUseLatestCount))
+	templatesUseDateCount := c.dao.TemplatesUseDateCount(ctx)
+	c.metrics.TemplatesUseDateCount.Set(float64(templatesUseDateCount))
+	templatesCount := templatesUseLatestCount + templatesUseDateCount
+	c.metrics.TemplatesCount.Set(float64(templatesCount))
+	templatesUpdatedCount := c.dao.TemplatesUpdatedInLast24HoursCount(ctx)
+	c.metrics.TemplatesUpdatedInLast24HoursCount.Set(float64(templatesUpdatedCount))
+	templatesAgeAverage := c.dao.TemplatesAgeAverage(ctx)
+	c.metrics.TemplatesAgeAverage.Set(templatesAgeAverage)
 }
 
 func (c *Collector) snapshottingFailCheckIterate() {

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -27,6 +27,12 @@ const (
 	TaskStatsLabelOldestWait                       = "task_stats_oldest_wait"
 	TaskStatsLabelAverageWait                      = "task_stats_average_wait"
 	RHReposSnapshotNotCompletedInLast36HoursCount  = "rh_repos_snapshot_not_completed_in_last_36_hour_count"
+	TemplatesUpdateTaskPendingTimeAverage          = "templates_update_task_pending_time_average"
+	TemplatesCount                                 = "templates_count"
+	TemplatesUseLatestCount                        = "templates_use_latest_count"
+	TemplatesUseDateCount                          = "templates_use_date_count"
+	TemplatesUpdatedInLast24HoursCount             = "templates_updated_in_last_24_hour_count"
+	TemplatesAgeAverage                            = "templates_age_average"
 )
 
 type Metrics struct {
@@ -45,6 +51,12 @@ type Metrics struct {
 	OrgTotal                                       prometheus.Gauge
 	RHCertExpiryDays                               prometheus.Gauge
 	RHReposSnapshotNotCompletedInLast36HoursCount  prometheus.Gauge
+	TemplatesUpdateTaskPendingTimeAverage          prometheus.Gauge
+	TemplatesCount                                 prometheus.Gauge
+	TemplatesUseLatestCount                        prometheus.Gauge
+	TemplatesUseDateCount                          prometheus.Gauge
+	TemplatesUpdatedInLast24HoursCount             prometheus.Gauge
+	TemplatesAgeAverage                            prometheus.Gauge
 	reg                                            *prometheus.Registry
 }
 
@@ -125,6 +137,36 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Namespace: NameSpace,
 			Name:      RHReposSnapshotNotCompletedInLast36HoursCount,
 			Help:      "Number of Red Hat repositories that haven't had successful snapshot task in the last 36 hours.",
+		}),
+		TemplatesUpdateTaskPendingTimeAverage: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesUpdateTaskPendingTimeAverage,
+			Help:      "Average pending time of the 'update-template-content' tasks.",
+		}),
+		TemplatesCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesCount,
+			Help:      "Total number of templates.",
+		}),
+		TemplatesUseLatestCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesUseLatestCount,
+			Help:      "Number of templates which are set to use latest.",
+		}),
+		TemplatesUseDateCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesUseDateCount,
+			Help:      "Number of templates which have a set date.",
+		}),
+		TemplatesUpdatedInLast24HoursCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesUpdatedInLast24HoursCount,
+			Help:      "Number of templates that have been updated in the last 24 hours.",
+		}),
+		TemplatesAgeAverage: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      TemplatesAgeAverage,
+			Help:      "Average age (days between the set template date and now) of templates.",
 		}),
 	}
 

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -27,7 +27,7 @@ const (
 	TaskStatsLabelOldestWait                       = "task_stats_oldest_wait"
 	TaskStatsLabelAverageWait                      = "task_stats_average_wait"
 	RHReposSnapshotNotCompletedInLast36HoursCount  = "rh_repos_snapshot_not_completed_in_last_36_hour_count"
-	TemplatesUpdateTaskPendingTimeAverage          = "templates_update_task_pending_time_average"
+	TaskPendingTimeAverageByType                   = "task_pending_time_average_by_type"
 	TemplatesCount                                 = "templates_count"
 	TemplatesUseLatestCount                        = "templates_use_latest_count"
 	TemplatesUseDateCount                          = "templates_use_date_count"
@@ -51,7 +51,7 @@ type Metrics struct {
 	OrgTotal                                       prometheus.Gauge
 	RHCertExpiryDays                               prometheus.Gauge
 	RHReposSnapshotNotCompletedInLast36HoursCount  prometheus.Gauge
-	TemplatesUpdateTaskPendingTimeAverage          prometheus.Gauge
+	TaskPendingTimeAverageByType                   prometheus.GaugeVec
 	TemplatesCount                                 prometheus.Gauge
 	TemplatesUseLatestCount                        prometheus.Gauge
 	TemplatesUseDateCount                          prometheus.Gauge
@@ -138,11 +138,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      RHReposSnapshotNotCompletedInLast36HoursCount,
 			Help:      "Number of Red Hat repositories that haven't had successful snapshot task in the last 36 hours.",
 		}),
-		TemplatesUpdateTaskPendingTimeAverage: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		TaskPendingTimeAverageByType: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: NameSpace,
-			Name:      TemplatesUpdateTaskPendingTimeAverage,
-			Help:      "Average pending time of the 'update-template-content' tasks.",
-		}),
+			Name:      TaskPendingTimeAverageByType,
+			Help:      "Average pending time of the tasks by their type.",
+		}, []string{"task_type"}),
 		TemplatesCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      TemplatesCount,

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -215,6 +215,7 @@ type TemplateSeedOptions struct {
 	Version               *string
 	RepositoryConfigUUIDs []string
 	Snapshots             []models.Snapshot
+	UseLatest             bool
 }
 
 func SeedTemplates(db *gorm.DB, size int, options TemplateSeedOptions) ([]models.Template, error) {
@@ -231,11 +232,14 @@ func SeedTemplates(db *gorm.DB, size int, options TemplateSeedOptions) ([]models
 			Name:          RandStringBytes(10),
 			OrgID:         orgID,
 			Description:   "description",
-			Date:          time.Now(),
 			Version:       createVersion(options.Version),
 			Arch:          createArch(options.Arch),
 			CreatedBy:     "user",
 			LastUpdatedBy: "user",
+			UseLatest:     options.UseLatest,
+		}
+		if !options.UseLatest {
+			t.Date = time.Now()
 		}
 		err := db.Create(&t).Error
 		if err != nil {


### PR DESCRIPTION
## Summary
This PR adds new Prometheus metrics that are gonna be used in our grafana dashboard.
```python
# HELP content_sources_templates_age_average Average age (days between the set template date and now) of templates.
content_sources_templates_age_average 
# HELP content_sources_templates_count Total number of templates.
content_sources_templates_count 
# HELP content_sources_templates_updated_in_last_24_hour_count Number of templates that have been updated in the last 24 hours.
content_sources_templates_updated_in_last_24_hour_count 
# HELP content_sources_templates_use_date_count Number of templates which have a set date.
content_sources_templates_use_date_count 
# HELP content_sources_templates_use_latest_count Number of templates which are set to use latest.
content_sources_templates_use_latest_count 
# HELP content_sources_task_pending_time_average_by_type Average pending time of the tasks by their type.
content_sources_task_pending_time_average_by_type{task_type="add-uploads-repository"}
content_sources_task_pending_time_average_by_type{task_type="delete-repository-snapshots"}
content_sources_task_pending_time_average_by_type{task_type="delete-snapshots"}
content_sources_task_pending_time_average_by_type{task_type="delete-templates"}
content_sources_task_pending_time_average_by_type{task_type="introspect"}
content_sources_task_pending_time_average_by_type{task_type="snapshot"}
content_sources_task_pending_time_average_by_type{task_type="update-latest-snapshot"}
content_sources_task_pending_time_average_by_type{task_type="update-repository"}
content_sources_task_pending_time_average_by_type{task_type="update-template-content"}
```
## Testing steps
1. Verify that the newly added metrics are showing up on our  `:9000/metrics` endpoint.
2. Create some templates which are using latest (at least 1) and have set dates (at least two, with different dates).
3. Verify that the `*_count` metrics have increased/changed accordingly.
4. Verify that the `content_sources_templates_age_average` is the average age of templates you created.
5. Run `make repos-import` and nightly jobs.
6. Wait for the pending time metrics to show up in the output of the metrics output.

\
_(tip: if you have the `bat` tool installed, you can pipe the output from that endpoint into `bat` and when you specify the language as Python, it will be a lot more readable, ex.: `http :9000/metrics | bat --language=python -P -p`)_ 😅 