### PR TITLE
HMS-5162: replace fedorapeople comps repos with github fixtures

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -228,8 +228,8 @@ jobs:
       - name: Import the smallest Redhat repos
         run: OPTIONS_REPOSITORY_IMPORT_FILTER=small make repos-import
 
-      - name: Run nightly job to trigger snapshot for redhat repos
-        run: go run cmd/external-repos/main.go process-repos
+      - name: Run snapshot for redhat repo
+        run: go run cmd/external-repos/main.go snapshot https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/
 
       - name: Backend run
         run: make run &

--- a/_playwright-tests/tests/API/Repositories.spec.ts
+++ b/_playwright-tests/tests/API/Repositories.spec.ts
@@ -27,10 +27,9 @@ test('Content > Verify repository introspection', async ({ client }) => {
     repo = await new RepositoriesApi(client).createRepository({
       apiRepositoryRequest: {
         name: 'test-repository',
-        url: 'https://rverdile.fedorapeople.org/dummy-repos/modules/repo1/',
+        url: 'https://content-services.github.io/fixtures/yum/comps-modules/v1/',
       },
     });
-
     expect(repo.name).toBe('test-repository');
   });
 

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -104,7 +104,7 @@ func (s *DeleteTest) TestDeleteSnapshot() {
 	// Create a repo and two snapshots for it
 	repo := s.createAndSyncRepository(orgID, "https://fedorapeople.org/groups/katello/fakerepos/zoo/")
 	_, err = s.dao.RepositoryConfig.Update(s.ctx, orgID, repo.UUID, api.RepositoryUpdateRequest{
-		URL: utils.Ptr("https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/"),
+		URL: utils.Ptr("https://content-services.github.io/fixtures/yum/comps-modules/v1/"),
 	})
 	assert.NoError(t, err)
 	repo, err = s.dao.RepositoryConfig.Fetch(s.ctx, orgID, repo.UUID)
@@ -130,11 +130,11 @@ func (s *DeleteTest) TestDeleteSnapshot() {
 	s.updateTemplateContentAndWait(orgID, tempResp.UUID, []string{repo.UUID})
 	rpms, _, err := s.dao.Rpm.ListTemplateRpms(s.ctx, orgID, tempResp.UUID, "", api.PaginationData{})
 	assert.NoError(t, err)
-	assert.Len(t, rpms, 3)
+	assert.Len(t, rpms, 7)
 
 	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath(s.ctx)
 	assert.NoError(s.T(), err)
-	rpmPath := fmt.Sprintf("%v%v/%v/latest/Packages/w", host, domain, repo.UUID)
+	rpmPath := fmt.Sprintf("%v%v/%v/latest/Packages/l", host, domain, repo.UUID)
 	err = s.getRequest(rpmPath, identity.Identity{OrgID: repo.OrgID, Internal: identity.Internal{OrgID: repo.OrgID}}, 404)
 	assert.NoError(s.T(), err)
 

--- a/test/integration/update_latest_snapshot_test.go
+++ b/test/integration/update_latest_snapshot_test.go
@@ -65,7 +65,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshot() {
 	domainName, err := s.dao.Domain.FetchOrCreateDomain(ctx, orgID)
 	assert.NoError(s.T(), err)
 
-	repo := s.createAndSyncRepository(orgID, "https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/")
+	repo := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v1/")
 
 	// Create template with use latest
 	reqTemplate := api.TemplateRequest{
@@ -109,7 +109,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshot() {
 	assert.NoError(s.T(), err)
 
 	// Change the URL of the repo, create a new snapshot, and update template snapshots
-	repoNewURL := "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/"
+	repoNewURL := "https://content-services.github.io/fixtures/yum/comps-modules/v2/"
 	_, err = s.dao.RepositoryConfig.Update(ctx, orgID, repo.UUID, api.RepositoryUpdateRequest{URL: &repoNewURL})
 	assert.NoError(s.T(), err)
 

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -66,8 +66,8 @@ func (s *UpdateTemplateContentSuite) TestUseLatest() {
 	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath(ctx)
 	require.NoError(s.T(), err)
 
-	repo := s.createAndSyncRepository(orgID, "https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/")
-	repoNewURL := "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/"
+	repo := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v1/")
+	repoNewURL := "https://content-services.github.io/fixtures/yum/comps-modules/v2/"
 
 	_, err = s.dao.RepositoryConfig.Update(ctx, orgID, repo.UUID, api.RepositoryUpdateRequest{URL: &repoNewURL})
 	assert.NoError(s.T(), err)
@@ -112,8 +112,8 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.NoError(s.T(), err)
 
 	repo1 := s.createAndSyncRepository(orgID, "https://fixtures.pulpproject.org/rpm-unsigned/")
-	repo2 := s.createAndSyncRepository(orgID, "https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/")
-	repo3 := s.createAndSyncRepository(orgID, "https://rverdile.fedorapeople.org/dummy-repos/comps/repo2/")
+	repo2 := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v1/")
+	repo3 := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v2/")
 
 	repo1ContentID := candlepin_client.GetContentID(repo1.UUID)
 	repo2ContentID := candlepin_client.GetContentID(repo2.UUID)
@@ -362,7 +362,7 @@ func (s *UpdateTemplateContentSuite) TestDelete() {
 	orgID := uuid2.NewString()
 
 	// Create repo
-	repo := s.createAndSyncRepository(orgID, "https://rverdile.fedorapeople.org/dummy-repos/comps/repo1/")
+	repo := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v1/")
 
 	// Create consumer
 	consumerName := "test-consumer"


### PR DESCRIPTION
## Summary
Replaces uses of the https://rverdile.fedorapeople.org/dummy-repos/comps repositories with the new ones at https://content-services.github.io/fixtures/yum/comps-modules

## Testing steps

