### PR TITLE
Test: re-add caching to buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,13 +23,13 @@ phases:
     commands:
       - echo Entered the post_build phase...
       - echo Build completed on `date`
-# cache:
-#   paths:
-#     - "/root/.cache"
-#     - "/root/.yarn/**/*"
-#     - "/root/.npm/**/*"  # npm cache
-#     - "/root/.gradle/**/*"  # Gradle cache
-#     - "/root/.m2/**/*"  # Maven cache
-#     - "/root/.docker"  # Docker cache
-#     - "/root/.gem/**/*"  # Gem cache
-#     - "/root/go/pkg/mod/**/*"  # Go modules cache
+cache:
+  paths:
+    - "/root/.cache"
+    - "/root/.yarn/**/*"
+    - "/root/.npm/**/*"  # npm cache
+    - "/root/.gradle/**/*"  # Gradle cache
+    - "/root/.m2/**/*"  # Maven cache
+    - "/root/.docker"  # Docker cache
+    - "/root/.gem/**/*"  # Gem cache
+    - "/root/go/pkg/mod/**/*"  # Go modules cache


### PR DESCRIPTION
## Summary

The build-playwright-test job has been taking a bit longer than 30 minutes (about 40 minutes) so this adds caching back to the buildspec to see if this speeds it up a bit

## Testing steps

build-playwright-test finishes, codebuild doesn't time out

