### PR TITLE
HMS-8627: start snapshot for repo once it's enabled

### DIFF
--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -334,10 +334,13 @@ func (rh *RepositoryHandler) update(c echo.Context, fillDefaults bool) error {
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}
-	if urlUpdated && response.Snapshot {
+
+	snapshottingNowEnabled := !repoConfig.Snapshot && response.Snapshot
+
+	if (urlUpdated && response.Snapshot) || snapshottingNowEnabled {
 		rh.enqueueSnapshotEvent(c, &response)
 	}
-	if urlUpdated {
+	if urlUpdated || snapshottingNowEnabled {
 		rh.enqueueIntrospectEvent(c, response, orgID)
 	}
 


### PR DESCRIPTION
## Summary

- Fixes issue where a snapshot task was not triggered immediately when updating a repo from introspection to snapshotting
- Requires this [test change](https://github.com/content-services/content-sources-frontend/pull/556) for playwright snapshot tests to pass

## Testing steps

1. Create a repo with snapshot set to false
2. Update the repo to set snapshot to true. Introspect and snapshot tasks for that repo should start immediately