### PR TITLE
Build: fix schema to disable gomod updates from konflux

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,8 @@
     "ignorePaths": [
       ".pre-commit-config.yaml"
     ],
-    "packageRules": [
-        {
-            "matchManagers": ["gomod"],
-            "enabled": false
-        }
-    ]
+    "gomod": {
+        "enabled": false
+    }
 }
 


### PR DESCRIPTION
## Summary
The konflux bot opened more dependency PRs, I think is why

https://docs.renovatebot.com/modules/manager/

## Testing steps

