### PR TITLE
HMS-5395: add metrics for cert expiration

### DIFF
--- a/pkg/config/certificates.go
+++ b/pkg/config/certificates.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 )
 
 type CertUser interface {
@@ -16,42 +18,25 @@ type CertUser interface {
 	ClientCertPath() string
 	ClientKeyPath() string
 	CACertPath() string
+	Label() string
 }
 
 func GetHTTPClient(certUser CertUser) (http.Client, error) {
 	timeout := 90 * time.Second
 
-	var cert []byte
-	if certUser.ClientCert() != "" {
-		cert = []byte(certUser.ClientCert())
-	} else if certUser.ClientCertPath() != "" {
-		file, err := os.ReadFile(certUser.ClientCertPath())
-		if err != nil {
-			return http.Client{}, err
-		}
-		cert = file
+	cert, err := ReadCert(certUser)
+	if err != nil {
+		return http.Client{}, fmt.Errorf("failed to read client certificate: %w", err)
 	}
 
-	var key []byte
-	if certUser.ClientKey() != "" {
-		key = []byte(certUser.ClientKey())
-	} else if certUser.ClientKeyPath() != "" {
-		file, err := os.ReadFile(certUser.ClientKeyPath())
-		if err != nil {
-			return http.Client{}, err
-		}
-		key = file
+	key, err := ReadKey(certUser)
+	if err != nil {
+		return http.Client{}, fmt.Errorf("failed to read client key: %w", err)
 	}
 
-	var caCert []byte
-	if certUser.CACert() != "" {
-		caCert = []byte(certUser.CACert())
-	} else if certUser.CACertPath() != "" {
-		file, err := os.ReadFile(certUser.CACertPath())
-		if err != nil {
-			return http.Client{}, err
-		}
-		caCert = file
+	caCert, err := ReadCACert(certUser)
+	if err != nil {
+		return http.Client{}, fmt.Errorf("failed to read client ca certificate: %w", err)
 	}
 
 	transport, err := GetTransport(cert, key, caCert, timeout)
@@ -62,13 +47,90 @@ func GetHTTPClient(certUser CertUser) (http.Client, error) {
 	return http.Client{Transport: transport, Timeout: timeout}, nil
 }
 
+func ReadCert(certUser CertUser) ([]byte, error) {
+	var cert []byte
+	if certUser.ClientCert() != "" {
+		cert = []byte(certUser.ClientCert())
+	} else if certUser.ClientCertPath() != "" {
+		file, err := os.ReadFile(certUser.ClientCertPath())
+		if err != nil {
+			return nil, err
+		}
+		cert = file
+	}
+	return cert, nil
+}
+
+func ReadKey(certUser CertUser) ([]byte, error) {
+	var key []byte
+	if certUser.ClientKey() != "" {
+		key = []byte(certUser.ClientKey())
+	} else if certUser.ClientKeyPath() != "" {
+		file, err := os.ReadFile(certUser.ClientKeyPath())
+		if err != nil {
+			return nil, err
+		}
+		key = file
+	}
+	return key, nil
+}
+
+func ReadCACert(certUser CertUser) ([]byte, error) {
+	var caCert []byte
+	if certUser.CACert() != "" {
+		caCert = []byte(certUser.CACert())
+	} else if certUser.CACertPath() != "" {
+		file, err := os.ReadFile(certUser.CACertPath())
+		if err != nil {
+			return nil, err
+		}
+		caCert = file
+	}
+	return caCert, nil
+}
+
+func GetCertificate(certUser CertUser) (tls.Certificate, error) {
+	var tlsCert tls.Certificate
+
+	cert, err := ReadCert(certUser)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to read client certificate: %w", err)
+	}
+
+	key, err := ReadKey(certUser)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to read client key: %w", err)
+	}
+
+	tlsCert, err = getCertificate(cert, key)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("could not load keypair: %w", err)
+	}
+
+	return tlsCert, nil
+}
+
+func getCertificate(certBytes, keyBytes []byte) (tls.Certificate, error) {
+	var cert tls.Certificate
+
+	if certBytes == nil && keyBytes == nil {
+		return tls.Certificate{}, ce.ErrCertKeyNotFound
+	}
+
+	cert, err := tls.X509KeyPair(certBytes, keyBytes)
+	if err != nil {
+		return cert, fmt.Errorf("could not load keypair: %w", err)
+	}
+	return cert, nil
+}
+
 func GetTransport(certBytes, keyBytes, caCertBytes []byte, timeout time.Duration) (*http.Transport, error) {
 	transport := &http.Transport{ResponseHeaderTimeout: timeout}
 
 	if certBytes != nil && keyBytes != nil {
-		cert, err := tls.X509KeyPair(certBytes, keyBytes)
+		cert, err := getCertificate(certBytes, keyBytes)
 		if err != nil {
-			return transport, fmt.Errorf("could not load keypair: %w", err)
+			return transport, err
 		}
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
@@ -123,6 +185,8 @@ func (c *FeatureServiceCertUser) ClientKeyPath() string {
 	return Get().Clients.FeatureService.ClientKeyPath
 }
 
+func (c *FeatureServiceCertUser) Label() string { return "feature_service" }
+
 type CandlepinCertUser struct {
 }
 
@@ -149,3 +213,5 @@ func (c *CandlepinCertUser) ClientCertPath() string {
 func (c *CandlepinCertUser) ClientKeyPath() string {
 	return ""
 }
+
+func (c *CandlepinCertUser) Label() string { return "candlepin" }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -514,13 +514,13 @@ func CDNCertDaysTillExpiration() (int, error) {
 	if Get().Certs.CdnCertPair == nil {
 		return 0, nil
 	}
-	return daysTillExpiration(Get().Certs.CdnCertPair)
+	return DaysTillExpiration(Get().Certs.CdnCertPair)
 }
 
-// daysTillExpiration Finds the number of days until the specified certificate expired
+// DaysTillExpiration Finds the number of days until the specified certificate expired
 // tls.Certificate allows for multiple certs to be combined, so this takes the expiration date
 // that is coming the soonest
-func daysTillExpiration(certs *tls.Certificate) (int, error) {
+func DaysTillExpiration(certs *tls.Certificate) (int, error) {
 	expires := time.Time{}.UTC()
 	found := false
 	if certs == nil {
@@ -553,6 +553,10 @@ func PulpConfigured() bool {
 
 func CandlepinConfigured() bool {
 	return Get().Clients.Candlepin.Server != ""
+}
+
+func FeatureServiceConfigured() bool {
+	return Get().Clients.FeatureService.Server != ""
 }
 
 func CustomHTTPErrorHandler(err error, c echo.Context) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfigureCertificateFile(t *testing.T) {
 	assert.NotNil(t, cert)
 	assert.NotNil(t, strCert)
 
-	days, err := daysTillExpiration(cert)
+	days, err := DaysTillExpiration(cert)
 	assert.NoError(t, err)
 	assert.True(t, days > 0)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,5 @@
+package errors
+
+import "fmt"
+
+var ErrCertKeyNotFound = fmt.Errorf("certificate and key not found")

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -33,6 +33,7 @@ const (
 	TemplatesUseDateCount                          = "templates_use_date_count"
 	TemplatesUpdatedInLast24HoursCount             = "templates_updated_in_last_24_hour_count"
 	TemplatesAgeAverage                            = "templates_age_average"
+	CertificateExpiryDays                          = "certificate_expiry_days"
 )
 
 type Metrics struct {
@@ -57,6 +58,7 @@ type Metrics struct {
 	TemplatesUseDateCount                          prometheus.Gauge
 	TemplatesUpdatedInLast24HoursCount             prometheus.Gauge
 	TemplatesAgeAverage                            prometheus.Gauge
+	CertificateExpiryDays                          prometheus.GaugeVec
 	reg                                            *prometheus.Registry
 }
 
@@ -132,7 +134,7 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Namespace: NameSpace,
 			Name:      RHCertExpiryDays,
 			Help:      "Number of days until the Red Hat client certificate expires",
-		}),
+		}), // TODO remove in favor of CertificateExpiry Days
 		RHReposSnapshotNotCompletedInLast36HoursCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      RHReposSnapshotNotCompletedInLast36HoursCount,
@@ -168,6 +170,11 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      TemplatesAgeAverage,
 			Help:      "Average age (days between the set template date and now) of templates.",
 		}),
+		CertificateExpiryDays: *promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: NameSpace,
+			Name:      CertificateExpiryDays,
+			Help:      "Number of days until the certificate expires by the certificate label",
+		}, []string{"certificate_label"}),
 	}
 
 	reg.MustRegister(collectors.NewBuildInfoCollector())


### PR DESCRIPTION
## Summary
- Adds gauge vector with "certificate_label" type to filter by 
- This replaces the existing red hat cdn metric, so eventually that can be removed. But not until the existing alert is removed.

## Testing steps
1. Configure all of the certs: cdn, candlepin, and feature service
2. `make run`
3. verify that `http:/localhost:9000/metrics` shows the CertificationExpiryDays metric, with each cert's days separated by the label

