### PR TITLE
HMS-5988: prevent creation of custom EPEL repo

### DIFF
--- a/_playwright-tests/tests/API/Repositories.spec.ts
+++ b/_playwright-tests/tests/API/Repositories.spec.ts
@@ -15,6 +15,7 @@ import {
   CreateSnapshotRequest,
   GetTaskRequest,
   ApiTaskInfoResponse,
+  FeaturesApi,
 } from 'test-utils/client';
 import {
   cleanupRepositories,
@@ -225,6 +226,12 @@ test.describe('Repositories', () => {
   });
 
   test('Add popular repository', async ({ client }) => {
+    const features = await new FeaturesApi(client).listFeatures();
+    test.skip(
+      !!features['communityrepos']?.enabled && !features['allowcustomepelcreation']?.enabled,
+      'Allow custom EPEL creation feature is not enabled, skipping test',
+    );
+
     let popularRepos: ApiPopularRepositoriesCollectionResponse;
     await test.step('List popular repositories', async () => {
       popularRepos = await new PopularRepositoriesApi(client).listPopularRepositories({

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -190,3 +190,5 @@ features:
     enabled: true
   kessel:
     enabled: false
+  allow_custom_epel_creation:
+    enabled: true

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -287,6 +287,12 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
               - name: FEATURES_COMMUNITY_REPOS_ENABLED
                 value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -1213,3 +1219,9 @@ parameters:
     default: ''
   - name: CLIENTS_KESSEL_AUTH_GRPC_INSECURE
     default: 'false'
+  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
+    description: Whether to allow custom EPEL repo creation
+  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
+    description: Organizations to allow custom EPEL repo creation for
+  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
+    description: Accounts to allow custom EPEL repo creation for

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,10 +73,11 @@ type MockKessel struct {
 	UserNoPermissions []string `mapstructure:"user_no_permissions"`
 }
 type FeatureSet struct {
-	Snapshots      Feature
-	AdminTasks     Feature `mapstructure:"admin_tasks"`
-	CommunityRepos Feature `mapstructure:"community_repos"`
-	Kessel         Feature `mapstructure:"kessel"`
+	Snapshots               Feature
+	AdminTasks              Feature `mapstructure:"admin_tasks"`
+	CommunityRepos          Feature `mapstructure:"community_repos"`
+	Kessel                  Feature `mapstructure:"kessel"`
+	AllowCustomEPELCreation Feature `mapstructure:"allow_custom_epel_creation"`
 }
 
 type Feature struct {
@@ -408,6 +409,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("features.kessel.accounts", nil)
 	v.SetDefault("features.kessel.organizations", nil)
 	v.SetDefault("features.kessel.users", nil)
+	v.SetDefault("features.allow_custom_epel_creation.enabled", true)
+	v.SetDefault("features.allow_custom_epel_creation.accounts", nil)
+	v.SetDefault("features.allow_custom_epel_creation.organizations", nil)
+	v.SetDefault("features.allow_custom_epel_creation.users", nil)
 
 	v.SetDefault("mocks.kessel.user_read_write", []string{"write-user"})
 	v.SetDefault("mocks.kessel.user_read", []string{"read-user"})

--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -43,6 +43,14 @@ const SnapshotForceInterval = 24 // In hours
 
 const FailedSnapshotLimit = 10 // Number of times to retry a snapshot before stopping
 
+const (
+	EPEL10Url = "https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"
+	EPEL9Url  = "https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/"
+	EPEL8Url  = "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/"
+)
+
+var EPELUrls = []string{EPEL10Url, EPEL9Url, EPEL8Url}
+
 type DistributionVersion struct {
 	Name  string `json:"name"`  // Human-readable form of the version
 	Label string `json:"label"` // Static label of the version

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -233,3 +233,30 @@ func (s *DaoSuite) createTestRedHatRepository(repo api.RepositoryRequest) api.Re
 
 	return repoResp
 }
+
+func (s *DaoSuite) createTestCommunityRepository(repo api.RepositoryRequest) api.RepositoryResponse {
+	t := s.T()
+	tx := s.tx
+
+	var modelRepoConfig models.RepositoryConfiguration
+	var modelRepository models.Repository
+	ApiFieldsToModel(repo, &modelRepoConfig, &modelRepository)
+
+	modelRepository.Origin = config.OriginCommunity
+	modelRepoConfig.OrgID = config.CommunityOrg
+	modelRepoConfig.Label = seeds.RandStringBytes(10)
+
+	err := tx.Create(&modelRepository).Error
+	assert.NoError(t, err)
+	modelRepoConfig.RepositoryUUID = modelRepository.UUID
+
+	err = tx.Create(&modelRepoConfig).Error
+	assert.NoError(t, err)
+
+	tx.Where("uuid = ?", modelRepoConfig.UUID).Preload("Repository").First(&modelRepoConfig)
+
+	var repoResp api.RepositoryResponse
+	ModelToApiFields(modelRepoConfig, &repoResp)
+
+	return repoResp
+}


### PR DESCRIPTION
## Summary

- Prevents creating custom EPEL repos
- If the `allow_custom_epel_creation` feature flag is true for some orgs, custom EPEL repos can be created by those

## Testing steps

1. Set `features.community_repos.enabled: true` and `features.allow_custom_epel_creation.enabled: false` in your config
2. Try to create an EPEL repo and a repo with `origin: community`. Both should fail with a 400
3. Do the same with the bulk create API. This should also fail with a 400
4. Add an org ID to the `features.allow_custom_epel_creation.organizations` field and flip `features.allow_custom_epel_creation.enabled`  to true
5. Request to create these repos with that org ID. The repos should be created (or fail with `Repository with this URL already belongs to organization` if you have one already)