### PR TITLE
HMS-8907: migrate test_create_validation

### DIFF
--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -321,6 +321,7 @@ func (suite *RepositoryConfigSuite) TestRepositoryUrlInvalid() {
 
 	invalidURL := "hey/there!"
 	invalidURL2 := "golang.org"
+	invalidURL3 := "go lang.org"
 	name := "name"
 	OrgID := seeds.RandomOrgId()
 
@@ -344,6 +345,14 @@ func (suite *RepositoryConfigSuite) TestRepositoryUrlInvalid() {
 				OrgID: &OrgID,
 			},
 			expected: "Invalid URL for request",
+		},
+		{
+			given: api.RepositoryRequest{
+				Name:  &name,
+				URL:   &invalidURL3,
+				OrgID: &OrgID,
+			},
+			expected: "URL cannot contain whitespace.",
 		},
 	}
 	tx.SavePoint("testrepositorycreateinvalidtest")


### PR DESCRIPTION
## Summary

Add URL whitespace validation
[HMS-8907 migrate test_create_validation](https://issues.redhat.com/browse/HMS-8907)

## Testing steps
tests pass 

Note: Although the original IQE test (link in Jira) was an API test I was asked many months ago to move input validation checks to unit tests.

