### PR TITLE
HMS-9071: Properly set color in logging

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -46,6 +46,7 @@ logging:
   level: debug
   metrics_level: debug
   console: True
+  color: True
 cloudwatch:
   region:
   group:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,7 @@ type Logging struct {
 	Level        string
 	MetricsLevel string `mapstructure:"metrics_level"`
 	Console      bool
+	Color        bool `mapstructure:"color"`
 }
 
 type Certs struct {
@@ -284,6 +285,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("logging.level", "info")
 	v.SetDefault("logging.metrics_level", "")
 	v.SetDefault("logging.console", true)
+	v.SetDefault("logging.color", false)
 	v.SetDefault("metrics.path", "/metrics")
 	v.SetDefault("metrics.port", 9000)
 	v.SetDefault("metrics.collection_frequency", 60)

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -34,7 +34,9 @@ func ConfigureLogging() {
 	}
 
 	if conf.Logging.Console {
-		writers = append(writers, zerolog.NewConsoleWriter())
+		consoleWriter := zerolog.NewConsoleWriter()
+		consoleWriter.NoColor = !conf.Logging.Color
+		writers = append(writers, consoleWriter)
 	}
 
 	if conf.Cloudwatch.Key != "" {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -53,11 +53,12 @@ func Connect() error {
 				SlowThreshold:             config.Get().Database.SlowQueryDuration,
 				LogLevel:                  zeroLogToGormLevel(log.Logger.GetLevel()),
 				IgnoreRecordNotFoundError: true,
-				Colorful:                  config.Get().Logging.Console,
+				Colorful:                  config.Get().Logging.Color,
 				zeroLogger:                log.Logger,
 			},
 		),
 	})
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

makes logger coloring optional and defaults to off. Sets this in both zerolog and in  gorm

## Testing steps

set color to true in logging
```
logging:
  level: info
  color: true
```
start server, see 🌈 .  Set it to false and try again, see ⚫ ⚪ 



