### PR TITLE
HMS-5925: bypass feature service api for red hat org

### DIFF
--- a/pkg/clients/feature_service_client/features.go
+++ b/pkg/clients/feature_service_client/features.go
@@ -143,7 +143,7 @@ func (fs featureServiceImpl) GetFeatureStatusByOrgID(ctx context.Context, orgID 
 func (fs featureServiceImpl) GetEntitledFeatures(ctx context.Context, orgID string) ([]string, error) {
 	entitledFeatures := []string{"RHEL-OS-x86_64", "RHEL-OS-aarch64"}
 
-	if config.Get().Clients.FeatureService.Server == "" {
+	if config.Get().Clients.FeatureService.Server == "" || orgID == config.RedHatOrg {
 		if config.Get().Options.EntitleAll {
 			return config.Get().Options.FeatureFilter, nil
 		}

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -385,25 +385,15 @@ func (r repositoryConfigDaoImpl) List(
 	var totalRepos int64
 	repoConfigs := make([]models.RepositoryConfiguration, 0)
 	var contentPath string
-	var filteredDB *gorm.DB
 
-	if OrgID == config.RedHatOrg {
-		// Bypass the feature service status API if listing repos with the RH org
-		var err error
-		filteredDB, err = r.filteredDbForList(OrgID, r.db.WithContext(ctx), filterData, []string{"RHEL-OS-x86_64", "RHEL-OS-aarch64"})
-		if err != nil {
-			return api.RepositoryCollectionResponse{}, totalRepos, err
-		}
-	} else {
-		accessibleFeatures, err := r.fsClient.GetEntitledFeatures(ctx, OrgID)
-		if err != nil {
-			return api.RepositoryCollectionResponse{}, totalRepos, err
-		}
+	accessibleFeatures, err := r.fsClient.GetEntitledFeatures(ctx, OrgID)
+	if err != nil {
+		return api.RepositoryCollectionResponse{}, totalRepos, err
+	}
 
-		filteredDB, err = r.filteredDbForList(OrgID, r.db.WithContext(ctx), filterData, accessibleFeatures)
-		if err != nil {
-			return api.RepositoryCollectionResponse{}, totalRepos, err
-		}
+	filteredDB, err := r.filteredDbForList(OrgID, r.db.WithContext(ctx), filterData, accessibleFeatures)
+	if err != nil {
+		return api.RepositoryCollectionResponse{}, totalRepos, err
 	}
 
 	sortMap := map[string]string{


### PR DESCRIPTION
## Summary

Task workers in stage are crashlooping due to calling the feature service status API with an invalid org ID (-1). This adds a check to bypass that API if using an org ID of -1 (which is only used to delete unneeded repos). 

## Testing steps

1. Run `make repos-import` when the feature service is enabled. Command should succeed and repos should be imported as normal
2. Layered repos (OCP and HA) should be present when listing RH repos or viewing RH repos in the UI if using an account that has access to these repos
3. Previously `make repos-import` failed when the feature service is enabled

