### PR TITLE
HMS-8916: Persist pulp database for compose-down

### DIFF
--- a/compose_files/pulp/docker-compose.yml
+++ b/compose_files/pulp/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
       POSTGRES_HOST_AUTH_METHOD: "scram-sha-256"
     volumes:
-      - "pg_data:/var/lib/postgresql"
+      - "pg_data:/var/lib/postgresql/data"
       - "./assets/postgres/passwd:/etc/passwd:Z"
     restart: always
     healthcheck:


### PR DESCRIPTION
## Summary
The pulp database was not persisting between compose-down and compose-up

## Testing steps
1. `make compose-clean compose-up`
2. Create a repository with snapshot
3. List the repositories in pulp. e.g. `get http://localhost:8080/api/pulp/cs-62edc243ec/api/v3/repositories/?offset=0&limit=25`
4. The repository will be listed
5. `make compose-down compose-up`
6. Again, list the repositories in pulp
7. The repository should still be listed. Without this PR, no repositories would be found
