### PR TITLE
Build: update getFrontendRepo to clone submodules

### DIFF
--- a/.github/workflowScripts/getFrontendRepo.sh
+++ b/.github/workflowScripts/getFrontendRepo.sh
@@ -47,7 +47,11 @@ while read -r pr; do
     # Check if PR title or body contains the search string
     if [[ "$pr_body" == *"$TAG_NAME"* ]] && [[ "$pr_body" == *"$SEARCH_STRING"* ]]; then
         echo "Cloning PR #$pr_number: $pr_title from $pr_repo on branch $pr_branch"
-        git clone --branch $pr_branch $pr_repo $CLONE_DIR
+        git clone --recurse-submodules --branch $pr_branch $pr_repo $CLONE_DIR
+        cd "$CLONE_DIR/_playwright-tests/test-utils/" ||
+        git sparse-checkout init --cone
+        git sparse-checkout set _playwright-tests/test-utils/
+        cd - ||
 
         # Check if the clone was successful
         if [ $? -eq 0 ]; then
@@ -57,7 +61,7 @@ while read -r pr; do
             echo "Failed to clone PR #$pr_number"
             exit 1
         fi
-        
+
         # Exit the loop after cloning the first matching PR
         break
     fi
@@ -66,7 +70,11 @@ done < <(echo "$prs" | jq -c '.[]')
 # If no matching PR was found, clone the main branch
 if [ "$found_pr" == false ]; then
     echo "No PR title or description contains '$TAG_NAME $SEARCH_STRING'. Cloning the main branch."
-    git clone --branch main $GIT_REPO_URL $CLONE_DIR
+    git clone --recurse-submodules --branch main $GIT_REPO_URL $CLONE_DIR
+    cd "$CLONE_DIR/_playwright-tests/test-utils/" ||
+    git sparse-checkout init --cone
+    git sparse-checkout set _playwright-tests/test-utils/
+    cd - ||
 
     # Check if the clone was successful
     if [ $? -eq 0 ]; then

--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -97,20 +97,20 @@ jobs:
         working-directory: content-sources-frontend
         run: |
           # Check if the secrets are set
-          if [ -z "$USER1USERNAME" ]; then
-            echo "Error: USER1USERNAME secret is not set."
+          if [ -z "$ADMIN_USERNAME" ]; then
+            echo "Error: ADMIN_USERNAME secret is not set."
             exit 1
           fi
 
-          if [ -z "$USER1PASSWORD" ]; then
-            echo "Error: USER1PASSWORD secret is not set."
+          if [ -z "$ADMIN_PASSWORD" ]; then
+            echo "Error: ADMIN_PASSWORD secret is not set."
             exit 1
           fi
 
           # Create the .env file and write the secrets and other variables to it
           {
-            echo "USER1USERNAME=$USER1USERNAME"
-            echo "USER1PASSWORD=$USER1PASSWORD"
+            echo "ADMIN_USERNAME=$ADMIN_USERNAME"
+            echo "ADMIN_PASSWORD=$ADMIN_PASSWORD"
             echo "BASE_URL=https://stage.foo.redhat.com:1337"
             echo "CI=true"
           } >> .env
@@ -278,7 +278,7 @@ jobs:
 
       - name: Run testing proxy
         working-directory: content-sources-frontend
-        run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -v "$(pwd)/config:/config:ro,Z" --name consoledot-testing-proxy quay.io/dvagner/consoledot-testing-proxy
+        run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -e ROUTES_JSON_PATH=/config/routes-ci.json -v "$(pwd)/config:/config:ro,Z" --name consoledot-testing-proxy quay.io/dvagner/consoledot-testing-proxy
 
       - name: Run front-end Playwright tests
         working-directory: content-sources-frontend


### PR DESCRIPTION
## Summary
This updates the `getFrontendRepo` workflow helper script to clone the frontend repo with submodules. Needed for cloning test utils.
This also switches the proxy to use the CI specific routes config, which is needed for the proxy to work correctly inside DinD. And makes the Playwright action use the updated user secrets.

## Testing steps
Playwright tests pass in CI.
