### PR TITLE
HMS-9081: make db log level configurable

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -45,6 +45,7 @@ tasking:
 logging:
   level: debug
   metrics_level: debug
+  db_level: debug
   console: True
   color: True
 cloudwatch:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,6 +155,7 @@ type Database struct {
 type Logging struct {
 	Level        string
 	MetricsLevel string `mapstructure:"metrics_level"`
+	DBLevel      string `mapstructure:"db_level"`
 	Console      bool
 	Color        bool `mapstructure:"color"`
 }
@@ -284,6 +285,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("options.snapshot_retain_days_limit", 365)
 	v.SetDefault("logging.level", "info")
 	v.SetDefault("logging.metrics_level", "")
+	v.SetDefault("logging.db_level", "")
 	v.SetDefault("logging.console", true)
 	v.SetDefault("logging.color", false)
 	v.SetDefault("metrics.path", "/metrics")

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -124,6 +124,18 @@ func MetricsLevel() zerolog.Level {
 	return level
 }
 
+func DBLevel() zerolog.Level {
+	logLevel := Get().Logging.DBLevel
+	if logLevel == "" { // Default to the base logging level, if not set
+		logLevel = Get().Logging.Level
+	}
+	level, err := zerolog.ParseLevel(logLevel)
+	if err != nil {
+		log.Error().Msgf("Could not parse db logging level %v %v", level, err)
+	}
+	return level
+}
+
 type RequestIdHook struct{}
 
 func (h RequestIdHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -50,11 +50,12 @@ func Connect() error {
 	DB, err = gorm.Open(pg.Open(dbURL), &gorm.Config{
 		Logger: NewDBLogger(
 			DBLogConfig{
-				SlowThreshold:             config.Get().Database.SlowQueryDuration,
-				LogLevel:                  zeroLogToGormLevel(log.Logger.GetLevel()),
-				IgnoreRecordNotFoundError: true,
-				Colorful:                  config.Get().Logging.Color,
-				zeroLogger:                log.Logger,
+				SlowThreshold:              config.Get().Database.SlowQueryDuration,
+				LogLevel:                   zeroLogToGormLevel(config.DBLevel()),
+				IgnoreRecordNotFoundError:  true,
+				IgnoreContextCanceledError: true,
+				Colorful:                   config.Get().Logging.Color,
+				zeroLogger:                 log.Logger,
 			},
 		),
 	})

--- a/pkg/db/db_logger.go
+++ b/pkg/db/db_logger.go
@@ -35,12 +35,13 @@ const (
 
 // Config logger config
 type DBLogConfig struct {
-	SlowThreshold             time.Duration
-	Colorful                  bool
-	IgnoreRecordNotFoundError bool
-	ParameterizedQueries      bool
-	LogLevel                  logger.LogLevel
-	zeroLogger                zerolog.Logger
+	SlowThreshold              time.Duration
+	Colorful                   bool
+	IgnoreRecordNotFoundError  bool
+	IgnoreContextCanceledError bool
+	ParameterizedQueries       bool
+	LogLevel                   logger.LogLevel
+	zeroLogger                 zerolog.Logger
 }
 
 // Implements logger.Interface
@@ -140,7 +141,7 @@ func (l *dbLogger) Trace(ctx context.Context, begin time.Time, fc func() (string
 
 	elapsed := time.Since(begin)
 	switch {
-	case err != nil && l.LogLevel >= logger.Error && (!errors.Is(err, gorm.ErrRecordNotFound) || !l.IgnoreRecordNotFoundError):
+	case err != nil && l.LogLevel >= logger.Error && (!errors.Is(err, gorm.ErrRecordNotFound) || !l.IgnoreRecordNotFoundError) && (!errors.Is(err, context.Canceled) || !l.IgnoreContextCanceledError):
 		sql, rows := fc()
 		if rows == -1 {
 			l.Error(ctx, l.traceErrStr, utils.FileWithLineNum(), err, float64(elapsed.Nanoseconds())/1e6, "-", sql)


### PR DESCRIPTION
## Summary
- Makes the DB log level optionally configurable because the number of logs is freezing up my laptop
- Gorm now ignores "context canceled" error logs 

## Testing steps
1. Use this to test the context canceling. It lists repositories and the cancels it quickly: https://gist.github.com/rverdile/646a8576d3919f18ab1998f7cb2682cd
2. Without this PR, gorm will log the context is canceled
3. Change the db_level option under logging to change it from the global logging level
