### PR TITLE
HMS-9391: remove skipping RBAC for users with admin privileges

### DIFF
--- a/pkg/rbac/client_wrapper.go
+++ b/pkg/rbac/client_wrapper.go
@@ -70,10 +70,6 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 	var cacheHit = false
 	logger := zerolog.Ctx(ctx)
 
-	if skipRbacCheck(ctx) {
-		return true, nil
-	}
-
 	if r.cache != nil {
 		acl, err = r.cache.GetAccessList(ctx)
 		cacheHit = err == nil
@@ -98,12 +94,4 @@ func (r *ClientWrapperImpl) Allowed(ctx context.Context, resource Resource, verb
 	}
 
 	return acl.IsAllowed(application, string(resource), string(verb)), nil
-}
-
-func skipRbacCheck(ctx context.Context) bool {
-	if identity.GetIdentity(ctx).Identity.User == nil {
-		return false
-	}
-
-	return identity.GetIdentity(ctx).Identity.User.OrgAdmin
 }

--- a/pkg/rbac/client_wrapper_test.go
+++ b/pkg/rbac/client_wrapper_test.go
@@ -77,17 +77,3 @@ func (s *RbacTestSuite) TestCachesWhenNotFoundAgain() {
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), allowed)
 }
-
-func (s *RbacTestSuite) TestOrgAdminSkip() {
-	ctx := context.Background()
-	mockIdentity := test_handler.MockIdentity
-	mockIdentity.Identity.User = &identity.User{
-		OrgAdmin: true,
-	}
-
-	ctx = identity.WithIdentity(ctx, mockIdentity)
-
-	allowed, err := s.rbac.Allowed(ctx, "repositories", "read")
-	assert.NoError(s.T(), err)
-	assert.True(s.T(), allowed)
-}

--- a/pkg/rbac/kessel.go
+++ b/pkg/rbac/kessel.go
@@ -29,11 +29,6 @@ func NewKesselClientWrapper() (ClientWrapper, error) {
 func (k *KesselClientWrapper) Allowed(ctx context.Context, resource Resource, verb Verb) (bool, error) {
 	logger := zerolog.Ctx(ctx)
 
-	// Skip RBAC check for org admins
-	if skipRbacCheck(ctx) {
-		return true, nil
-	}
-
 	// Get identity from context
 	id := identity.GetIdentity(ctx)
 	if id.Identity.User == nil && id.Identity.ServiceAccount == nil {


### PR DESCRIPTION
## Summary

Previously, if a user was an admin, RBAC was skipped.  
It was added as a work around for something that is no longer needed.  
The commit removes this behavior.

## Testing steps

- Test locally, enable RBAC in config.yaml.
- If you want for a user to get authorized, add their username under mocks.rbac in config.yaml under appropriate role.
- Perform a request to an endpoint.
- A user should not get authorized, even if they are an admin, if their username is not listed in mocks.rbac.

Note that redis is set up to keep identity headers for a certain period of time.
You might want to set it up in config.yaml under redis.expiration.rbac to use a short time frame.
I used a 1s setting (default is 1min).

