### PR TITLE
Test: change codebuild project references

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -71,7 +71,7 @@ jobs:
 
   playwright-tests:
     runs-on:
-      - codebuild-content-services-backend-repo-${{ github.run_id }}-${{ github.run_attempt }}
+      - codebuild-content-services-be-repo-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:medium
       - buildspec-override:true
 


### PR DESCRIPTION
## Summary

Changes the codebuild project reference to point to the new backend codebuild project in our AWS account

## Testing steps

Playwright tests run