### PR TITLE
HMS-5570: delete upload entries on failed upload > artifact conversion

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -216,4 +216,5 @@ type UploadDao interface {
 	StoreFileUpload(ctx context.Context, orgID string, uploadUUID string, sha256 string, chunkSize int64) error
 	StoreChunkUpload(ctx context.Context, orgID string, uploadUUID string, sha256 string) error
 	GetExistingUploadIDAndCompletedChunks(ctx context.Context, orgID string, sha256 string, chunkSize int64) (string, []string, error)
+	DeleteUpload(ctx context.Context, uploadUUID string) error
 }

--- a/pkg/dao/uploads.go
+++ b/pkg/dao/uploads.go
@@ -66,3 +66,14 @@ func (t uploadDaoImpl) StoreChunkUpload(ctx context.Context, orgID string, uploa
 
 	return nil
 }
+
+func (t uploadDaoImpl) DeleteUpload(ctx context.Context, uploadUUID string) error {
+	err := t.db.WithContext(ctx).
+		Where("upload_uuid = ?", UuidifyString(uploadUUID)).
+		Delete(models.Upload{}).Error
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/dao/uploads_test.go
+++ b/pkg/dao/uploads_test.go
@@ -2,6 +2,9 @@ package dao
 
 import (
 	"context"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
@@ -26,9 +29,11 @@ func (s *UploadsSuite) uploadsDao() uploadDaoImpl {
 		pulpClient: s.mockPulpClient,
 	}
 }
+
 func (s *UploadsSuite) SetupTest() {
 	s.DaoSuite.SetupTest()
 }
+
 func (s *UploadsSuite) TestStoreFileUpload() {
 	uploadDao := s.uploadsDao()
 	ctx := context.Background()
@@ -52,4 +57,23 @@ func (s *UploadsSuite) TestStoreFileUpload() {
 	assert.Equal(s.T(), nil, err)
 	assert.Equal(s.T(), "bananaUUID", uploadUUID)
 	assert.Equal(s.T(), []string{"bananaChunkHash256"}, chunkList)
+}
+
+func (s *UploadsSuite) TestDeleteUpload() {
+	uploadDao := s.uploadsDao()
+	ctx := context.Background()
+	uploadUUID := uuid.New()
+	var found models.Upload
+
+	err := uploadDao.StoreFileUpload(ctx, orgIDTest, uploadUUID.String(), "test-sha", 500)
+	require.NoError(s.T(), err)
+
+	err = uploadDao.DeleteUpload(ctx, uploadUUID.String())
+	require.NoError(s.T(), err)
+
+	err = s.tx.
+		First(&found, "upload_uuid = ?", uploadUUID).
+		Error
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "record not found", err.Error())
 }

--- a/pkg/tasks/add_uploads.go
+++ b/pkg/tasks/add_uploads.go
@@ -211,6 +211,10 @@ func (ur *AddUploads) ConvertUploadsToArtifacts() ([]api.Artifact, error) {
 	for _, pendArt := range pendingArtifacts {
 		result, err := ur.pulpClient.PollTask(ur.ctx, pendArt.TaskHref)
 		if err != nil {
+			dbErr := ur.daoReg.Uploads.DeleteUpload(ur.ctx, pendArt.Upload.Uuid)
+			if dbErr != nil {
+				return artifacts, fmt.Errorf("could not delete upload record: %w", dbErr)
+			}
 			return artifacts, fmt.Errorf("finish upload task failed unexpectedly : %w", err)
 		}
 		if len(result.CreatedResources) != 1 {


### PR DESCRIPTION
## Summary

- Adds a DeleteUpload method
- If an upload fails to be converted to an artifact, the upload record is deleted in our db so the user can try to upload the rpm again

## Testing steps

1. Checkout the main branch
2. Create an upload, upload the same chunk twice, and finish the upload using these endpoints:
    - `POST /repositories/uploads/`
    - `POST /repositories/uploads/:upload_uuid/upload_chunk/`
    - `POST /repositories/:uuid/add_uploads/`
3. The add_uploads call should fail and you shouldn't be able to create another upload
4. Checkout this PR, and call add_uploads again. It should still fail but you should be able to create another upload and start over