### PR TITLE
HMS-5565: fix admin task fetch parsing error

### DIFF
--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -143,7 +143,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 			return err
 		}
 
-		_, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, snaps.PublicationHref, distName, distPath)
+		_, _, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, snaps.PublicationHref, distName, distPath)
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 		if err != nil {
 			return err
 		}
-		_, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, latestSnap.PublicationHref, repo.UUID, latestPathIdent)
+		_, _, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, latestSnap.PublicationHref, repo.UUID, latestPathIdent)
 		if err != nil {
 			return err
 		}

--- a/pkg/tasks/helpers/pulp_distribution_helper_test.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper_test.go
@@ -81,14 +81,17 @@ func (s *PulpDistributionHelperTest) TestRedHatDistributionUpdate() {
 	orgId := config.RedHatOrg
 	taskHref := "taskHref"
 	var guardHref *string
+	taskResp := zest.TaskResponse{
+		PulpHref: &taskHref,
+	}
 
 	mockPulp.On("UpdateRpmDistribution", ctx, distHref, pubHref, distName, distPath, guardHref).Return(taskHref, nil)
-
+	mockPulp.On("PollTask", ctx, taskHref).Return(&taskResp, nil)
 	mockPulp.On("FindDistributionByPath", ctx, distPath).Return(&zest.RpmRpmDistributionResponse{
 		PulpHref: &distHref,
 	}, nil)
 
-	_, err := helper.CreateOrUpdateDistribution(api.RepositoryResponse{OrgID: orgId}, pubHref, distName, distPath)
+	_, _, err := helper.CreateOrUpdateDistribution(api.RepositoryResponse{OrgID: orgId}, pubHref, distName, distPath)
 	assert.NoError(s.T(), err)
 }
 

--- a/pkg/tasks/update_latest_snapshot.go
+++ b/pkg/tasks/update_latest_snapshot.go
@@ -119,7 +119,7 @@ func (t *UpdateLatestSnapshot) updateLatestSnapshot(repo api.RepositoryResponse,
 		return err
 	}
 
-	_, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snap.PublicationHref, distName, distPath)
+	_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snap.PublicationHref, distName, distPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -251,7 +251,7 @@ func (t *UpdateTemplateContent) handleReposUnchanged(reposUnchanged []string, sn
 			return err
 		}
 
-		_, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
+		_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
Fixes bug where fetching a snapshot task resulted in a parsing error. The snapshot payload was incorrectly saving the distribution href instead of the distribution task href.

Also fixes issue where we were not polling the update distribution task from pulp

## Testing steps
1. Create a snapshot
2. Fetch that snapshot task from the admin tasks API: `/admin/tasks/<task_uuid>`
3. Previously, there would be a 500 because of a missing "logging_cid"

