### PR TITLE
Build: turn off konflux dependency bumping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
     ],
     "ignorePaths": [
       ".pre-commit-config.yaml"
+    ],
+    "packageRules": [
+        {
+            "matchManagers": ["gomod"],
+            "enabled": false
+        }
     ]
 }
 


### PR DESCRIPTION
## Summary
We already use dependabot, so the konflux bot is just creating unnecessary noise

## Testing steps

