### PR TITLE
HMS-8834: add turnpike via composite for red hat repos

### DIFF
--- a/pkg/clients/pulp_client/interfaces.go
+++ b/pkg/clients/pulp_client/interfaces.go
@@ -38,6 +38,7 @@ type PulpClient interface {
 	// Content Guards
 	CreateOrUpdateGuardsForOrg(ctx context.Context, orgId string) (string, error)
 	CreateOrUpdateFeatureGuard(ctx context.Context, featureName string) (string, error)
+	CreateOrUpdateGuardsForRhelRepo(ctx context.Context, featureName string) (string, error)
 
 	// Tasks
 	GetTask(ctx context.Context, taskHref string) (zest.TaskResponse, error)

--- a/pkg/clients/pulp_client/pulp_client_mock.go
+++ b/pkg/clients/pulp_client/pulp_client_mock.go
@@ -72,6 +72,33 @@ func (_m *MockPulpClient) CreateOrUpdateFeatureGuard(ctx context.Context, featur
 	return r0, r1
 }
 
+func (_m *MockPulpClient) CreateOrUpdateGuardsForRhelRepo(ctx context.Context, featureName string) (string, error) {
+	ret := _m.Called(ctx, featureName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateOrUpdateGuardsForRhelRepo")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, featureName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, featureName)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, featureName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateOrUpdateGuardsForOrg provides a mock function with given fields: ctx, orgId
 func (_m *MockPulpClient) CreateOrUpdateGuardsForOrg(ctx context.Context, orgId string) (string, error) {
 	ret := _m.Called(ctx, orgId)

--- a/pkg/external_repos/snapshotted_repos/high_availability-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/high_availability-x86_64.json
@@ -16,5 +16,14 @@
         "distribution_version": "9",
         "feature_name": "RHEL-HA-x86_64",
         "origin": "red_hat"
+    },
+    {
+        "name":"Red Hat Enterprise Linux 10 for x86_64 - High Availability (RPMs)",
+        "content_label":"rhel-10-for-x86_64-highavailability-rpms",
+        "url":"https://cdn.redhat.com/content/dist/rhel10/10/x86_64/highavailability/os",
+        "distribution_arch":"x86_64",
+        "distribution_version":"10",
+        "feature_name":"RHEL-HA-x86_64",
+        "origin":"red_hat"
     }
 ]

--- a/pkg/tasks/helpers/pulp_distribution_helper.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper.go
@@ -136,9 +136,9 @@ func (pdh *PulpDistributionHelper) FetchContentGuard(orgId string, feature strin
 	}
 	if orgId == config.RedHatOrg {
 		if !slices.Contains(config.SubscriptionFeaturesIgnored, feature) {
-			href, err := pdh.pulpClient.CreateOrUpdateFeatureGuard(pdh.ctx, feature)
+			href, err := pdh.pulpClient.CreateOrUpdateGuardsForRhelRepo(pdh.ctx, feature)
 			if err != nil {
-				return nil, fmt.Errorf("could not fetch/create/update feature content guard: %w", err)
+				return nil, fmt.Errorf("could not fetch/create/update RHEL composite content guard: %w", err)
 			}
 			return &href, nil
 		}

--- a/pkg/tasks/helpers/pulp_distribution_helper_test.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper_test.go
@@ -111,7 +111,7 @@ func (s *PulpDistributionHelperTest) TestRedHatDistributionWithFeatureCreate() {
 		PulpHref: &taskHref,
 	}
 
-	mockPulp.On("CreateOrUpdateFeatureGuard", ctx, feature).Return(guardHref, nil)
+	mockPulp.On("CreateOrUpdateGuardsForRhelRepo", ctx, feature).Return(guardHref, nil)
 	mockPulp.On("CreateRpmDistribution", ctx, pubHref, distName, distPath, &guardHref).Return(&taskHref, nil)
 	mockPulp.On("PollTask", ctx, taskHref).Return(&taskResp, nil)
 	created, err := helper.CreateDistribution(api.RepositoryResponse{OrgID: orgId, FeatureName: feature}, pubHref, distName, distPath)


### PR DESCRIPTION
## Summary

for red hat repos this changes the content guard set on red hat repos with features to now be a composite guard which has
* the previous feature guard
* the turnpike guard

## Testing steps

on a fresh server, and this PR:
* in config.yaml, configure the feature service (let me know if you need help):
```
  feature_service:
    server: 
    client_cert:
    client_key:
    ca_cert:
    client_cert_path:
    client_key_path:
    ca_cert_path:
```
Ensure that the guard dn is set to 'some_dn':
```
clients:
  pulp:
    guard_subject_dn: "some_dn"
```

* make repos-import
* go run cmd/external-repos/main.go snapshot --url=https://cdn.redhat.com/content/dist/rhel8/8/x86_64/highavailability/os/
* grab the last snapshot url:  ``curl -X GET --location "http://localhost:8000/api/content-sources/v1.0/repositories/?search=High" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxODkzOTc2NCIsICJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiIxODkzOTc2NCJ9LCJhY2NvdW50X251bWJlciI6IjE4OTM5NzY0IiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTg5Mzk3NjQifX19Cg==" \
    -H "Content-Type: application/json"``
* curl the snapshot url with the turnpike header: ```curl http://pulp.content:8081/pulp/content/cs-redhat/c9957eab-9f81-4ecf-89fc-431d4c9b2d6b/latest/  -H "`./scripts/turnpike_header.sh some_dn`"```

You might check the pulp db:
* `psql --username=pulp --host=localhost`  (password `password`)



```
# select cg.pulp_type, cg.name, cg2.name as included from core_contentguard cg left join core_compositecontentguard_guards ccg on ccg.compositecontentguard_id = cg.pulp_id left join core_contentguard cg2 on  ccg.contentguard_id = cg2.pulp_id;
       pulp_type       |                               name                               |        included        
-----------------------+------------------------------------------------------------------+------------------------
 core.composite        | rhel_composite_RHEL-HA-x86_64                                    | turnpike_guard
 core.composite        | rhel_composite_RHEL-HA-x86_64                                    | feature_RHEL-HA-x86_64
 core.header           | turnpike_guard                                                   | 
 service.header        | feature_RHEL-HA-x86_64                                           | 
 core.content_redirect | ab178f5e06c1dc9ef6f3431f53f6d01b88f67eae95482ea37914c7a45912b33c | 
```
This shows a feature specific server guard, the turnpike guard and a composite guard including both

Generated by cursor, reviewed by me