### PR TITLE
HMS-5526: ignore canceled ctx for failed_snapshot_count

### DIFF
--- a/pkg/pulp_client/status.go
+++ b/pkg/pulp_client/status.go
@@ -31,7 +31,7 @@ func (r *pulpDaoImpl) GetContentPath(ctx context.Context) (string, error) {
 	logger := zerolog.Ctx(ctx)
 
 	pulpContentPath, err := r.cache.GetPulpContentPath(ctx)
-	if err != nil && !errors.Is(err, cache.NotFound) {
+	if err != nil && (!errors.Is(err, cache.NotFound) || !errors.Is(err, context.Canceled)) {
 		logger.Error().Err(err).Msg("GetContentPath: error reading from cache")
 	}
 

--- a/pkg/tasks/repository_snapshot.go
+++ b/pkg/tasks/repository_snapshot.go
@@ -52,7 +52,7 @@ func SnapshotHandler(ctx context.Context, task *models.TaskInfo, queue *queue.Qu
 	if err == nil {
 		return daoReg.RepositoryConfig.InternalOnly_ResetFailedSnapshotCount(ctx, sr.repoConfig.UUID)
 	} else {
-		updateErr := daoReg.RepositoryConfig.InternalOnly_IncrementFailedSnapshotCount(ctx, sr.repoConfig.UUID)
+		updateErr := daoReg.RepositoryConfig.InternalOnly_IncrementFailedSnapshotCount(context.Background(), sr.repoConfig.UUID)
 		if updateErr != nil {
 			log.Error().Err(updateErr).Msgf("failed to increment failed snapshot count")
 		}


### PR DESCRIPTION
## Summary
There are two small bugs fixed here

- For canceled snapshots, the failed_snapshot_count was not being updated because the DB query was using context that was canceled. This changes it to use context.Background().
- GetContentPath() in the pulp client was logging an error when it failed due to canceled context, but an error is expected if context is canceled
## Testing steps
1. In the UI, add and remove the popular repositories (EPEL)
2. After removing them, there will no longer be an error logged "Failed to update failed_snapshot_count: context canceled"

