### PR TITLE
Build: use full path for compose files

### DIFF
--- a/mk/pulp.mk
+++ b/mk/pulp.mk
@@ -1,5 +1,7 @@
-CS_COMPOSE_FILE ?= "deployments/docker-compose.yml"
-PULP_COMPOSE_FILES ?= "compose_files/pulp/docker-compose.yml"
+
+CS_COMPOSE_FILE ?= $(realpath deployments/docker-compose.yml)
+PULP_COMPOSE_FILES ?= $(realpath compose_files/pulp/docker-compose.yml)
+
 PULP_COMPOSE_OPTIONS=PULP_POSTGRES_PATH="pulp_db" PULP_STORAGE_PATH="pulp_storage"
 
 PULP_COMPOSE_COMMAND=$(PULP_COMPOSE_OPTIONS) $(DOCKER)-compose --project-name=$(COMPOSE_PROJECT_NAME)  -f $(PULP_COMPOSE_FILES) up --detach


### PR DESCRIPTION
## Summary

specifies full path to compose files to work around podman-compose bug

## Testing steps

make compose-clean compose-up 

