### PR TITLE
HMS-5998: properly get newest version for modules

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -236,10 +236,10 @@ func (r *rpmDaoImpl) addModuleInfo(ctx context.Context, rpmResponse []api.Search
 	err := r.db.WithContext(ctx).
 		Table("module_streams").
 		Joins("inner join repositories_module_streams rms ON rms.module_stream_uuid = module_streams.uuid").
-		Select("name, stream, context, arch, version, description, package_names").
+		Select("DISTINCT ON (name, stream) name, stream, context, arch, version, description, package_names").
 		Where("rms.repository_uuid in (?)", repoUUIDs).
-		Where("version = (SELECT MAX(version) FROM module_streams  ms WHERE module_streams.name = ms.name AND module_streams.stream = ms.stream)").
 		Where("module_streams.package_names && ?", clause.Expr{SQL: "ARRAY[?]", Vars: []interface{}{pkgNames}, WithoutParentheses: true}).
+		Order("module_streams.name, module_streams.stream, module_streams.version desc").
 		Find(&moduleInfo).Error
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

The previous PR for HMS-5998 had a bug where if a module stream existed in a different repository with a higher version, that entire module stream would be ignored. 

## Testing steps

to reproduce the original issue, import and sync  all the appstream repos:

```
make repos-import
go run cmd/external-repos/main.go introspect  https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os
go run cmd/external-repos/main.go introspect  https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os
go run cmd/external-repos/main.go introspect https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os
```

wait for them to finish.

Then trigger rpm search:

```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/rpms/names" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiIxIn0sImFjY291bnRfbnVtYmVyIjoiZm9vIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K" \
    -H "Content-Type: application/json" \
    -d '{"urls":["https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os"],
          "include_package_sources": true,
          "search":"nginx"}'
```


You should see modules:

```
[
  {
    "package_name": "nginx",
    "summary": "A high performance web server and reverse proxy server",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-all-modules",
    "summary": "A meta package that installs all available Nginx modules",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-core",
    "summary": "nginx minimal core",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-filesystem",
    "summary": "The basic directory layout for the Nginx server",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-devel",
    "summary": "Nginx module development files",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-http-image-filter",
    "summary": "Nginx HTTP image filter module",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-http-perl",
    "summary": "Nginx HTTP perl module",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-http-xslt-filter",
    "summary": "Nginx XSLT module",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-mail",
    "summary": "Nginx mail modules",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  },
  {
    "package_name": "nginx-mod-stream",
    "summary": "Nginx stream modules",
    "package_sources": [
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.22",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324053651",
        "description": "nginx 1.22 webserver module"
      },
      {
        "type": "module",
        "name": "nginx",
        "stream": "1.24",
        "context": "9",
        "arch": "aarch64",
        "version": "9050020250324055038",
        "description": "nginx 1.24 webserver module"
      }
    ]
  }
]
```

