### PR TITLE
HMS-5395: remove RHCertExpiryDays metric

### DIFF
--- a/pkg/instrumentation/custom/collector.go
+++ b/pkg/instrumentation/custom/collector.go
@@ -53,7 +53,6 @@ func NewCollector(ctx context.Context, metrics *instrumentation.Metrics, db *gor
 func (c *Collector) iterateExpiryTime() {
 	expire, err := config.CDNCertDaysTillExpiration()
 	if err == nil {
-		c.metrics.RHCertExpiryDays.Set(float64(expire)) // TODO remove in favor of CertificateExpiryDays
 		c.metrics.CertificateExpiryDays.WithLabelValues("cdn").Set(float64(expire))
 	} else {
 		log.Ctx(c.context).Error().Err(err).Msgf("Could not calculate cdn cert expiration")
@@ -66,7 +65,6 @@ func (c *Collector) iterateExpiryTime() {
 	if config.FeatureServiceConfigured() {
 		certUsers = append(certUsers, &config.FeatureServiceCertUser{})
 	}
-	log.Info().Msgf("featureServiceConfigured: %v", config.FeatureServiceConfigured())
 	c.iterateCertUserExpiryTime(certUsers...)
 }
 

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -21,7 +21,6 @@ const (
 	MessageLatency                                 = "message_latency"
 	MessageResultTotal                             = "message_result_total"
 	OrgTotal                                       = "org_total"
-	RHCertExpiryDays                               = "rh_cert_expiry_days"
 	TaskStats                                      = "task_stats"
 	TaskStatsLabelPendingCount                     = "task_stats_pending_count"
 	TaskStatsLabelOldestWait                       = "task_stats_oldest_wait"
@@ -50,7 +49,6 @@ type Metrics struct {
 	MessageLatency                                 prometheus.Histogram
 	TaskStats                                      prometheus.GaugeVec
 	OrgTotal                                       prometheus.Gauge
-	RHCertExpiryDays                               prometheus.Gauge
 	RHReposSnapshotNotCompletedInLast36HoursCount  prometheus.Gauge
 	TaskPendingTimeAverageByType                   prometheus.GaugeVec
 	TemplatesCount                                 prometheus.Gauge
@@ -130,11 +128,6 @@ func NewMetrics(reg *prometheus.Registry) *Metrics {
 			Name:      OrgTotal,
 			Help:      "Number of organizations with at least one repository.",
 		}),
-		RHCertExpiryDays: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Namespace: NameSpace,
-			Name:      RHCertExpiryDays,
-			Help:      "Number of days until the Red Hat client certificate expires",
-		}), // TODO remove in favor of CertificateExpiry Days
 		RHReposSnapshotNotCompletedInLast36HoursCount: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Namespace: NameSpace,
 			Name:      RHReposSnapshotNotCompletedInLast36HoursCount,


### PR DESCRIPTION
## Summary
Removes the RHCertExpiryDays metric because it is replaced by the CertificateExpiryDays metric

Alert has already been removed from stage

## Testing steps
1. `make run`
2. View metrics at `http://localhost:9000/metrics
3. This metric no longer shows up 
