### PR TITLE
Build: Only recompile the main binary on make run

### DIFF
--- a/mk/go-rules.mk
+++ b/mk/go-rules.mk
@@ -30,7 +30,7 @@ clean: ## Clean binaries and testbin generated
 	@[ ! -e "$(GO_OUTPUT)" ] || for item in cmd/*; do rm -vf "$(GO_OUTPUT)/$${item##cmd/}"; done
 
 .PHONY: run
-run: build ## Run the api & kafka consumer locally
+run: $(GO_OUTPUT)/content-sources ## Run the api & kafka consumer locally
 	"$(GO_OUTPUT)/content-sources" api consumer instrumentation mock_rbac
 
 .PHONY: process-repos


### PR DESCRIPTION
## Summary

After updating some code and re-running 'make run', the makefile would recompile every binary, which wasn't really necessary.  This limits it to only rebuilding content-sources.

## Testing steps

Modify some dao file or model
run 'make run'

look for:
```
go build  -o "/home/jlsherri/git/content-sources-backend/release/content-sources" "cmd/content-sources/main.go"
```

previously you'd see about ~5 of these.
