### PR TITLE
HMS-8735: only fetch appstreams roadmap once per req

### DIFF
--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -248,6 +248,12 @@ func (r *rpmDaoImpl) addPackageSources(ctx context.Context, rpmResponse []api.Se
 	}
 
 	var unmatchedRPMs []string
+
+	appstreams, _, err := r.roadmapClient.GetAppstreams(ctx)
+	if err != nil {
+		return err
+	}
+
 	for i, rpm := range rpmResponse {
 		var packageSources []api.PackageSourcesResponse
 		var pkgStreamFound bool
@@ -268,12 +274,12 @@ func (r *rpmDaoImpl) addPackageSources(ctx context.Context, rpmResponse []api.Se
 			}
 		}
 
-		packageSources, pkgStreamFound, err = r.addRoadmapPackageStreams(ctx, rpm, packageSources)
+		packageSources, pkgStreamFound, err = r.addRoadmapPackageStreams(appstreams, rpm, packageSources)
 		if err != nil {
 			return err
 		}
 
-		packageSources, moduleStreamFound, err = r.addRoadmapModuleStreams(ctx, packageSources)
+		packageSources, moduleStreamFound, err = r.addRoadmapModuleStreams(appstreams, packageSources)
 		if err != nil {
 			return err
 		}
@@ -304,14 +310,9 @@ func (r *rpmDaoImpl) addPackageSources(ctx context.Context, rpmResponse []api.Se
 
 // addRoadmapPackageStreams calls the roadmap API to add the package streams associated to the given RPM to packageSources. Also adds
 // the lifecycle start_date and end_date
-func (r *rpmDaoImpl) addRoadmapPackageStreams(ctx context.Context, rpm api.SearchRpmResponse, packageSources []api.PackageSourcesResponse) ([]api.PackageSourcesResponse, bool, error) {
+func (r *rpmDaoImpl) addRoadmapPackageStreams(appstreams roadmap_client.AppstreamsResponse, rpm api.SearchRpmResponse, packageSources []api.PackageSourcesResponse) ([]api.PackageSourcesResponse, bool, error) {
 	if !config.RoadmapConfigured() {
 		return packageSources, false, nil
-	}
-
-	appstreams, _, err := r.roadmapClient.GetAppstreams(ctx)
-	if err != nil {
-		return packageSources, false, err
 	}
 
 	var streamFound bool
@@ -335,14 +336,9 @@ func (r *rpmDaoImpl) addRoadmapPackageStreams(ctx context.Context, rpm api.Searc
 
 // addRoadmapModuleStreams calls the roadmap API to add the module stream lifecycle information to the module
 // streams in packageSources
-func (r *rpmDaoImpl) addRoadmapModuleStreams(ctx context.Context, packageSources []api.PackageSourcesResponse) ([]api.PackageSourcesResponse, bool, error) {
+func (r *rpmDaoImpl) addRoadmapModuleStreams(appstreams roadmap_client.AppstreamsResponse, packageSources []api.PackageSourcesResponse) ([]api.PackageSourcesResponse, bool, error) {
 	if !config.RoadmapConfigured() {
 		return packageSources, false, nil
-	}
-
-	appstreams, _, err := r.roadmapClient.GetAppstreams(ctx)
-	if err != nil {
-		return packageSources, false, err
 	}
 
 	var streamFound bool


### PR DESCRIPTION
## Summary

A major source for slow package searches (especially when many packages are returned) is that we are fetching the appstream from cache twice for each package.  Each fetch is relatively small (4-5ms), but when this is done up to 100 times, it can quickly add up.  

This changes it to only fetch once for the whole request

## Testing steps

in config.yaml clients section add:

```
  roadmap:
    server: https://console.stage.redhat.com/api/roadmap/v1
    username: USERNAME
    password: PASSWORD
    proxy: STAGE_PROXY
```

Restart the server.

snaphot the rhel x86_64 repos

and perform a package search:
```
curl -X POST --location "http://localhost:8000/api/content-sources/v1.0/rpms/names" \
    -H "x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiIxIn0sImFjY291bnRfbnVtYmVyIjoiZm9vIiwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSJ9fX0K" \
    -H "x-Rh-Insights-Request-Id: 9d229d34-7219-405d-ba3d-8f99cf7c36ae" \
    -H "Content-Type: application/json" \
    -d '{"urls":["https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os","https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os"],
          "include_package_sources": true,
          "search":"n"}'
```

when passing 1 or two letters, the search is much slower without this change, but even with passing something like 'node', the difference is noticeable (30-40ms vs 80-130ms)
