### PR TITLE
HMS-5551: use prefix match for rpm search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.9
 require (
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.12
+	github.com/content-services/tang v0.0.13
 	github.com/content-services/yummy v1.0.14
 	github.com/getkin/kin-openapi v0.129.0
 	github.com/go-openapi/spec v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/content-services/caliri/release/v4 v4.5.0 h1:hPdGSxG20IcVX/qA9fJ9J6Up
 github.com/content-services/caliri/release/v4 v4.5.0/go.mod h1:+FDRCiyWWdfd8mYmbXOjHkbInwlZXp+cqfABEcEdF7o=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.12 h1:EE8t1bZsWjT3X3wviUYW5+KvYPduU2WoGhHy+g7CGf4=
-github.com/content-services/tang v0.0.12/go.mod h1:J0A8WTEt8h8xxMHfXN84Ucu4DUItp+uH0tLwrQbtpYE=
+github.com/content-services/tang v0.0.13 h1:Ftr/S8c+acmgj/gg0P3RtAZAk5/hUFd/VxdO2ANYH6E=
+github.com/content-services/tang v0.0.13/go.mod h1:J0A8WTEt8h8xxMHfXN84Ucu4DUItp+uH0tLwrQbtpYE=
 github.com/content-services/yummy v1.0.14 h1:XYoqidBhElo0cMxDyJ/sswmZsN0Cbuf9Yoe8e0iVIMg=
 github.com/content-services/yummy v1.0.14/go.mod h1:rrVMHk0HnYXIfp3W3CeWrl3Ev5EojpQo8FWn5ktgCJg=
 github.com/content-services/zest/release/v2024 v2024.12.1734541842 h1:vIIWFZ5j76MVg2VuxkXAR56NAvkst7LtAeAugbfJmFU=

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -199,7 +199,7 @@ func (r rpmDaoImpl) Search(ctx context.Context, orgID string, request api.Conten
 	if len(request.ExactNames) != 0 {
 		db = db.Where("rpms.name in (?)", request.ExactNames)
 	} else {
-		db = db.Where("rpms.name ILIKE ?", fmt.Sprintf("%%%s%%", request.Search))
+		db = db.Where("rpms.name ILIKE ?", fmt.Sprintf("%s%%", request.Search))
 	}
 
 	db = db.Order("rpms.name ASC").

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -460,12 +460,7 @@ func (s *RpmSuite) TestRpmSearch() {
 					Limit:  utils.Ptr(50),
 				},
 			},
-			expected: []api.SearchRpmResponse{
-				{
-					PackageName: "demo-package",
-					Summary:     "demo-package Epoch",
-				},
-			},
+			expected: []api.SearchRpmResponse{},
 		},
 		{
 			name: "Exact matched items are returned",


### PR DESCRIPTION
## Summary

Changes the rpm name search to only search using prefixes.  This has a couple advantages:

1.  it is much much faster
2. The exact match will appear in the list first

Snapshot search is also switched here: https://github.com/content-services/tang/pull/18

## Testing steps

create a repo, then search for rpms:

```
POST http://localhost:8000/api/content-sources/v1.0/rpms/names
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiIxIn0sImFjY291bnRfbnVtYmVyIjoiZm9vIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K
Content-Type: application/json

{"urls":["https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/",
  "http://yum.theforeman.org/pulpcore/3.16/el8/x86_64/"],
  "search":"p"}
```

from the results, try search for a prefix, or a middle substring.  Only prefix's should return a match


Do the same for the created snapshot:

```
GET http://localhost:8000/api/content-sources/v1.0/snapshots/b158a14a-50d9-470a-9d3f-e0e596d859d9/rpms?search=a&limit=10
x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI5IiwgInR5cGUiOiJVc2VyIiwidXNlciI6eyJ1c2VybmFtZSI6ImZvbyJ9LCJhY2NvdW50X251bWJlciI6ImZvbyIsImludGVybmFsIjp7Im9yZ19pZCI6IjkifX19Cg==
Content-Type: application/json
```
