### PR TITLE
Build: separate delete-snapshots from process-repos

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -127,11 +127,6 @@ func main() {
 			if err != nil {
 				log.Error().Err(err).Msg("error queueing snapshot tasks")
 			}
-			snapshotRetainDaysLimit := config.Get().Options.SnapshotRetainDaysLimit
-			err = enqueueSnapshotsCleanup(ctx, snapshotRetainDaysLimit)
-			if err != nil {
-				log.Error().Err(err).Msg("error queueing delete snapshot tasks for snapshot cleanup")
-			}
 		}
 		err = uploadCleanup(ctx, db.DB)
 		if err != nil {

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -875,6 +875,87 @@ objects:
                     name: content-sources-candlepin
                     key: key
                     optional: true
+        - name: snapshot-cleanup
+          schedule: "0 1 * * *"
+          suspend: ${{SUSPEND_CRON_JOB}}
+          concurrencyPolicy: "Forbid"
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /external-repos
+              - snapshot-cleanup
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: RH_CDN_CERT_PAIR
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-certs
+                    key: cdn.redhat.com
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-sentry
+                    key: dsn
+                    optional: true
+              - name: CLIENTS_PULP_SERVER
+                value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
+              - name: CLIENTS_PULP_GUARD_SUBJECT_DN
+                value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
+              - name: CLIENTS_PULP_USERNAME
+                value: ${{CLIENTS_PULP_USERNAME}}
+              - name: CLIENTS_PULP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-content-sources-password
+                    key: password
+                    optional: true
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: OPTIONS_EXTERNAL_URL
+                value: ${OPTIONS_EXTERNAL_URL}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
+              - name: FEATURES_ADMIN_TASKS_ENABLED
+                value: ${FEATURES_ADMIN_TASKS_ENABLED}
+              - name: FEATURES_ADMIN_TASKS_ACCOUNTS
+                value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
+              - name: CLIENTS_RBAC_BASE_URL
+                value: ${{CLIENTS_RBAC_BASE_URL}}
+              - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
+                value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
+                value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
       database:
         name: content-sources
         version: 15
@@ -1059,3 +1140,7 @@ parameters:
     description: path prefix to store pulp logs at in s3
   - name: CLIENTS_ROADMAP_SERVER
     description: URL to the roadmap service (i.e. https://console.stage.redhat.com/api/roadmap/v1)
+  - name: SUSPEND_SNAPSHOT_CLEANUP
+    description: whether to not run the daily job to delete outdated snapshots
+    required: false
+    value: "false"

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -876,7 +876,7 @@ objects:
                     key: key
                     optional: true
         - name: snapshot-cleanup
-          schedule: "0 1 * * *"
+          schedule: ${DAILY_CRON_JOB}
           suspend: ${{SUSPEND_CRON_JOB}}
           concurrencyPolicy: "Forbid"
           podSpec:
@@ -1013,6 +1013,8 @@ parameters:
     value: "0 8 * * 4"
   - name: NIGHTLY_CRON_JOB
     value: "0 0/1 * * *"
+  - name: DAILY_CRON_JOB
+    value: "0 1 * * *"
   - name: SUSPEND_CRON_JOB
     value: "false"
   - name: IMAGE_TAG
@@ -1140,7 +1142,3 @@ parameters:
     description: path prefix to store pulp logs at in s3
   - name: CLIENTS_ROADMAP_SERVER
     description: URL to the roadmap service (i.e. https://console.stage.redhat.com/api/roadmap/v1)
-  - name: SUSPEND_SNAPSHOT_CLEANUP
-    description: whether to not run the daily job to delete outdated snapshots
-    required: false
-    value: "false"

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -180,7 +180,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 	if err != nil {
 		return err
 	}
-	if deleteDistributionHref != nil {
+	if deleteVersionHref != nil {
 		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteVersionHref)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Separates the snapshot-cleanup job from process-repos so it can be run on its own schedule (this sets it to run daily). This may also help narrow down and reduce the errors being reported by glitchtip (https://issues.redhat.com/browse/HMS-5947)

## Testing steps

1. Create a repo, let it snapshot, then edit the repo URL to get another snapshot
2. Adjust the date of one of the snapshots to be a year old: `UPDATE snapshots SET created_at = (NOW() - CAST('365 days' AS INTERVAL)) WHERE uuid = '<snapshot_uuid>';`
3. Run `go run cmd/external-repos/main.go process-repos`. You shouldn't see any delete-snapshots tasks enqueued
4. Run `go run cmd/external-repos/main.go snapshot-cleanup`. This should start the delete-snapshots task
