### PR TITLE
Build: pin the downloaded mockery version to v2

### DIFF
--- a/mk/mockery.mk
+++ b/mk/mockery.mk
@@ -1,4 +1,6 @@
-MOCKERY_VERSION := $(shell curl -L https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
+# MOCKERY_VERSION := $(shell curl -L https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
+# TODO: When the mockery config is updated to be v3 compatible. Remove the line bellow which pins the version to "v2.*" and uncomment the one above.
+MOCKERY_VERSION := $(shell curl -L https://api.github.com/repos/vektra/mockery/tags\?per_page=1000 | grep "\"name\": \"v2." | head -n 1 | sed 's/.*"v\([^"]*\)".*/\1/')
 
 export GO_OUTPUT
 


### PR DESCRIPTION
## Summary
This pins the version of the downloaded mockery binary to `v2.*` as our config isn't v3 compatible. This should be reverted/removed when we or if we update the config.

Task for updating our config was created here [[HMS-8889](https://issues.redhat.com/browse/HMS-8889)].

## Testing steps
- When you remove your currently downloaded version of the mockery tool (`release/mockery`), the `make mock` command should download the latest v2 version and the mocks should be generated successfully.
