### PR TITLE
HMS-8626: fix pulp log parsing, add job to fix logs

### DIFF
--- a/cmd/jobs/main.go
+++ b/cmd/jobs/main.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type jobFunc func()
+type jobFunc func([]string)
 
 func loadJobs() map[string]jobFunc {
 	return map[string]jobFunc{
@@ -42,7 +42,7 @@ func main() {
 	}
 	job, ok := loadJobs()[args[1]]
 	if ok {
-		job()
+		job(args[2:])
 	} else {
 		usage()
 	}

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -723,6 +723,64 @@ objects:
                   secretKeyRef:
                     name: ${FLOORIST_BUCKET_SECRET_NAME}
                     key: aws_region
+        - name: transform-pulp-logs-fix-2025-05
+          suspend: ${{SUSPEND_TRANSFORM_PULP_LOGS}}
+          concurrencyPolicy: "Forbid"
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /jobs
+              - transform-pulp-logs
+              - "2025-05-09"
+              - "24"
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
+                value: ${CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_REGION
+                value: ${CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_REGION}
+              - name: CLIENTS_PULP_LOG_PARSER_S3_FILE_PREFIX
+                value: ${CLIENTS_PULP_LOG_PARSER_S3_FILE_PREFIX}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-appsre-log-access-pulp
+                    key: aws_access_key_id
+                    optional: true
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-appsre-log-access-pulp
+                    key: aws_secret_access_key
+                    optional: true
+              - name: CLIENTS_PULP_LOG_PARSER_S3_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: ${FLOORIST_BUCKET_SECRET_NAME}
+                    key: bucket
+                    optional: true
+              - name: CLIENTS_PULP_LOG_PARSER_S3_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: ${FLOORIST_BUCKET_SECRET_NAME}
+                    key: aws_secret_access_key
+              - name: CLIENTS_PULP_LOG_PARSER_S3_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: ${FLOORIST_BUCKET_SECRET_NAME}
+                    key: aws_access_key_id
+              - name: CLIENTS_PULP_LOG_PARSER_S3_REGION
+                valueFrom:
+                  secretKeyRef:
+                    name: ${FLOORIST_BUCKET_SECRET_NAME}
+                    key: aws_region
         - name: cleanup-missing-domains
           podSpec:
             securityContext:

--- a/deployments/jobs-prod.yaml
+++ b/deployments/jobs-prod.yaml
@@ -13,3 +13,13 @@ objects:
       appName: content-sources-backend
       jobs:
         - set-domain-label
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      labels:
+        app: content-sources-backend
+      name: transform-pulp-logs-fix-2025-05
+    spec:
+      appName: content-sources-backend
+      jobs:
+        - transform-pulp-logs-fix-2025-05

--- a/deployments/jobs-stage.yaml
+++ b/deployments/jobs-stage.yaml
@@ -13,3 +13,14 @@ objects:
       appName: content-sources-backend
       jobs:
         - set-domain-label
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdJobInvocation
+    metadata:
+      labels:
+        app: content-sources-backend
+      name: transform-pulp-logs-fix-2025-05
+    spec:
+      appName: content-sources-backend
+      jobs:
+        - transform-pulp-logs-fix-2025-05
+

--- a/pkg/jobs/cleanup_missing_domains.go
+++ b/pkg/jobs/cleanup_missing_domains.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func CleanupMissingDomains() {
+func CleanupMissingDomains(_ []string) {
 	err := db.Connect()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to connect to database")

--- a/pkg/jobs/create_latest_distributions.go
+++ b/pkg/jobs/create_latest_distributions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func CreateLatestDistributions() {
+func CreateLatestDistributions(_ []string) {
 	err := db.Connect()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to connect to database")

--- a/pkg/jobs/retry_failed_tasks.go
+++ b/pkg/jobs/retry_failed_tasks.go
@@ -5,7 +5,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func RetryFailedTasks() {
+func RetryFailedTasks(_ []string) {
 	query :=
 		`
 			UPDATE tasks

--- a/pkg/jobs/set_domain_label.go
+++ b/pkg/jobs/set_domain_label.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func SetDomainLabel() {
+func SetDomainLabel(_ []string) {
 	err := db.Connect()
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to connect to database")

--- a/pkg/jobs/transform_pulp_logs_test.go
+++ b/pkg/jobs/transform_pulp_logs_test.go
@@ -21,53 +21,26 @@ func TestTransformPulpLogsSuite(t *testing.T) {
 	suite.Run(t, &r)
 }
 
-var PULP_LOG_1 = `10.128.35.104 [27/Jan/2025:20:44:09 +0000] "GET /api/pulp-content/mydomain/gaudi-rhel-9.4/repodata/-primary.xml.gz HTTP/1.0" 302 791 "-" "libdnf (Red Hat Enterprise Linux 9.4; generic; Linux.x86_64)" "MISS" "21547" "789"`
+var PULP_LOG_1 = `10.128.35.104 [27/Jan/2025:20:44:09 +0000] "GET /api/pulp-content/mydomain/gaudi-rhel-9.4/repodata/-primary.xml.gz HTTP/1.0" 302 791 "-" "libdnf (Red Hat Enterprise Linux 9.4; generic; Linux.x86_64)" cache:"MISS" artifact_size:"21547" rh_org_id:"789"`
 var FULL_MESSAGE = `{
-    "@timestamp": "2025-01-27T20:44:09.468383983Z",
-    "hostname": "ip-10-110-168-88.ec2.internal",
+    "@timestamp": "2025-05-21T19:23:44.403067792Z",
+    "hostname": "ip-10-110-154-130.ec2.internal",
     "kubernetes": {
         "annotations": {
-            "configHash": "94aa153d7615e87cf1c6f0c0b42de188656cd1c287018760d9333f6640302f13",
-            "k8s.ovn.org/pod-networks": "{\"default\":{\"ip_addresses\":[\"10.130.22.232/23\"],\"mac_address\":\"0a:58:0a:82:16:e8\",\"gateway_ips\":[\"10.130.22.1\"],\"routes\":[{\"dest\":\"10.128.0.0/14\",\"nextHop\":\"10.130.22.1\"},{\"dest\":\"172.30.0.0/16\",\"nextHop\":\"10.130.22.1\"},{\"dest\":\"169.254.169.5/32\",\"nextHop\":\"10.130.22.1\"},{\"dest\":\"100.64.0.0/16\",\"nextHop\":\"10.130.22.1\"}],\"ip_address\":\"10.130.22.232/23\",\"gateway_ip\":\"10.130.22.1\"}}",
-            "k8s.v1.cni.cncf.io/network-status": "[{\n    \"name\": \"ovn-kubernetes\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.130.22.232\"\n    ],\n    \"mac\": \"0a:58:0a:82:16:e8\",\n    \"default\": true,\n    \"dns\": {}\n}]",
+            "configHash": "89916124c57361a137853509cb30ff83affba06bf5a6c9ed2187c69f8bd363a9",
             "openshift.io/scc": "restricted-v2",
             "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
-        },
-        "container_id": "cri-o://08546922adc81f7baa8b3c230d4e14de03ed34e1c35edf71008e4801efcb93cb",
-        "container_image": "quay.io/cloudservices/pulp-ubi:05fd4bd",
-        "container_image_id": "quay.io/cloudservices/pulp-ubi@sha256:1af7e77010b6f8f3331aea3753605fac199e2a53284e895161278a5323378ff1",
-        "container_name": "pulp-content",
-        "labels": {
-            "app": "pulp",
-            "pod": "pulp-content",
-            "pod-template-hash": "797d78c958"
-        },
-        "namespace_id": "660113ad-c221-4f49-878b-ab2e0a7fca25",
-        "namespace_labels": {
-            "kubernetes_io_metadata_name": "pulp-prod",
-            "name": "pulp-prod",
-            "openshift_io_workload-monitoring": "true",
-            "pod-security_kubernetes_io_audit": "baseline",
-            "pod-security_kubernetes_io_audit-version": "v1.24",
-            "pod-security_kubernetes_io_warn": "baseline",
-            "pod-security_kubernetes_io_warn-version": "v1.24",
-            "service": "pulp"
-        },
-        "namespace_name": "pulp-prod",
-        "pod_id": "0561cd60-8c50-470f-b2e6-a8c032ac2da6",
-        "pod_ip": "10.130.22.232",
-        "pod_name": "pulp-content-797d78c958-ngj5w",
-        "pod_owner": "ReplicaSet/pulp-content-797d78c958"
+        }
     },
     "level": "default",
     "log_source": "container",
     "log_type": "application",
-    "message": "10.128.35.104 [27/Jan/2025:20:44:09 +0000] \"GET /api/pulp-content/mydomain/gaudi-rhel-9.4/repodata/ff044ba6207abde56d0539134f6c371f49f74ad78d22331303d244fa72171da9-primary.xml.gz HTTP/1.0\" 302 791 \"-\" \"libdnf (Red Hat Enterprise Linux 9.4; generic; Linux.x86_64)\" \"MISS\" \"21547\" \"9999\"",
+    "message": "192.168.1.1 [21/May/2025:19:23:44 +0000] \"GET /api/pulp-content/mydomain/templates/8c18e4a4-077f-468b-ba26-73a507e86f6e/content/dist/rhel9/9/x86_64/appstream/os/repodata/repomd.xml HTTP/1.1\" 302 728 \"-\" \"libdnf (Red Hat Enterprise Linux 9.5; generic; Linux.x86_64)\" cache:\"HIT\" artifact_size:\"3141\" rh_org_id:\"5483888\"",
     "openshift": {
         "cluster_id": "33f28efd-3f10-41df-ae1f-d48036f42349",
-        "sequence": 1738010651787697179
+        "sequence": 1747855430177207299
     },
-    "stream_name": "pulp-prod_pulp-content-797d78c958-ngj5w_pulp-content"
+    "stream_name": "pulp-prod_pulp-content-857ffc5b9f-grljs_pulp-content"
 }
 `
 
@@ -83,9 +56,9 @@ func (s *TransformPulpLogsSuite) TestTransformLogEvents() {
 	assert.Len(s.T(), events, 1)
 	event := events[0]
 	assert.Equal(s.T(), "1234", event.OrgId)
-	assert.Equal(s.T(), "/api/pulp-content/mydomain/gaudi-rhel-9.4/repodata/ff044ba6207abde56d0539134f6c371f49f74ad78d22331303d244fa72171da9-primary.xml.gz", event.Path)
+	assert.Equal(s.T(), "/api/pulp-content/mydomain/templates/8c18e4a4-077f-468b-ba26-73a507e86f6e/content/dist/rhel9/9/x86_64/appstream/os/repodata/repomd.xml", event.Path)
 	assert.Equal(s.T(), "mydomain", event.DomainName)
-	assert.Equal(s.T(), "9999", event.RequestOrgId)
+	assert.Equal(s.T(), "5483888", event.RequestOrgId)
 }
 
 func (s *TransformPulpLogsSuite) TestParsePulpLogMessage() {


### PR DESCRIPTION
## Summary

* Adds the ability for arguments to be passed to jobs (most all jobs ignore this)
* Fixes the log parsing for pulp to handle the new format (example included in tests)
* Adds new arguments to the ./jobs transform-pulp-logs DATE COUNT
  * DATE 2025-01-01 is the date to start processing of logs
  * COUNT is the number of days to process
* Adds a stage and prod job to re-run these from May the 5th, through the end of may

## Testing steps

