### PR TITLE
HMS-5947: fix delete-snapshots glitchtip errors

### DIFF
--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -219,6 +219,7 @@ type TemplateDao interface {
 	DeleteTemplateSnapshot(ctx context.Context, snapshotUUID string) error
 	GetRepositoryConfigurationFile(ctx context.Context, orgID string, templateUUID string) (string, error)
 	InternalOnlyGetTemplatesForRepoConfig(ctx context.Context, repoUUID string, useLatestOnly bool) ([]api.TemplateResponse, error)
+	InternalOnlyGetTemplatesForSnapshots(ctx context.Context, snapUUIDs []string) ([]api.TemplateResponse, error)
 }
 
 type UploadDao interface {

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -701,6 +701,33 @@ func (t templateDaoImpl) InternalOnlyGetTemplatesForRepoConfig(ctx context.Conte
 	return responses, nil
 }
 
+func (t templateDaoImpl) InternalOnlyGetTemplatesForSnapshots(ctx context.Context, snapUUIDs []string) ([]api.TemplateResponse, error) {
+	var templates []models.Template
+	filtered := t.db.Model(&models.Template{}).WithContext(ctx).
+		Joins("INNER JOIN templates_repository_configurations on templates_repository_configurations.template_uuid = templates.uuid").
+		Where("templates_repository_configurations.snapshot_uuid IN ?", snapUUIDs)
+	res := filtered.Find(&templates)
+	if res.Error != nil {
+		return nil, TemplateDBToApiError(res.Error, nil)
+	}
+
+	pulpContentPath := ""
+	if config.Get().Features.Snapshots.Enabled {
+		var err error
+		pulpContentPath, err = t.pulpClient.GetContentPath(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	lastSnapshotUUIDs, err := t.fetchLatestSnapshotUUIDsForReposOfTemplates(ctx, templates)
+	if err != nil {
+		return nil, TemplateDBToApiError(err, nil)
+	}
+	responses := templatesConvertToResponses(templates, lastSnapshotUUIDs, pulpContentPath)
+
+	return responses, nil
+}
+
 func templatesCreateApiToModel(api api.TemplateRequest, model *models.Template) {
 	if api.Name != nil {
 		model.Name = *api.Name

--- a/pkg/dao/templates_mock.go
+++ b/pkg/dao/templates_mock.go
@@ -316,6 +316,36 @@ func (_m *MockTemplateDao) InternalOnlyGetTemplatesForRepoConfig(ctx context.Con
 	return r0, r1
 }
 
+// InternalOnlyGetTemplatesForSnapshots provides a mock function with given fields: ctx, snapUUIDs
+func (_m *MockTemplateDao) InternalOnlyGetTemplatesForSnapshots(ctx context.Context, snapUUIDs []string) ([]api.TemplateResponse, error) {
+	ret := _m.Called(ctx, snapUUIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InternalOnlyGetTemplatesForSnapshots")
+	}
+
+	var r0 []api.TemplateResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]api.TemplateResponse, error)); ok {
+		return rf(ctx, snapUUIDs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []api.TemplateResponse); ok {
+		r0 = rf(ctx, snapUUIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.TemplateResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, snapUUIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // List provides a mock function with given fields: ctx, orgID, includeSoftDel, paginationData, filterData
 func (_m *MockTemplateDao) List(ctx context.Context, orgID string, includeSoftDel bool, paginationData api.PaginationData, filterData api.TemplateFilterData) (api.TemplateCollectionResponse, int64, error) {
 	ret := _m.Called(ctx, orgID, includeSoftDel, paginationData, filterData)


### PR DESCRIPTION
## Summary

Template distributions were not being updated when cleaning up outdated snapshots for RH repos, resulting in failed deletion of repo versions. There might be other issues at play here, so I've left in the debug logs for now.

## Testing steps

I haven't found a way to test this without multiple RH snapshots, this hasn't been reproducible for me locally with custom or EPEL repos. If you have multiple RH snapshots, you can follow these steps:

1. Create a template with just the base RH repos for any version or arch. Set to a date earlier than the oldest snapshot so it uses the oldest
2. Update one of the RH repo's oldest snapshot so that it is set to be cleaned up. You can use this query:  `UPDATE snapshots SET created_at = (NOW() - CAST('365 days' AS INTERVAL)) WHERE uuid = '<snapshot_uuid>';`
3. Confirm the template now shows a warning that some repos have snapshots that are soon to be deleted.
4. Grab the pulp URL to the snapshot you'll be deleting so we can verify it doesn't exist later.
5. Run the snapshot cleanup task: `go run cmd/external-repos/main.go cleanup --type snapshot`
6. Follow the logs, you shouldn't see errors related to existing distributions and the task should succeed. 
7. In the template, the warning should disappear and you should see the next available snapshot of that RH repo on that template.
8. The RH snapshot should be fully deleted (not available when viewing snapshots in the UI or listing via the API, not stuck in a soft-deleted state in the DB, and the older snapshot URL should give you a 404).

