### PR TITLE
HMS-6020: add pool limit for tasking

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -41,7 +41,7 @@ tasking:
   heartbeat: 1m
   worker_count: 3
   retry_wait_upper_bound: 12h
-
+  pool_limit: 20
 logging:
   level: debug
   metrics_level: debug

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,7 @@ type Tasking struct {
 	Heartbeat           time.Duration `mapstructure:"heartbeat"`
 	WorkerCount         int           `mapstructure:"worker_count"`
 	RetryWaitUpperBound time.Duration `mapstructure:"retry_wait_upper_bound"`
+	PoolLimit           int           `mapstructure:"pool_limit"`
 }
 
 type Database struct {
@@ -351,6 +352,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("tasking.worker_count", 3)
 	v.SetDefault("tasking.pgx_logging", true)
 	v.SetDefault("tasking.retry_wait_upper_bound", time.Hour*12)
+	v.SetDefault("tasking.pool_limit", 20)
 
 	v.SetDefault("features.snapshots.enabled", false)
 	v.SetDefault("features.snapshots.accounts", nil)

--- a/pkg/tasks/queue/pgqueue.go
+++ b/pkg/tasks/queue/pgqueue.go
@@ -204,10 +204,14 @@ func (d *dequeuers) notifyAll() {
 
 func NewPgxPool(ctx context.Context, url string) (*pgxpool.Pool, error) {
 	pxConfig, err := pgxpool.ParseConfig(url)
-	poolLimit := config.Get().Database.PoolLimit
+	poolLimit := config.Get().Tasking.PoolLimit
 	if poolLimit < math.MinInt32 || poolLimit > math.MaxInt32 {
 		return nil, errors.New("invalid pool limit size")
 	}
+	if poolLimit <= config.Get().Tasking.WorkerCount {
+		return nil, errors.New("pool size too small for the number of workers ")
+	}
+
 	pxConfig.MaxConns = int32(poolLimit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

and add a warning if its too small

## Testing steps

in config.yaml set: 
```
  worker_count: 25
  pool_limit: 30
```

then import and sync all repos:

```
make repos-import
go run cmd/external-repos/main.go process-repos
```


see that they all complete

