### PR TITLE
Test: Update playwright trigger

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -1,16 +1,11 @@
 name: build-playwright-test
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This enables us to use secrets and manually trigger the workflow. Update also group to using PR number as `ref` would be always sha of main.

Copied from frontend.

