### PR TITLE
HMS-5585: do not delete last template update tasks

### DIFF
--- a/pkg/dao/task_info.go
+++ b/pkg/dao/task_info.go
@@ -132,13 +132,14 @@ func (t taskInfoDaoImpl) Cleanup(ctx context.Context) error {
 	// Do not delete tasks if they are the last update-template-content task that updated a template
 	q := "delete from tasks where " +
 		"(type in (%v) and " +
+		"NOT EXISTS (SELECT 1 FROM templates WHERE templates.last_update_task_uuid = tasks.id) AND" +
 		"((status = 'completed' or status = 'failed') and finished_at < (current_date - interval '20' day)) OR" +
 		"((status = 'canceled') and queued_at < (current_date - interval '20' day)))" +
 		"OR" +
 		"(type in (%v) and " +
-		"status = 'completed' and  finished_at < (current_date - interval '10' day)" +
-		"AND NOT EXISTS (SELECT 1 FROM templates WHERE templates.last_update_task_uuid = tasks.id))"
+		"status = 'completed' and  finished_at < (current_date - interval '10' day))"
 	q = fmt.Sprintf(q, stringSliceToQueryList(config.TasksToCleanup), stringSliceToQueryList(config.TasksToCleanupIfCompleted))
+
 	result := t.db.WithContext(ctx).Exec(q)
 	if result.Error != nil {
 		return result.Error


### PR DESCRIPTION
## Summary

Fixes a regression where by templates last update tasks were being deleted

## Testing steps
import and snapshot rhle9 repos
Create a rhel 9 template 
update the dates:

```
update tasks set queued_at =  now() - interval '30 day';
update tasks set started_at =  now() - interval '30 day';
update tasks set finished_at =  now() - interval '30 day';
```

run process-repos:
```
go run cmd/external-repos/main.go process-repos
```

On main, you'll see the task get deleted and the template will show up in the UI as 'invalid'.  "edit" the templates to get them back to a green status and then repeat on this PR.