### PR TITLE
HMS-5801: fix /rpms/names for RH repo uuids

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -303,7 +303,7 @@ func (r *rpmDaoImpl) addLifecycleInfo(ctx context.Context, rpmResponse []api.Sea
 func readableRepositoryQuery(dbWithContext *gorm.DB, orgID string, urls []string, uuids []string) *gorm.DB {
 	orGroupPublicPrivatePopular := dbWithContext.Where("repository_configurations.org_id = ?", orgID).Or("repositories.public").Or("repositories.url in ?", popularRepoUrls())
 	readableRepos := dbWithContext.Model(&models.Repository{}).
-		Joins("left join repository_configurations on repositories.uuid = repository_configurations.repository_uuid and repository_configurations.org_id = ?", orgID).
+		Joins("left join repository_configurations on repositories.uuid = repository_configurations.repository_uuid and repository_configurations.org_id IN (?,?)", orgID, config.RedHatOrg).
 		Where(orGroupPublicPrivatePopular).
 		Where(dbWithContext.Where("repositories.url in ?", urls).
 			Or("repository_configurations.uuid in ?", UuidifyStrings(uuids)))


### PR DESCRIPTION
## Summary

Adds RH org to the query to fix searching for rpms by repo UUID

## Testing steps

1. Import RH repos and introspect at least one: `make repos-import-rhel9 && go run cmd/external-repos/main.go introspect https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/`
2. Searching rpms for that repo by UUID should work 

```
POST /rpms/names

{
  "search": "nodejs",
  "uuids": ["1d4d6b01-d5fd-466a-a56f-1863e0ce4d24"]
}
```
```
[
    {
        "package_name": "nodejs",
        "summary": "JavaScript runtime"
    },
    {
        "package_name": "nodejs-devel",
        "summary": "JavaScript runtime - development headers"
    },
    ...
]
``` 