### PR TITLE
HMS-6307: Snapshot Red Hat repos together during process-repos

### DIFF
--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const (
 	StatusValid       = "Valid"       // Repository introspected successfully
@@ -129,4 +132,12 @@ func ValidArchLabel(label string) bool {
 		}
 	}
 	return false
+}
+
+func SnapshotInterval(redHat bool) string {
+	if redHat {
+		return fmt.Sprintf("%v minutes", 45)
+	}
+	// 24 hours - 1. Subtract 1, as the next run will be more than 24 hours
+	return fmt.Sprintf("%v hours", 23)
 }


### PR DESCRIPTION
## Summary
Changes the functionality of the process-repos command:
 * snapshot all Red Hat repos every hour
 * snapshot failed Community Repos regardless of failed_snapshot_count

Also refactors the InternalOnly_ListReposToSnapshot method to modularize more of it and improve the readability

## Testing steps
1. Use this CLI cursor made to add tasks to repositories: https://gist.github.com/rverdile/5c4d43d1fba474bfdd24fea030d0dd6a
2. Create some combinations of custom, community, and red hat repositories with new, old, or failed tasks
3. run `make process-repos` 
4. Snapshots should be enqueued as expected based on the tasks you've created
5. For Red Hat repos specifically, if just one of the snapshots is older than 45 minutes, all Red Hat repos should be enqueued.
