### PR TITLE
Build: append RHEL feature manually when importing repos

### DIFF
--- a/pkg/clients/feature_service_client/features.go
+++ b/pkg/clients/feature_service_client/features.go
@@ -141,7 +141,7 @@ func (fs featureServiceImpl) GetFeatureStatusByOrgID(ctx context.Context, orgID 
 }
 
 func (fs featureServiceImpl) GetEntitledFeatures(ctx context.Context, orgID string) ([]string, error) {
-	entitledFeatures := []string{"RHEL-OS-x86_64", "RHEL-OS-aarch64"}
+	entitledFeatures := []string{"RHEL-OS-x86_64"}
 
 	if config.Get().Clients.FeatureService.Server == "" || orgID == config.RedHatOrg {
 		if config.Get().Options.EntitleAll {

--- a/pkg/external_repos/snapshotted_repos_importer.go
+++ b/pkg/external_repos/snapshotted_repos_importer.go
@@ -129,6 +129,7 @@ func (rhr *SnapshotRepoImporter) loadFromFile(filename string) ([]SnapshottedRep
 	filter := config.Get().Options.RepositoryImportFilter
 	filters := strings.Split(filter, ",")
 	features := config.Get().Options.FeatureFilter
+	features = append(features, "RHEL-OS-x86_64")
 	for _, repo := range repos {
 		selectors := strings.Split(repo.Selector, ",")
 		if filter == "" || utils.ContainsAny(filters, selectors) {


### PR DESCRIPTION
## Summary

The prod feature service doesn't include RHEL-OS-x86_64 as a feature, so we can't include that in the request.

## Testing steps

1. Set the feature service server in the clients section of the config to the prod server and grab the certs from vault and set them here too: 

```
  feature_service:
    server: https://feature.api.redhat.com/features/v1
    client_cert:
    client_key:
    ca_cert:
    client_cert_path: /home/bhouse/certs/cp_prod_client.cert
    client_key_path: /home/bhouse/certs/cp_prod_client.key
    ca_cert_path:
```
2. Also set options.feature_filter in the config to `["RHEL-HA-x86_64", "OPENSHIFT-OCP-x86_64"]`
3. On a fresh backend, run make repos-import
4. You should see the layered repos (openshift and HA) in the response when listing repos either via API or UI (using your prod account) 
    

