### PR TITLE
HMS-5522: cleanup snapshots even if partially deleted

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -328,14 +328,15 @@ func enqueueSnapshotsCleanup(ctx context.Context, olderThanDays int) error {
 	if err != nil {
 		return fmt.Errorf("error getting repository configurations: %v", err)
 	}
-
 	for _, repo := range repoConfigs {
+		log.Error().Msgf("Repository %v", repo.Name)
 		// Fetch snapshots for repo and find those which are to be deleted
-		snaps, err := snapshotDao.FetchForRepoConfigUUID(ctx, repo.UUID)
+		snaps, err := snapshotDao.FetchForRepoConfigUUID(ctx, repo.UUID, true)
 		if err != nil {
 			return fmt.Errorf("error fetching snapshots for repository %v", repo.Name)
 		}
 		if len(snaps) < 2 {
+			log.Warn().Msgf("Skipping snapshot for repository %v", repo.Name)
 			continue
 		}
 
@@ -368,7 +369,7 @@ func enqueueSnapshotsCleanup(ctx context.Context, olderThanDays int) error {
 		for _, s := range toBeDeletedSnapUUIDs {
 			err := snapshotDao.SoftDelete(ctx, s)
 			if err != nil {
-				return err
+				return fmt.Errorf("Could not soft delete snapshot %w", err)
 			}
 		}
 

--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -315,83 +315,81 @@ func enqueueSnapshotsCleanup(ctx context.Context, olderThanDays int) error {
 		return fmt.Errorf("error getting new task queue: %w", err)
 	}
 	c := client.NewTaskClient(&q)
-	fs, err := feature_service_client.NewFeatureServiceClient()
-	if err != nil {
-		return fmt.Errorf("error getting feature service client: %w", err)
-	}
-
-	repoConfigDao := dao.GetRepositoryConfigDao(db.DB, pulp_client.GetPulpClientWithDomain(""), fs)
-	snapshotDao := dao.GetSnapshotDao(db.DB)
-	taskInfoDao := dao.GetTaskInfoDao(db.DB)
-
-	repoConfigs, err := repoConfigDao.ListReposWithOutdatedSnapshots(ctx, olderThanDays)
+	daoReg := dao.GetDaoRegistry(db.DB)
+	repoConfigs, err := daoReg.RepositoryConfig.ListReposWithOutdatedSnapshots(ctx, olderThanDays)
 	if err != nil {
 		return fmt.Errorf("error getting repository configurations: %v", err)
 	}
 	for _, repo := range repoConfigs {
-		log.Error().Msgf("Repository %v", repo.Name)
-		// Fetch snapshots for repo and find those which are to be deleted
-		snaps, err := snapshotDao.FetchForRepoConfigUUID(ctx, repo.UUID, true)
+		err := enqueueSnapshotCleanupForRepoConfig(ctx, c, daoReg, olderThanDays, repo)
 		if err != nil {
-			return fmt.Errorf("error fetching snapshots for repository %v", repo.Name)
+			log.Err(err).Msgf("error cleaning snapshot for repository %v (%v)", repo.Name, repo.UUID)
 		}
-		if len(snaps) < 2 {
-			log.Warn().Msgf("Skipping snapshot for repository %v", repo.Name)
-			continue
-		}
+	}
+	return nil
+}
 
-		slices.SortFunc(snaps, func(s1, s2 models.Snapshot) int {
-			return s1.CreatedAt.Compare(s2.CreatedAt)
-		})
-		toBeDeletedSnapUUIDs := make([]string, 0, len(snaps))
-		for i, snap := range snaps {
-			if i == len(snaps)-1 && len(toBeDeletedSnapUUIDs) == len(snaps)-1 {
-				break
-			}
-			if snap.CreatedAt.Before(time.Now().Add(-time.Duration(olderThanDays) * 24 * time.Hour)) {
-				toBeDeletedSnapUUIDs = append(toBeDeletedSnapUUIDs, snap.UUID)
-			}
-		}
-		if len(toBeDeletedSnapUUIDs) == 0 {
-			return fmt.Errorf("no outdated snapshot found for repository %v", repo.Name)
-		}
+func enqueueSnapshotCleanupForRepoConfig(ctx context.Context, taskClient client.TaskClient, daoReg *dao.DaoRegistry, olderThanDays int, repo models.RepositoryConfiguration) error {
+	// Fetch snapshots for repo and find those which are to be deleted
+	snaps, err := daoReg.Snapshot.FetchForRepoConfigUUID(ctx, repo.UUID, true)
+	if err != nil {
+		return fmt.Errorf("error fetching snapshots for repository %v", repo.Name)
+	}
+	if len(snaps) < 2 {
+		log.Warn().Msgf("Skipping snapshot for repository %v", repo.Name)
+		return nil
+	}
 
-		// Check for a running delete task
-		inProgressTasks, err := taskInfoDao.FetchActiveTasks(ctx, repo.OrgID, repo.UUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask)
+	slices.SortFunc(snaps, func(s1, s2 models.Snapshot) int {
+		return s1.CreatedAt.Compare(s2.CreatedAt)
+	})
+	toBeDeletedSnapUUIDs := make([]string, 0, len(snaps))
+	for i, snap := range snaps {
+		if i == len(snaps)-1 && len(toBeDeletedSnapUUIDs) == len(snaps)-1 {
+			break
+		}
+		if snap.CreatedAt.Before(time.Now().Add(-time.Duration(olderThanDays) * 24 * time.Hour)) {
+			toBeDeletedSnapUUIDs = append(toBeDeletedSnapUUIDs, snap.UUID)
+		}
+	}
+	if len(toBeDeletedSnapUUIDs) == 0 {
+		return fmt.Errorf("no outdated snapshot found for repository %v", repo.Name)
+	}
+
+	// Check for a running delete task
+	inProgressTasks, err := daoReg.TaskInfo.FetchActiveTasks(ctx, repo.OrgID, repo.UUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask)
+	if err != nil {
+		return fmt.Errorf("error fetching delete repository snapshots task for repository %v", repo.Name)
+	}
+	if len(inProgressTasks) >= 1 {
+		return fmt.Errorf("error, delete is already in progress for repoository %v", repo.Name)
+	}
+
+	// Soft delete to-be-deleted snapshots
+	for _, s := range toBeDeletedSnapUUIDs {
+		err := daoReg.Snapshot.SoftDelete(ctx, s)
 		if err != nil {
-			return fmt.Errorf("error fetching delete repository snapshots task for repository %v", repo.Name)
-		}
-		if len(inProgressTasks) >= 1 {
-			return fmt.Errorf("error, delete is already in progress for repoository %v", repo.Name)
-		}
-
-		// Soft delete to-be-deleted snapshots
-		for _, s := range toBeDeletedSnapUUIDs {
-			err := snapshotDao.SoftDelete(ctx, s)
-			if err != nil {
-				return fmt.Errorf("Could not soft delete snapshot %w", err)
-			}
-		}
-
-		// Enqueue new delete task
-		t := queue.Task{
-			Typename: config.DeleteSnapshotsTask,
-			Payload: payloads.DeleteSnapshotsPayload{
-				RepoUUID:       repo.UUID,
-				SnapshotsUUIDs: toBeDeletedSnapUUIDs,
-			},
-			OrgId:      repo.OrgID,
-			AccountId:  repo.AccountID,
-			ObjectUUID: &repo.RepositoryUUID,
-			ObjectType: utils.Ptr(config.ObjectTypeRepository),
-		}
-
-		_, err = c.Enqueue(t)
-		if err != nil {
-			return fmt.Errorf("error enqueueing delete snapshots task for repository %v", repo.Name)
+			return fmt.Errorf("Could not soft delete snapshot %w", err)
 		}
 	}
 
+	// Enqueue new delete task
+	t := queue.Task{
+		Typename: config.DeleteSnapshotsTask,
+		Payload: payloads.DeleteSnapshotsPayload{
+			RepoUUID:       repo.UUID,
+			SnapshotsUUIDs: toBeDeletedSnapUUIDs,
+		},
+		OrgId:      repo.OrgID,
+		AccountId:  repo.AccountID,
+		ObjectUUID: &repo.RepositoryUUID,
+		ObjectType: utils.Ptr(config.ObjectTypeRepository),
+	}
+
+	_, err = taskClient.Enqueue(t)
+	if err != nil {
+		return fmt.Errorf("error enqueueing delete snapshots task for repository %v", repo.Name)
+	}
 	return nil
 }
 

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -123,7 +123,7 @@ type SnapshotDao interface {
 	Create(ctx context.Context, snap *models.Snapshot) error
 	List(ctx context.Context, orgID string, repoConfigUuid string, paginationData api.PaginationData, filterData api.FilterData) (api.SnapshotCollectionResponse, int64, error)
 	ListByTemplate(ctx context.Context, orgID string, template api.TemplateResponse, repositorySearch string, paginationData api.PaginationData) (api.SnapshotCollectionResponse, int64, error)
-	FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string) ([]models.Snapshot, error)
+	FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string, inclSoftDel bool) ([]models.Snapshot, error)
 	FetchModel(ctx context.Context, uuid string, includeSoftDel bool) (models.Snapshot, error)
 	SoftDelete(ctx context.Context, snapUUID string) error
 	Delete(ctx context.Context, snapUUID string) error

--- a/pkg/dao/snapshots_mock.go
+++ b/pkg/dao/snapshots_mock.go
@@ -119,9 +119,9 @@ func (_m *MockSnapshotDao) Fetch(ctx context.Context, uuid string) (api.Snapshot
 	return r0, r1
 }
 
-// FetchForRepoConfigUUID provides a mock function with given fields: ctx, repoConfigUUID
-func (_m *MockSnapshotDao) FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string) ([]models.Snapshot, error) {
-	ret := _m.Called(ctx, repoConfigUUID)
+// FetchForRepoConfigUUID provides a mock function with given fields: ctx, repoConfigUUID, inclSoftDel
+func (_m *MockSnapshotDao) FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string, inclSoftDel bool) ([]models.Snapshot, error) {
+	ret := _m.Called(ctx, repoConfigUUID, inclSoftDel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchForRepoConfigUUID")
@@ -129,19 +129,19 @@ func (_m *MockSnapshotDao) FetchForRepoConfigUUID(ctx context.Context, repoConfi
 
 	var r0 []models.Snapshot
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]models.Snapshot, error)); ok {
-		return rf(ctx, repoConfigUUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) ([]models.Snapshot, error)); ok {
+		return rf(ctx, repoConfigUUID, inclSoftDel)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []models.Snapshot); ok {
-		r0 = rf(ctx, repoConfigUUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) []models.Snapshot); ok {
+		r0 = rf(ctx, repoConfigUUID, inclSoftDel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.Snapshot)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, repoConfigUUID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
+		r1 = rf(ctx, repoConfigUUID, inclSoftDel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -456,6 +456,16 @@ func (s *SnapshotsSuite) TestFetchForRepoUUID() {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(snaps))
 	assert.Equal(t, snaps[0].RepositoryConfigurationUUID, repoConfig.UUID)
+
+	assert.NoError(t, tx.Delete(&snaps[0]).Error)
+
+	snaps, err = sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(snaps))
+
+	snaps, err = sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(snaps))
 }
 
 func (s *SnapshotsSuite) TestFetchLatestSnapshot() {

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -452,7 +452,7 @@ func (s *SnapshotsSuite) TestFetchForRepoUUID() {
 	s.createSnapshot(repoConfig)
 
 	sDao := snapshotDaoImpl{db: tx}
-	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID)
+	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(snaps))
 	assert.Equal(t, snaps[0].RepositoryConfigurationUUID, repoConfig.UUID)
@@ -934,7 +934,7 @@ func (s *SnapshotsSuite) TestSoftDeleteSnapshotAlreadyDeleted() {
 	assert.NoError(t, err)
 
 	err = sDao.SoftDelete(context.Background(), snapshot.UUID)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func (s *SnapshotsSuite) TestClearDeletedAt() {
@@ -991,7 +991,7 @@ func (s *SnapshotsSuite) TestBulkDelete() {
 	_, err = sDao.Fetch(context.Background(), s2.UUID)
 	assert.Error(t, err)
 
-	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID)
+	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, false)
 	assert.NoError(t, err)
 	assert.Len(t, snaps, 1)
 	assert.Equal(t, s1.UUID, snaps[0].UUID)
@@ -1014,7 +1014,7 @@ func (s *SnapshotsSuite) TestBulkDeleteNotFound() {
 	assert.Len(t, slices.DeleteFunc(errs, func(e error) bool { return e == nil }), 1)
 	assert.Equal(t, fmt.Sprintf("Snapshot with UUID %s not found: record not found", s2.UUID), errs[0].Error())
 
-	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID)
+	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, false)
 	assert.NoError(t, err)
 	assert.Len(t, snaps, 2)
 	assert.True(t, slices.ContainsFunc(snaps, func(snap models.Snapshot) bool { return snap.UUID == s1.UUID }))

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -382,7 +382,7 @@ func (sh *SnapshotHandler) isDeleteAllowed(c echo.Context, orgID, repoUUID strin
 		return err
 	}
 
-	repoSnaps, err := sh.DaoRegistry.Snapshot.FetchForRepoConfigUUID(c.Request().Context(), repoUUID)
+	repoSnaps, err := sh.DaoRegistry.Snapshot.FetchForRepoConfigUUID(c.Request().Context(), repoUUID, false)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching snapshots", err.Error())
 	}

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -236,7 +236,7 @@ func (suite *SnapshotSuite) TestDelete() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("Fetch", test.MockCtx(), snapUUID).Return(snap, nil)
 	suite.reg.Snapshot.On("SoftDelete", test.MockCtx(), snapUUID).Return(nil)
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUID).Return(uuid.New(), nil)
@@ -326,7 +326,7 @@ func (suite *SnapshotSuite) TestDeleteRepoFetchFailed() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, errors.New("test error"))
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, errors.New("test error"))
 
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapUUID)
 	req := httptest.NewRequest(http.MethodDelete, path, nil)
@@ -349,7 +349,7 @@ func (suite *SnapshotSuite) TestDeleteAllSnapshotsError() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapUUID)
 	req := httptest.NewRequest(http.MethodDelete, path, nil)
@@ -373,7 +373,7 @@ func (suite *SnapshotSuite) TestDeleteSnapNotInRepo() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapUUID)
 	req := httptest.NewRequest(http.MethodDelete, path, nil)
@@ -396,7 +396,7 @@ func (suite *SnapshotSuite) TestDeleteSoftDeleteFailed() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("SoftDelete", test.MockCtx(), snapUUID).Return(errors.New("test error"))
 
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapUUID)
@@ -420,7 +420,7 @@ func (suite *SnapshotSuite) TestDeleteEnqueueFailed() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("SoftDelete", test.MockCtx(), snapUUID).Return(nil)
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUID).Return(uuid.Nil, errors.New("test error"))
 	suite.reg.Snapshot.On("ClearDeletedAt", test.MockCtx(), snapUUID).Return(nil)
@@ -447,7 +447,7 @@ func (suite *SnapshotSuite) TestDeleteClearDeletedAtFailed() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("SoftDelete", test.MockCtx(), snapUUID).Return(nil)
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUID).Return(uuid.Nil, errors.New("test error"))
 	suite.reg.Snapshot.On("ClearDeletedAt", test.MockCtx(), snapUUID).Return(errors.New("test error"))
@@ -474,7 +474,7 @@ func (suite *SnapshotSuite) TestBulkDelete() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("BulkDelete", test.MockCtx(), snapUUIDs).Return([]error{})
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUIDs...).Return(uuid.New(), nil)
 
@@ -552,7 +552,7 @@ func (suite *SnapshotSuite) TestBulkDeleteHasErr() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 
 	body, err := json.Marshal(api.UUIDListRequest{UUIDs: snapUUIDs})
 	assert.NoError(t, err)
@@ -580,7 +580,7 @@ func (suite *SnapshotSuite) TestBulkDeleteFailedEnqueueAndClear() {
 
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
-	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID).Return(collection, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
 	suite.reg.Snapshot.On("BulkDelete", test.MockCtx(), snapUUIDs).Return([]error{})
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUIDs...).Return(uuid.Nil, errors.New("test error, failed enqueue"))
 	suite.reg.Snapshot.On("ClearDeletedAt", test.MockCtx(), snapUUIDs[0]).Return(nil)

--- a/pkg/pulp_client/interfaces.go
+++ b/pkg/pulp_client/interfaces.go
@@ -58,7 +58,7 @@ type PulpClient interface {
 
 	// Rpm Repository Version
 	GetRpmRepositoryVersion(ctx context.Context, href string) (*zest.RepositoryVersionResponse, error)
-	DeleteRpmRepositoryVersion(ctx context.Context, href string) (string, error)
+	DeleteRpmRepositoryVersion(ctx context.Context, href string) (*string, error)
 	RepairRpmRepositoryVersion(ctx context.Context, href string) (string, error)
 	ModifyRpmRepositoryContent(ctx context.Context, repoHref string, contentHrefsToAdd []string, contentHrefsToRemove []string) (string, error)
 
@@ -69,7 +69,7 @@ type PulpClient interface {
 	// Distribution
 	CreateRpmDistribution(ctx context.Context, publicationHref string, name string, basePath string, contentGuardHref *string) (*string, error)
 	FindDistributionByPath(ctx context.Context, path string) (*zest.RpmRpmDistributionResponse, error)
-	DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (string, error)
+	DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (*string, error)
 	UpdateRpmDistribution(ctx context.Context, rpmDistributionHref string, rpmPublicationHref string, distributionName string, basePath string, contentGuardHref *string) (string, error)
 
 	// Domains

--- a/pkg/pulp_client/pulp_client_mock.go
+++ b/pkg/pulp_client/pulp_client_mock.go
@@ -286,22 +286,24 @@ func (_m *MockPulpClient) CreateUpload(ctx context.Context, size int64) (*zest.U
 }
 
 // DeleteRpmDistribution provides a mock function with given fields: ctx, rpmDistributionHref
-func (_m *MockPulpClient) DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (string, error) {
+func (_m *MockPulpClient) DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (*string, error) {
 	ret := _m.Called(ctx, rpmDistributionHref)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteRpmDistribution")
 	}
 
-	var r0 string
+	var r0 *string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*string, error)); ok {
 		return rf(ctx, rpmDistributionHref)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) *string); ok {
 		r0 = rf(ctx, rpmDistributionHref)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
@@ -370,22 +372,24 @@ func (_m *MockPulpClient) DeleteRpmRepository(ctx context.Context, rpmRepository
 }
 
 // DeleteRpmRepositoryVersion provides a mock function with given fields: ctx, href
-func (_m *MockPulpClient) DeleteRpmRepositoryVersion(ctx context.Context, href string) (string, error) {
+func (_m *MockPulpClient) DeleteRpmRepositoryVersion(ctx context.Context, href string) (*string, error) {
 	ret := _m.Called(ctx, href)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteRpmRepositoryVersion")
 	}
 
-	var r0 string
+	var r0 *string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*string, error)); ok {
 		return rf(ctx, href)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string) *string); ok {
 		r0 = rf(ctx, href)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {

--- a/pkg/pulp_client/rpm_distributions.go
+++ b/pkg/pulp_client/rpm_distributions.go
@@ -44,7 +44,7 @@ func (r *pulpDaoImpl) FindDistributionByPath(ctx context.Context, path string) (
 	}
 }
 
-func (r *pulpDaoImpl) DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (string, error) {
+func (r *pulpDaoImpl) DeleteRpmDistribution(ctx context.Context, rpmDistributionHref string) (*string, error) {
 	ctx, client := getZestClient(ctx)
 	resp, httpResp, err := client.DistributionsRpmAPI.DistributionsRpmRpmDelete(ctx, rpmDistributionHref).Execute()
 	if httpResp != nil {
@@ -52,11 +52,11 @@ func (r *pulpDaoImpl) DeleteRpmDistribution(ctx context.Context, rpmDistribution
 	}
 	if err != nil {
 		if err.Error() == "404 Not Found" {
-			return "", nil
+			return nil, nil
 		}
-		return "", errorWithResponseBody("error deleting rpm distribution", httpResp, err)
+		return nil, errorWithResponseBody("error deleting rpm distribution", httpResp, err)
 	}
-	return resp.Task, nil
+	return &resp.Task, nil
 }
 
 func (r *pulpDaoImpl) UpdateRpmDistribution(ctx context.Context, rpmDistributionHref string, rpmPublicationHref string, distributionName string, basePath string, contentGuardHref *string) (string, error) {

--- a/pkg/pulp_client/rpm_repository_version.go
+++ b/pkg/pulp_client/rpm_repository_version.go
@@ -22,7 +22,7 @@ func (r *pulpDaoImpl) GetRpmRepositoryVersion(ctx context.Context, href string) 
 }
 
 // DeleteRpmRepositoryVersion starts task to delete repository version and returns delete task's href
-func (r *pulpDaoImpl) DeleteRpmRepositoryVersion(ctx context.Context, href string) (string, error) {
+func (r *pulpDaoImpl) DeleteRpmRepositoryVersion(ctx context.Context, href string) (*string, error) {
 	ctx, client := getZestClient(ctx)
 	resp, httpResp, err := client.RepositoriesRpmVersionsAPI.RepositoriesRpmRpmVersionsDelete(ctx, href).Execute()
 	if httpResp != nil {
@@ -30,11 +30,11 @@ func (r *pulpDaoImpl) DeleteRpmRepositoryVersion(ctx context.Context, href strin
 	}
 	if err != nil {
 		if err.Error() == "404 Not Found" {
-			return "", nil
+			return nil, nil
 		}
-		return "", errorWithResponseBody("error deleting rpm repository versions", httpResp, err)
+		return nil, errorWithResponseBody("error deleting rpm repository versions", httpResp, err)
 	}
-	return resp.Task, nil
+	return &resp.Task, nil
 }
 
 func (r *pulpDaoImpl) RepairRpmRepositoryVersion(ctx context.Context, href string) (string, error) {

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -146,7 +146,7 @@ func (d *DeleteRepositorySnapshots) getPulpClient() pulp_client.PulpClient {
 }
 
 func (d *DeleteRepositorySnapshots) fetchSnapshots() ([]models.Snapshot, error) {
-	return d.daoReg.Snapshot.FetchForRepoConfigUUID(d.ctx, d.payload.RepoConfigUUID)
+	return d.daoReg.Snapshot.FetchForRepoConfigUUID(d.ctx, d.payload.RepoConfigUUID, false)
 }
 
 func (d *DeleteRepositorySnapshots) deleteRpmDistribution(snapDistributionHref string) (*zest.TaskResponse, error) {
@@ -154,7 +154,10 @@ func (d *DeleteRepositorySnapshots) deleteRpmDistribution(snapDistributionHref s
 	if err != nil {
 		return nil, err
 	}
-	task, err := d.getPulpClient().PollTask(d.ctx, deleteDistributionHref)
+	if deleteDistributionHref == nil {
+		return nil, nil
+	}
+	task, err := d.getPulpClient().PollTask(d.ctx, *deleteDistributionHref)
 	if err != nil {
 		return task, err
 	}
@@ -246,8 +249,8 @@ func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() error {
 			return err
 		}
 
-		if taskHref != "" {
-			_, err = d.getPulpClient().PollTask(d.ctx, taskHref)
+		if taskHref != nil {
+			_, err = d.getPulpClient().PollTask(d.ctx, *taskHref)
 			if err != nil {
 				return err
 			}

--- a/pkg/tasks/delete_repository_snapshots_test.go
+++ b/pkg/tasks/delete_repository_snapshots_test.go
@@ -129,7 +129,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteNoSnapshotsWithClient() {
 		ObjectUUID: repoUuid,
 	}
 
-	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID).Return([]models.Snapshot{}, nil).Once()
+	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID, false).Return([]models.Snapshot{}, nil).Once()
 	s.mockDaoRegistry.RepositoryConfig.On("Delete", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 
 	s.MockPulpClient.On("FindDistributionByPath", ctx, fmt.Sprintf("%v/%v", repoConfig.UUID, "latest")).Return(nil, nil).Once()
@@ -186,7 +186,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 	remoteResp := zest.RpmRpmRemoteResponse{PulpHref: utils.Ptr("remoteHref"), Url: repoConfig.URL}
 	repoResp := zest.RpmRpmRepositoryResponse{PulpHref: utils.Ptr("repoHref")}
 
-	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID).Return([]models.Snapshot{expectedSnap}, nil).Once()
+	s.mockDaoRegistry.Snapshot.On("FetchForRepoConfigUUID", ctx, repoConfig.UUID, false).Return([]models.Snapshot{expectedSnap}, nil).Once()
 	s.mockDaoRegistry.Snapshot.On("Delete", ctx, expectedSnap.UUID).Return(nil).Once()
 	s.mockDaoRegistry.RepositoryConfig.On("Delete", ctx, repoConfig.OrgID, repoConfig.UUID).Return(nil).Once()
 	s.mockDaoRegistry.Template.On("DeleteTemplateSnapshot", ctx, expectedSnap.UUID).Return(nil).Once()
@@ -194,7 +194,7 @@ func (s *DeleteRepositorySnapshotsSuite) TestDeleteSnapshotFull() {
 	s.MockPulpClient.On("PollTask", ctx, "taskHref").Return(&taskResp, nil).Times(3)
 	s.MockPulpClient.On("DeleteRpmRepositoryVersion", ctx, expectedSnap.VersionHref).Return(nil).Once()
 	s.MockPulpClient.On("FindDistributionByPath", ctx, fmt.Sprintf("%v/%v", repoConfig.UUID, "latest")).Return(nil, nil).Once()
-	s.MockPulpClient.On("DeleteRpmDistribution", ctx, expectedSnap.DistributionHref).Return("taskHref", nil).Once()
+	s.MockPulpClient.On("DeleteRpmDistribution", ctx, expectedSnap.DistributionHref).Return(utils.Ptr("taskHref"), nil).Once()
 
 	s.MockPulpClient.On("GetRpmRemoteByName", ctx, repoConfig.UUID).Return(nil).Return(&remoteResp, nil).Once()
 	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(&repoResp, nil).Once()

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -169,18 +169,22 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 	if err != nil {
 		return err
 	}
-	_, err = ds.getPulpClient().PollTask(ds.ctx, deleteDistributionHref)
-	if err != nil {
-		return err
+	if deleteDistributionHref != nil {
+		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteDistributionHref)
+		if err != nil {
+			return err
+		}
 	}
 
 	deleteVersionHref, err := ds.getPulpClient().DeleteRpmRepositoryVersion(ds.ctx, snap.VersionHref)
 	if err != nil {
 		return err
 	}
-	_, err = ds.getPulpClient().PollTask(ds.ctx, deleteVersionHref)
-	if err != nil {
-		return err
+	if deleteDistributionHref != nil {
+		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteVersionHref)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/tasks/delete_snapshots_test.go
+++ b/pkg/tasks/delete_snapshots_test.go
@@ -110,9 +110,9 @@ func (s *DeleteSnapshotsSuite) TestDeleteSnapshots() {
 	s.mockPulpClient.On("CreateOrUpdateGuardsForOrg", ctx, orgID).Return(uuid.NewString(), nil)
 	s.mockPulpClient.On("CreateRpmDistribution", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uuid.NewString(), nil)
 	s.mockPulpClient.On("UpdateRpmDistribution", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uuid.NewString(), nil)
-	s.mockPulpClient.On("DeleteRpmDistribution", ctx, snap.DistributionHref).Return(deleteDistributionHref, nil)
+	s.mockPulpClient.On("DeleteRpmDistribution", ctx, snap.DistributionHref).Return(&deleteDistributionHref, nil)
 	s.mockPulpClient.On("PollTask", ctx, mock.Anything).Return(nil, nil)
-	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, snap.VersionHref).Return("taskHref", nil)
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, snap.VersionHref).Return(utils.Ptr("taskHref"), nil)
 
 	pulpClient := s.pulpClient()
 	task := DeleteSnapshots{

--- a/pkg/tasks/delete_templates.go
+++ b/pkg/tasks/delete_templates.go
@@ -125,8 +125,8 @@ func (d *DeleteTemplates) deleteDistributions() error {
 			return err
 		}
 
-		if taskHref != "" {
-			_, err = d.pulpClient.PollTask(d.ctx, taskHref)
+		if taskHref != nil {
+			_, err = d.pulpClient.PollTask(d.ctx, *taskHref)
 			if err != nil {
 				return err
 			}

--- a/pkg/tasks/snapshot_helper.go
+++ b/pkg/tasks/snapshot_helper.go
@@ -119,9 +119,11 @@ func (sh *SnapshotHelper) Cleanup() error {
 		if err != nil {
 			return err
 		}
-		_, err = sh.pulpClient.PollTask(sh.ctx, deleteDistributionHref)
-		if err != nil {
-			return err
+		if deleteDistributionHref != nil {
+			_, err = sh.pulpClient.PollTask(sh.ctx, *deleteDistributionHref)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = sh.payload.SavePublicationTaskHref("")
@@ -159,9 +161,11 @@ func (sh *SnapshotHelper) Cleanup() error {
 				if err != nil {
 					return err
 				}
-				_, err = sh.pulpClient.PollTask(sh.ctx, deleteDistributionHref)
-				if err != nil {
-					return err
+				if deleteDistributionHref != nil {
+					_, err = sh.pulpClient.PollTask(sh.ctx, *deleteDistributionHref)
+					if err != nil {
+						return err
+					}
 				}
 				return nil
 			}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -291,8 +291,8 @@ func (t *UpdateTemplateContent) handleReposRemoved(reposRemoved []string) error 
 			return err
 		}
 
-		if taskHref != "" {
-			_, err = t.pulpClient.PollTask(t.ctx, taskHref)
+		if taskHref != nil {
+			_, err = t.pulpClient.PollTask(t.ctx, *taskHref)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

* Changes snapshot SoftDelete to not error if the given snapshot was already soft deleted
* Adds the ability to list snapshots that are also soft deleted and uses this in cleanup
* makes pulp repo version delete and distribution delete return a string pointer instead of a string to make it obvious that 404s will not return a task href
* modified it so that if an error occurred for one repository, it would log it and still try to do the rest.

## Testing steps

create a repository and get its repo config uuid

use this to create old snapshots, run in the terminal:

```
rcuuid="abcde"
created="2024-10-02 00:55:30.953994+00"
snapUUID=`uuidgen`

query="insert into snapshots (uuid,created_at, repository_configuration_uuid, version_href, publication_href, distribution_href, distribution_path) VALUES  ('$snapUUID','$created', '$rcuuid', '', '', '/$RANDOM/$RANDOM/', '/$RANDOM/$RANDOM');"
psql "sslmode=disable dbname=content user=content host=localhost port=5433 password=content" -c "$query"
```
do this a few times with different dates
then run ```OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT=30 go run cmd/external-repos/main.go process-repos```

check the db/api and see the older snapshots get deleted.
