### PR TITLE
HMS-5303: remove ansible repositories for snapshotting

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/clients/feature_service_client"
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -49,12 +50,7 @@ func main() {
 		}
 		scanForExternalRepos(args[2])
 	} else if args[1] == "import" {
-		config.Load()
-		err := db.Connect()
-		if err != nil {
-			log.Panic().Err(err).Msg("Failed to save repositories")
-		}
-		err = saveToDB(ctx, db.DB)
+		err = importRepos(ctx, db.DB)
 		if err != nil {
 			log.Panic().Err(err).Msg("Failed to save repositories")
 		}
@@ -145,8 +141,8 @@ func main() {
 	}
 }
 
-func saveToDB(ctx context.Context, db *gorm.DB) error {
-	dao := dao.GetDaoRegistry(db)
+func importRepos(ctx context.Context, db *gorm.DB) error {
+	daoReg := dao.GetDaoRegistry(db)
 	var (
 		err      error
 		extRepos []external_repos.ExternalRepository
@@ -158,14 +154,62 @@ func saveToDB(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	urls = external_repos.GetBaseURLs(extRepos)
-	err = dao.RepositoryConfig.SavePublicRepos(ctx, urls)
+	err = daoReg.RepositoryConfig.SavePublicRepos(ctx, urls)
 	if err != nil {
 		return err
 	}
 
-	rh := external_repos.NewRedHatRepos(dao)
+	rh := external_repos.NewRedHatRepos(daoReg)
 	err = rh.LoadAndSave(ctx)
+	if err != nil {
+		return err
+	}
+	err = deleteNoLongerNeededRepos(ctx, daoReg)
+	if err != nil {
+		return err
+	}
 	return err
+}
+
+func deleteNoLongerNeededRepos(ctx context.Context, daoReg *dao.DaoRegistry) error {
+	q, err := queue.NewPgQueue(ctx, db.GetUrl())
+	if err != nil {
+		return fmt.Errorf("error getting new task queue: %w", err)
+	}
+	defer q.Close()
+	c := client.NewTaskClient(&q)
+
+	urls := []string{
+		"https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/",
+		"https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os/",
+	}
+	for _, url := range urls {
+		results, _, err := daoReg.RepositoryConfig.List(ctx, "0", api.PaginationData{Limit: 1}, api.FilterData{URL: url, Origin: config.OriginRedHat})
+		if err != nil {
+			return fmt.Errorf("could not list repositories: %v", err)
+		}
+		if len(results.Data) == 1 && results.Data[0].URL == url {
+			repo := results.Data[0]
+			err = daoReg.RepositoryConfig.SoftDelete(ctx, config.RedHatOrg, results.Data[0].UUID)
+			if err != nil {
+				return fmt.Errorf("could not soft delete repository for url (%v): %v", url, err)
+			}
+			payload := tasks.DeleteRepositorySnapshotsPayload{RepoConfigUUID: repo.UUID}
+			task := queue.Task{
+				Typename:   config.DeleteRepositorySnapshotsTask,
+				Payload:    payload,
+				OrgId:      config.RedHatOrg,
+				AccountId:  repo.AccountID,
+				ObjectUUID: &repo.RepositoryUUID,
+				ObjectType: utils.Ptr(config.ObjectTypeRepository),
+			}
+			_, err := c.Enqueue(task)
+			if err != nil {
+				return fmt.Errorf("could not enqueue task for repo deletion (%v): %v", url, err)
+			}
+		}
+	}
+	return nil
 }
 
 func waitForPulp(ctx context.Context) {

--- a/pkg/clients/candlepin_client/interface.go
+++ b/pkg/clients/candlepin_client/interface.go
@@ -34,7 +34,7 @@ type CandlepinClient interface {
 	AssociateEnvironment(ctx context.Context, orgID string, templateName string, consumerUuid string) error
 	CreateEnvironment(ctx context.Context, orgID string, name string, id string, prefix string) (*caliri.EnvironmentDTO, error)
 	PromoteContentToEnvironment(ctx context.Context, templateUUID string, repoConfigUUIDs []string) error
-	DemoteContentFromEnvironment(ctx context.Context, templateUUID string, repoConfigUUIDs []string) error
+	DemoteContentFromEnvironment(ctx context.Context, templateUUID string, customRepoConfigUUIDs []string) error
 	FetchEnvironment(ctx context.Context, templateUUID string) (*caliri.EnvironmentDTO, error)
 	UpdateContentOverrides(ctx context.Context, templateUUID string, dtos []caliri.ContentOverrideDTO) error
 	FetchContentOverrides(ctx context.Context, templateUUID string) ([]caliri.ContentOverrideDTO, error)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -85,7 +85,7 @@ type RepositoryConfigDao interface {
 	InternalOnly_RefreshRedHatRepo(ctx context.Context, request api.RepositoryRequest, label string, featureName string) (*api.RepositoryResponse, error)
 	InternalOnly_IncrementFailedSnapshotCount(ctx context.Context, rcUuid string) error
 	InternalOnly_ResetFailedSnapshotCount(ctx context.Context, rcUuid string) error
-	FetchWithoutOrgID(ctx context.Context, uuid string) (api.RepositoryResponse, error)
+	FetchWithoutOrgID(ctx context.Context, uuid string, includeSoftDel bool) (api.RepositoryResponse, error)
 	BulkExport(ctx context.Context, orgID string, reposToExport api.RepositoryExportRequest) ([]api.RepositoryExportResponse, error)
 	BulkImport(ctx context.Context, reposToImport []api.RepositoryRequest) ([]api.RepositoryImportResponse, []error)
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -117,6 +117,7 @@ type RepositoryDao interface {
 	Update(ctx context.Context, repo RepositoryUpdate) error
 	FetchRepositoryRPMCount(ctx context.Context, repoUUID string) (int, error)
 	OrphanCleanup(ctx context.Context) error
+	MarkAsNotPublic(ctx context.Context, url string) error
 }
 
 type SnapshotDao interface {

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -156,6 +157,14 @@ func (p repositoryDaoImpl) Update(ctx context.Context, repoIn RepositoryUpdate) 
 		return result.Error
 	}
 
+	return nil
+}
+
+func (r repositoryDaoImpl) MarkAsNotPublic(ctx context.Context, url string) error {
+	res := r.db.WithContext(ctx).Model(&models.Repository{}).Where("url = ?", url).Update("public", false)
+	if res.Error != nil {
+		return fmt.Errorf("could not mark as public: %s", res.Error.Error())
+	}
 	return nil
 }
 

--- a/pkg/dao/repositories.go
+++ b/pkg/dao/repositories.go
@@ -160,6 +160,10 @@ func (p repositoryDaoImpl) Update(ctx context.Context, repoIn RepositoryUpdate) 
 	return nil
 }
 
+// MarkAsNotPublic updates the repository with the given URL to set the 'public' attribute to false
+//
+//	This allows deletion of repos defined in external_repos.json that are no longer needed.  By setting to false,
+//	  They should be cleaned up if they are not in use by the cleanup cron job
 func (r repositoryDaoImpl) MarkAsNotPublic(ctx context.Context, url string) error {
 	res := r.db.WithContext(ctx).Model(&models.Repository{}).Where("url = ?", url).Update("public", false)
 	if res.Error != nil {

--- a/pkg/dao/repositories_mock.go
+++ b/pkg/dao/repositories_mock.go
@@ -136,6 +136,24 @@ func (_m *MockRepositoryDao) ListPublic(ctx context.Context, paginationData api.
 	return r0, r1, r2
 }
 
+// MarkAsNotPublic provides a mock function with given fields: ctx, url
+func (_m *MockRepositoryDao) MarkAsNotPublic(ctx context.Context, url string) error {
+	ret := _m.Called(ctx, url)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkAsNotPublic")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, url)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // OrphanCleanup provides a mock function with given fields: ctx
 func (_m *MockRepositoryDao) OrphanCleanup(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -650,11 +650,15 @@ func (r repositoryConfigDaoImpl) FetchByRepoUuid(ctx context.Context, orgID stri
 	return repo, nil
 }
 
-func (r repositoryConfigDaoImpl) FetchWithoutOrgID(ctx context.Context, uuid string) (api.RepositoryResponse, error) {
+func (r repositoryConfigDaoImpl) FetchWithoutOrgID(ctx context.Context, uuid string, includeSoftDel bool) (api.RepositoryResponse, error) {
 	found := models.RepositoryConfiguration{}
 	var repo api.RepositoryResponse
-	result := r.db.WithContext(ctx).
-		Preload("Repository").Preload("LastSnapshot").Preload("LastSnapshotTask").
+	result := r.db.WithContext(ctx)
+	if includeSoftDel {
+		result = result.Unscoped()
+	}
+
+	result = result.Preload("Repository").Preload("LastSnapshot").Preload("LastSnapshotTask").
 		Where("UUID = ?", UuidifyString(uuid)).
 		First(&found)
 

--- a/pkg/dao/repository_configs_mock.go
+++ b/pkg/dao/repository_configs_mock.go
@@ -234,7 +234,7 @@ func (_m *MockRepositoryConfigDao) FetchByRepoUuid(ctx context.Context, orgID st
 }
 
 // FetchWithoutOrgID provides a mock function with given fields: ctx, uuid
-func (_m *MockRepositoryConfigDao) FetchWithoutOrgID(ctx context.Context, uuid string) (api.RepositoryResponse, error) {
+func (_m *MockRepositoryConfigDao) FetchWithoutOrgID(ctx context.Context, uuid string, includeSoftDel bool) (api.RepositoryResponse, error) {
 	ret := _m.Called(ctx, uuid)
 
 	if len(ret) == 0 {

--- a/pkg/dao/repository_configs_mock.go
+++ b/pkg/dao/repository_configs_mock.go
@@ -233,9 +233,9 @@ func (_m *MockRepositoryConfigDao) FetchByRepoUuid(ctx context.Context, orgID st
 	return r0, r1
 }
 
-// FetchWithoutOrgID provides a mock function with given fields: ctx, uuid
+// FetchWithoutOrgID provides a mock function with given fields: ctx, uuid, includeSoftDel
 func (_m *MockRepositoryConfigDao) FetchWithoutOrgID(ctx context.Context, uuid string, includeSoftDel bool) (api.RepositoryResponse, error) {
-	ret := _m.Called(ctx, uuid)
+	ret := _m.Called(ctx, uuid, includeSoftDel)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchWithoutOrgID")
@@ -243,17 +243,17 @@ func (_m *MockRepositoryConfigDao) FetchWithoutOrgID(ctx context.Context, uuid s
 
 	var r0 api.RepositoryResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (api.RepositoryResponse, error)); ok {
-		return rf(ctx, uuid)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) (api.RepositoryResponse, error)); ok {
+		return rf(ctx, uuid, includeSoftDel)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) api.RepositoryResponse); ok {
-		r0 = rf(ctx, uuid)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) api.RepositoryResponse); ok {
+		r0 = rf(ctx, uuid, includeSoftDel)
 	} else {
 		r0 = ret.Get(0).(api.RepositoryResponse)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, uuid)
+	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
+		r1 = rf(ctx, uuid, includeSoftDel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1156,7 +1156,7 @@ func (suite *RepositoryConfigSuite) TestFetchWithoutOrgID() {
 		Error
 	assert.NoError(t, err)
 
-	fetched, err := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient).FetchWithoutOrgID(context.Background(), found.UUID)
+	fetched, err := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient).FetchWithoutOrgID(context.Background(), found.UUID, false)
 	assert.Nil(t, err)
 	assert.Equal(t, found.UUID, fetched.UUID)
 	assert.Equal(t, found.Name, fetched.Name)

--- a/pkg/external_repos/external_repos.json
+++ b/pkg/external_repos/external_repos.json
@@ -6,9 +6,6 @@
         "base_url": "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/"
     },
     {
-        "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os"
-    },
-    {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"
     },
     {
@@ -109,9 +106,6 @@
     },
     {
         "base_url": "http://mirror.stream.centos.org/9-stream/BaseOS/aarch64/os/"
-    },
-    {
-        "base_url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os"
     },
     {
         "base_url": "https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os"

--- a/pkg/external_repos/redhat_repos.json
+++ b/pkg/external_repos/redhat_repos.json
@@ -1,13 +1,5 @@
 [
     {
-        "name": "Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)",
-        "url": "https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os",
-        "content_label": "ansible-2-for-rhel-8-x86_64-rpms",
-        "arch": "x86_64",
-        "distribution_version": "8",
-        "feature_name": "RHEL-OS-x86_64"
-    },
-    {
         "name": "Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)",
         "url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os",
         "content_label": "rhel-8-for-x86_64-appstream-rpms",
@@ -57,14 +49,6 @@
         "content_label": "codeready-builder-for-rhel-8-x86_64-rpms",
         "url": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os",
         "arch": "x86_64",
-        "distribution_version": "8",
-        "feature_name": "RHEL-OS-x86_64"
-    },
-    {
-        "name": "Red Hat Ansible Engine 2 for RHEL 8 ARM 64 (RPMs)",
-        "url": "https://cdn.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2/os",
-        "content_label": "ansible-2-for-rhel-8-aarch64-rpms",
-        "arch": "aarch64",
         "distribution_version": "8",
         "feature_name": "RHEL-OS-x86_64"
     },

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -789,7 +789,7 @@ func (rh *RepositoryHandler) addUploads(c echo.Context) error {
 func (rh *RepositoryHandler) getGpgKeyFile(c echo.Context) error {
 	uuid := c.Param("uuid")
 
-	resp, err := rh.DaoRegistry.RepositoryConfig.FetchWithoutOrgID(c.Request().Context(), uuid)
+	resp, err := rh.DaoRegistry.RepositoryConfig.FetchWithoutOrgID(c.Request().Context(), uuid, false)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}

--- a/pkg/handler/repositories_test.go
+++ b/pkg/handler/repositories_test.go
@@ -1452,7 +1452,7 @@ func (suite *ReposSuite) TestGetGpgKeyFile() {
 		bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
-	suite.reg.RepositoryConfig.On("FetchWithoutOrgID", req.Context(), uuid).Return(repo, nil).Once()
+	suite.reg.RepositoryConfig.On("FetchWithoutOrgID", req.Context(), uuid, false).Return(repo, nil).Once()
 
 	code, body, err := suite.serveRepositoriesRouter(req)
 	assert.Nil(t, err)

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -207,17 +207,12 @@ func (t *UpdateTemplateContent) handleReposAdded(reposAdded []string, snapshots 
 			return err
 		}
 
-		distResp, err := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
+		distHref, err := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
 		if err != nil {
 			return err
 		}
 
-		distHrefPtr := pulp_client.SelectRpmDistributionHref(distResp)
-		if distHrefPtr == nil {
-			return fmt.Errorf("could not find a distribution href in task: %v", *distResp.PulpHref)
-		}
-
-		repoConfigDistributionHref[repoConfigUUID] = *distHrefPtr
+		repoConfigDistributionHref[repoConfigUUID] = distHref
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This adds support for removing Red Hat repos for syncing.  (Currently they stay for introspection).  

Some changes needed to support this

* within the delete-repository-snapshots task, move the candlepin processing prior to the pulp processing.  This is due to some models being deleted during the pulp processing (it also makes sense to do things in reverse upon deletion).
* Looking up the red hat content ids from their labels
* Looking up templates to remove the repo from across all orgs, not just templates with the same org as the repository

## Testing steps

setup, i'd recommend on a clean db.  On Main, run:

```
make compose-clean compose-up
make repos-import
```
start the server:
```
make run
```
snapshot all the repos:
```
go run cmd/external-repos/main.go process-repos
```

Create a template with RHEL 8, adding the ansible repo to the template.



Check the pulp db:
```
psql --host localhost --port 5432  -U pulp
select base_path from core_distribution;
```

look for:

```
 templates/341aaa4f-6050-4599-99d8-01e81bf4bf5c/content/dist/rhel8/8/x86_64/baseos/os
 templates/341aaa4f-6050-4599-99d8-01e81bf4bf5c/content/dist/rhel8/8/x86_64/appstream/os
 templates/341aaa4f-6050-4599-99d8-01e81bf4bf5c/content/dist/rhel8/8/x86_64/ansible/os
```

Check the candlepin db:
```
make db-cli-connect
\connect candlepin
 select * from cp_environment_content;
```
You should have 3 pieces of content.

Register RHEL 8 system and assign it to the template using https://github.com/content-services/content-sources-backend/blob/main/docs/register_client.md  and verify you can see the 3 repos on the client (via yum repolist).

Now checkout this pr, restart the server:
```
make run
```
Now reimport the red hat repos which will trigger the deletion:

```
make repos-import
```

re-run the pulp and candlepin queries and you should see the ansible repo distribution no longer there in pulp, and only 2 content objects in the environment in candlepin

On the client, run 'subscription-manager refresh', and verify that you only see 2 repos configured on the client
