### PR TITLE
Test: add cdn cert

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -139,6 +139,22 @@ jobs:
       - name: Copy the example config
         run: cp ./configs/config.yaml.example ./configs/config.yaml
 
+      - name: Create cdn.pem file
+        run: |
+          echo "$REDHAT_CDN_CERT" | sed 's/\\n/\n/g' > ./configs/cdn.pem
+
+      - name: Update cert_path in config.yaml
+        run: |
+          sed -i 's|# cert_path:.*|cert_path: ./configs/cdn.pem|' ./configs/config.yaml
+
+      - name: Throw error if cert is invalid
+        run: |
+          if ! openssl x509 -in ./configs/cdn.pem -noout; then
+            echo "Invalid PEM certificate format"
+            exit 1
+          fi
+          echo "PEM certificate is valid"
+
       - name: Create backend .env file
         working-directory: _playwright-tests
         run: |


### PR DESCRIPTION
## Summary

- Adds the CDN cert for RH repos to the backend config

## Testing steps

- The same action steps exist on the frontend repo via this [PR](https://github.com/content-services/content-sources-frontend/pull/440) and were validated with the frontend RH repo tests
- You shouldn't see this warning anymore in the action step to trigger a snapshot for RH repos: `{"level":"warn","time":"2025-02-14T17:18:43Z","message":"No Red Hat CDN cert pair configured."}`