### PR TITLE
HMS-5913: add package dates from RHEL lifecycle

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -134,6 +134,7 @@ clients:
       rbac: 1m
       pulp_content_path: 1h
       subscription_check: 1h
+      roadmap: 24h
   feature_service:
     server: #https://feature.stage.api.redhat.com/features/v1
     client_cert:

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -28,6 +28,9 @@ type Cache interface {
 
 	GetRoadmapAppstreams(ctx context.Context) ([]byte, error)
 	SetRoadmapAppstreams(ctx context.Context, roadmapAppstreamsResponse []byte)
+
+	GetRoadmapRhelLifecycle(ctx context.Context) ([]byte, error)
+	SetRoadmapRhelLifecycle(ctx context.Context, rhelLifecyleResponse []byte)
 }
 
 func Initialize() Cache {

--- a/pkg/cache/cache_mock.go
+++ b/pkg/cache/cache_mock.go
@@ -135,6 +135,36 @@ func (_m *MockCache) GetRoadmapAppstreams(ctx context.Context) ([]byte, error) {
 	return r0, r1
 }
 
+// GetRoadmapRhelLifecycle provides a mock function with given fields: ctx
+func (_m *MockCache) GetRoadmapRhelLifecycle(ctx context.Context) ([]byte, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoadmapRhelLifecycle")
+	}
+
+	var r0 []byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]byte, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []byte); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSubscriptionCheck provides a mock function with given fields: ctx
 func (_m *MockCache) GetSubscriptionCheck(ctx context.Context) (*api.SubscriptionCheckResponse, error) {
 	ret := _m.Called(ctx)
@@ -222,6 +252,11 @@ func (_m *MockCache) SetPulpContentPath(ctx context.Context, pulpContentPath str
 // SetRoadmapAppstreams provides a mock function with given fields: ctx, roadmapAppstreamsResponse
 func (_m *MockCache) SetRoadmapAppstreams(ctx context.Context, roadmapAppstreamsResponse []byte) {
 	_m.Called(ctx, roadmapAppstreamsResponse)
+}
+
+// SetRoadmapRhelLifecycle provides a mock function with given fields: ctx, rhelLifecyleResponse
+func (_m *MockCache) SetRoadmapRhelLifecycle(ctx context.Context, rhelLifecyleResponse []byte) {
+	_m.Called(ctx, rhelLifecyleResponse)
 }
 
 // SetSubscriptionCheck provides a mock function with given fields: ctx, response

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -64,3 +64,12 @@ func (c *noOpCache) GetRoadmapAppstreams(ctx context.Context) ([]byte, error) {
 // SetRoadmapAppstreams a NoOp version to store cached roadmap appstreams check
 func (c *noOpCache) SetRoadmapAppstreams(ctx context.Context, response []byte) {
 }
+
+// GetRoadmapRhelLifecycle a NoOp version to fetch a cached roadmap rhel lifecycle check
+func (c *noOpCache) GetRoadmapRhelLifecycle(ctx context.Context) ([]byte, error) {
+	return nil, NotFound
+}
+
+// SetRoadmapRhelLifecycle a NoOp version to store cached roadmap rhel lifecycle check
+func (c *noOpCache) SetRoadmapRhelLifecycle(ctx context.Context, response []byte) {
+}

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -61,6 +61,11 @@ func roadmapAppstreamsKey(ctx context.Context) string {
 	return fmt.Sprintf("roadmap-appstreams:%v", identity.Identity.OrgID)
 }
 
+func roadmapRhelLifecycleKey(ctx context.Context) string {
+	identity := identity.GetIdentity(ctx)
+	return fmt.Sprintf("roadmap-rhel-lifecycle:%v", identity.Identity.OrgID)
+}
+
 // GetAccessList uses the request context to read user information, and then tries to retrieve the role AccessList from the cache
 func (c *redisCache) GetAccessList(ctx context.Context) (rbac.AccessList, error) {
 	accessList := rbac.AccessList{}
@@ -184,7 +189,21 @@ func (c *redisCache) GetRoadmapAppstreams(ctx context.Context) ([]byte, error) {
 
 func (c *redisCache) SetRoadmapAppstreams(ctx context.Context, response []byte) {
 	key := roadmapAppstreamsKey(ctx)
-	c.client.Set(ctx, key, string(response), config.Get().Clients.Redis.Expiration.SubscriptionCheck)
+	c.client.Set(ctx, key, string(response), config.Get().Clients.Redis.Expiration.Roadmap)
+}
+
+func (c *redisCache) GetRoadmapRhelLifecycle(ctx context.Context) ([]byte, error) {
+	key := roadmapRhelLifecycleKey(ctx)
+	buf, err := c.get(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("redis get error: %w", err)
+	}
+	return buf, nil
+}
+
+func (c *redisCache) SetRoadmapRhelLifecycle(ctx context.Context, response []byte) {
+	key := roadmapRhelLifecycleKey(ctx)
+	c.client.Set(ctx, key, string(response), config.Get().Clients.Redis.Expiration.Roadmap)
 }
 
 func (c *redisCache) get(ctx context.Context, key string) ([]byte, error) {

--- a/pkg/clients/roadmap_client/client.go
+++ b/pkg/clients/roadmap_client/client.go
@@ -13,6 +13,8 @@ import (
 
 type RoadmapClient interface {
 	GetAppstreams(ctx context.Context) (AppstreamsResponse, int, error)
+	GetRhelLifecycle(ctx context.Context) (LifecycleResponse, int, error)
+	GetRhelLifecycleForLatestMajorVersions(ctx context.Context) (map[int]LifecycleEntity, error)
 }
 
 type roadmapClient struct {

--- a/pkg/clients/roadmap_client/roadmap.go
+++ b/pkg/clients/roadmap_client/roadmap.go
@@ -35,6 +35,18 @@ type AppstreamEntity struct {
 	Impl      string `json:"impl"`
 }
 
+type LifecycleResponse struct {
+	Data []LifecycleEntity `json:"data"`
+}
+
+type LifecycleEntity struct {
+	Name      string `json:"name"`
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	Major     int    `json:"major"`
+	Minor     int    `json:"minor"`
+}
+
 func encodedIdentity(ctx context.Context) (string, error) {
 	id := identity.GetIdentity(ctx)
 	jsonIdentity, err := json.Marshal(id)
@@ -106,4 +118,83 @@ func (rc roadmapClient) GetAppstreams(ctx context.Context) (AppstreamsResponse, 
 	}
 
 	return appStreamResp, statusCode, nil
+}
+
+func (rc roadmapClient) GetRhelLifecycle(ctx context.Context) (LifecycleResponse, int, error) {
+	statusCode := http.StatusInternalServerError
+	server := config.Get().Clients.Roadmap.Server
+	var err error
+	var lifecycleResponse LifecycleResponse
+	var body []byte
+
+	appstreams, err := rc.cache.GetRoadmapRhelLifecycle(ctx)
+	if err != nil && !errors.Is(err, cache.NotFound) {
+		log.Error().Err(err).Msg("GetAppstreams - error reading from cache")
+	}
+	if appstreams != nil {
+		err = json.Unmarshal(appstreams, &lifecycleResponse)
+		if err != nil {
+			return LifecycleResponse{}, statusCode, fmt.Errorf("error during unmarshal response body: %w", err)
+		}
+		return lifecycleResponse, http.StatusOK, nil
+	}
+
+	fullPath := server + "/lifecycle/rhel"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullPath, nil)
+	if err != nil {
+		return LifecycleResponse{}, statusCode, fmt.Errorf("error building request: %w", err)
+	}
+
+	if config.Get().Clients.Roadmap.Username != "" && config.Get().Clients.Roadmap.Password != "" {
+		req.SetBasicAuth(config.Get().Clients.Roadmap.Username, config.Get().Clients.Roadmap.Password)
+	}
+
+	encodedXRHID, err := encodedIdentity(ctx)
+	if err != nil {
+		return LifecycleResponse{}, statusCode, fmt.Errorf("error getting encoded XRHID: %w", err)
+	}
+	req.Header.Set(api.IdentityHeader, encodedXRHID)
+
+	resp, err := rc.client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return LifecycleResponse{}, statusCode, fmt.Errorf("error reading response body: %w", err)
+		}
+		if resp.StatusCode != 0 {
+			statusCode = resp.StatusCode
+		}
+	}
+	if err != nil {
+		return LifecycleResponse{}, statusCode, fmt.Errorf("error sending request: %w", err)
+	}
+	if statusCode < 200 || statusCode >= 300 {
+		return LifecycleResponse{}, statusCode, fmt.Errorf("unexpected status code with body: %s", string(body))
+	}
+
+	rc.cache.SetRoadmapRhelLifecycle(ctx, body)
+
+	err = json.Unmarshal(body, &lifecycleResponse)
+	if err != nil {
+		return LifecycleResponse{}, statusCode, fmt.Errorf("error during unmarshal response body: %w", err)
+	}
+
+	return lifecycleResponse, statusCode, nil
+}
+
+func (rc roadmapClient) GetRhelLifecycleForLatestMajorVersions(ctx context.Context) (map[int]LifecycleEntity, error) {
+	lifecycleResp, _, err := rc.GetRhelLifecycle(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rhelEolMap := make(map[int]LifecycleEntity)
+	for _, item := range lifecycleResp.Data {
+		if existing, found := rhelEolMap[item.Major]; !found || (item.Minor > existing.Minor) {
+			rhelEolMap[item.Major] = item
+		}
+	}
+	return rhelEolMap, nil
 }

--- a/pkg/clients/roadmap_client/roadmap_client_mock.go
+++ b/pkg/clients/roadmap_client/roadmap_client_mock.go
@@ -48,6 +48,71 @@ func (_m *MockRoadmapClient) GetAppstreams(ctx context.Context) (AppstreamsRespo
 	return r0, r1, r2
 }
 
+// GetRhelLifecycle provides a mock function with given fields: ctx
+func (_m *MockRoadmapClient) GetRhelLifecycle(ctx context.Context) (LifecycleResponse, int, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRhelLifecycle")
+	}
+
+	var r0 LifecycleResponse
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context) (LifecycleResponse, int, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) LifecycleResponse); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(LifecycleResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) int); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// GetRhelLifecycleForLatestMajorVersions provides a mock function with given fields: ctx
+func (_m *MockRoadmapClient) GetRhelLifecycleForLatestMajorVersions(ctx context.Context) (map[int]LifecycleEntity, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRhelLifecycleForLatestMajorVersions")
+	}
+
+	var r0 map[int]LifecycleEntity
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (map[int]LifecycleEntity, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) map[int]LifecycleEntity); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[int]LifecycleEntity)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewMockRoadmapClient creates a new instance of MockRoadmapClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockRoadmapClient(t interface {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,6 +184,7 @@ type Expiration struct {
 	Rbac              time.Duration `mapstructure:"rbac"`
 	PulpContentPath   time.Duration `mapstructure:"pulp_content_path"`
 	SubscriptionCheck time.Duration `mapstructure:"subscription_check"`
+	Roadmap           time.Duration `mapstructure:"roadmap"`
 }
 
 type Sentry struct {
@@ -323,6 +324,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.redis.expiration.rbac", 1*time.Minute)
 	v.SetDefault("clients.redis.expiration.pulp_content_path", 1*time.Hour)
 	v.SetDefault("clients.redis.expiration.subscription_check", 1*time.Hour)
+	v.SetDefault("clients.redis.expiration.roadmap", 24*time.Hour)
 
 	v.SetDefault("clients.feature_service.server", "")
 	v.SetDefault("clients.feature_service.client_cert", "")


### PR DESCRIPTION
## Summary
Adds package streams info to package_sources. Pulls package stream info from the roadmap API and adds it to package sources if the RPM name matches.
    
Also adds RHEL EoL as the end date for any package source that is not in the roadmap API. Uses the end date for the latest released version of the matching RHEL major version.

## Testing steps
To test package streams:
1. Search for "nodejs" in a rhel9 repo
2. Under package sources, you should see both the node 16 module and the 16.14.0 package stream

To test the rhel lifecycle info:
1. When a RHEL package doesn't exist in the roadmap, the RHEL end date is used instead
2. Search with a codeready repo. For example, "help2man" in https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/

