### PR TITLE
HMS-9325: make client fixture respect test info headers

### DIFF
--- a/_playwright-tests/test-utils/src/fixtures/client.ts
+++ b/_playwright-tests/test-utils/src/fixtures/client.ts
@@ -20,7 +20,7 @@ const responseReader = {
 export const clientTest = oldTest.extend<WithApiConfig>({
   client:
     // eslint-disable-next-line no-empty-pattern
-    async ({}, use, r) => {
+    async ({ extraHTTPHeaders }, use, r) => {
       if (r.project?.use?.proxy?.server) {
         const dispatcher = new ProxyAgent({ uri: new URL(r.project.use.proxy.server).toString() });
         setGlobalDispatcher(dispatcher);
@@ -31,7 +31,7 @@ export const clientTest = oldTest.extend<WithApiConfig>({
 
       const client = new Configuration({
         basePath: r.project.use.baseURL + '/api/content-sources/v1',
-        headers: r.project.use.extraHTTPHeaders,
+        headers: extraHTTPHeaders ?? r.project.use.extraHTTPHeaders,
         middleware: [responseReader],
       });
 


### PR DESCRIPTION
## Summary
This makes the Playwright client fixture inside of test-utils respect the 'extraHTTPHeaders' passed in from the TestInfo. That will enable setting test wide headers for specific users, which will be helpful for API integration tests.

## Testing steps
Tests pass. 
_This was tested manually with integration tests in our frontend repo. If you wanted to the same, pull the changes from this PR into test-utils in the FE repo and in integration tests that use the client, you should be able to set the `extraHTTPHeaders` for the whole test, as we do it in other tests._
