### PR TITLE
Test: Change to centirepos

### DIFF
--- a/_playwright-tests/test-utils/src/helpers/repositories.ts
+++ b/_playwright-tests/test-utils/src/helpers/repositories.ts
@@ -1,13 +1,12 @@
 export const randomName = () => (Math.random() + 1).toString(36).substring(2, 6);
 
-export const rank = () => Math.floor(Math.random() * 10 + 1).toString();
 export const randomNum = () =>
-  Math.floor(Math.random() * 10 + 1)
+  Math.floor(Math.random() * 100 + 1)
     .toString()
     .padStart(2, '0');
 
 export const randomUrl = () =>
-  `https://stephenw.fedorapeople.org/multirepos/${rank()}/repo${randomNum()}/`;
+  `https://content-services.github.io/fixtures/yum/centirepos/repo${randomNum()}/`;
 
 export const SmallRedHatRepoURL =
   'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/';


### PR DESCRIPTION


## Summary

I made a new batch of 100 repos without a number in the URL
The multirepos path with a rank number in URL causes problems when that number corresponds to a release version.

## Testing steps

tests pass