### PR TITLE
Test: add test describes to playwright tests

### DIFF
--- a/_playwright-tests/tests/API/CheckGetFeatures.spec.ts
+++ b/_playwright-tests/tests/API/CheckGetFeatures.spec.ts
@@ -2,7 +2,9 @@ import { expect } from '@playwright/test';
 import { test } from './base_client';
 import { FeaturesApi } from './client';
 
-test('Content > GetFeatures API', async ({ client }) => {
-  const resp = await new FeaturesApi(client).listFeatures();
-  expect(resp['snapshots']['enabled']).toBe(true);
+test.describe('Features', () => {
+  test('List features', async ({ client }) => {
+    const resp = await new FeaturesApi(client).listFeatures();
+    expect(resp['snapshots']['enabled']).toBe(true);
+  });
 });

--- a/_playwright-tests/tests/API/PopularRepos.spec.ts
+++ b/_playwright-tests/tests/API/PopularRepos.spec.ts
@@ -2,10 +2,12 @@ import { expect } from '@playwright/test';
 import { test } from './base_client';
 import { PopularRepositoriesApi } from './client';
 
-test('Content > listPopularRepositories API', async ({ client }) => {
-  const resp = await new PopularRepositoriesApi(client).listPopularRepositories({
-    search: 'EPEL 9',
+test.describe('Populat repositories', () => {
+  test('List popular repositories', async ({ client }) => {
+    const resp = await new PopularRepositoriesApi(client).listPopularRepositories({
+      search: 'EPEL 9',
+    });
+    expect(resp.meta?.count).toBe(1);
+    expect(resp.data?.[0].suggestedName).toBe('EPEL 9 Everything x86_64');
   });
-  expect(resp.meta?.count).toBe(1);
-  expect(resp.data?.[0].suggestedName).toBe('EPEL 9 Everything x86_64');
 });

--- a/_playwright-tests/tests/API/Repositories.spec.ts
+++ b/_playwright-tests/tests/API/Repositories.spec.ts
@@ -8,45 +8,47 @@ import {
 import { expect } from '@playwright/test';
 import { poll } from './apiHelpers';
 
-test('Content > Verify repository introspection', async ({ client }) => {
-  await test.step('delete existing repository if exists', async () => {
-    const existing = await new RepositoriesApi(client).listRepositories(<ListRepositoriesRequest>{
-      search: 'test-repository',
-    });
-
-    if (existing?.data?.length) {
-      const resp = await new RepositoriesApi(client).deleteRepositoryRaw(<GetRepositoryRequest>{
-        uuid: existing.data[0].uuid?.toString(),
+test.describe('Repositories', () => {
+  test('Verify repository introspection', async ({ client }) => {
+    await test.step('delete existing repository if exists', async () => {
+      const existing = await new RepositoriesApi(client).listRepositories(<ListRepositoriesRequest>{
+        search: 'test-repository',
       });
-      expect(resp.raw.status).toBe(204);
-    }
-  });
 
-  let repo: ApiRepositoryResponse;
-  await test.step('Create a repo with name test-repository', async () => {
-    repo = await new RepositoriesApi(client).createRepository({
-      apiRepositoryRequest: {
-        name: 'test-repository',
-        url: 'https://content-services.github.io/fixtures/yum/comps-modules/v1/',
-      },
+      if (existing?.data?.length) {
+        const resp = await new RepositoriesApi(client).deleteRepositoryRaw(<GetRepositoryRequest>{
+          uuid: existing.data[0].uuid?.toString(),
+        });
+        expect(resp.raw.status).toBe(204);
+      }
     });
-    expect(repo.name).toBe('test-repository');
-  });
 
-  await test.step('wait for introspection to be completed', async () => {
-    const getRepository = () =>
-      new RepositoriesApi(client).getRepository(<GetRepositoryRequest>{
+    let repo: ApiRepositoryResponse;
+    await test.step('Create a repo with name test-repository', async () => {
+      repo = await new RepositoriesApi(client).createRepository({
+        apiRepositoryRequest: {
+          name: 'test-repository',
+          url: 'https://content-services.github.io/fixtures/yum/comps-modules/v1/',
+        },
+      });
+      expect(repo.name).toBe('test-repository');
+    });
+
+    await test.step('Wait for introspection to be completed', async () => {
+      const getRepository = () =>
+        new RepositoriesApi(client).getRepository(<GetRepositoryRequest>{
+          uuid: repo.uuid?.toString(),
+        });
+      const waitWhilePending = (resp: ApiRepositoryResponse) => resp.status === 'Pending';
+      const resp = await poll(getRepository, waitWhilePending, 10);
+      expect(resp.status).toBe('Valid');
+    });
+
+    await test.step('delete repository', async () => {
+      const resp = await new RepositoriesApi(client).deleteRepositoryRaw(<GetRepositoryRequest>{
         uuid: repo.uuid?.toString(),
       });
-    const waitWhilePending = (resp: ApiRepositoryResponse) => resp.status === 'Pending';
-    const resp = await poll(getRepository, waitWhilePending, 10);
-    expect(resp.status).toBe('Valid');
-  });
-
-  await test.step('delete repository', async () => {
-    const resp = await new RepositoriesApi(client).deleteRepositoryRaw(<GetRepositoryRequest>{
-      uuid: repo.uuid?.toString(),
+      expect(resp.raw.status).toBe(204);
     });
-    expect(resp.raw.status).toBe(204);
   });
 });

--- a/_playwright-tests/tests/API/Templates.spec.ts
+++ b/_playwright-tests/tests/API/Templates.spec.ts
@@ -1,12 +1,14 @@
 import { test, expectError } from './base_client';
 import { TemplatesApi } from './client';
 
-test('Content > Create Bad Template', async ({ client }) => {
-  await expectError(
-    400,
-    'Name cannot be blank',
-    new TemplatesApi(client).createTemplate({
-      apiTemplateRequest: { name: '', arch: '', repositoryUuids: [], version: '' },
-    }),
-  );
+test.describe('Templates', () => {
+  test('Create bad template', async ({ client }) => {
+    await expectError(
+      400,
+      'Name cannot be blank',
+      new TemplatesApi(client).createTemplate({
+        apiTemplateRequest: { name: '', arch: '', repositoryUuids: [], version: '' },
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
This adds test describes/suite wrappers to all current PW test files and removes the weird 'Content >' prefix that they all had, we know those tests test our API, since they live in out repo.

## Testing steps
- All tests should pass (nothing has changed there) but the PW reports and traces should be better/cleaner.
