### PR TITLE
Build: add development helper make commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ If you have a virtual bridge interface (virbr0, started up by running `virt-mana
 make compose-up
 ```
 
+If you want to start containers without initializing any data:
+
+```sh
+make compose-run
+```
+
 ### Import RHEL 9 Repos
 
 ```sh
@@ -61,6 +67,12 @@ If you want less Red Hat repos:
 
 ```sh
 OPTIONS_REPOSITORY_IMPORT_FILTER=small make repos-import
+```
+
+This will import and snapshot repos needed for the minimal viable environment. Useful for running Playwright tests.
+
+```sh
+make repos-minimal
 ```
 
 ### Run the server!

--- a/mk/compose.mk
+++ b/mk/compose.mk
@@ -21,6 +21,12 @@ compose-up: $(GO_OUTPUT)/dbmigrate $(GO_OUTPUT)/candlepin ## Start up service de
 	@echo "Creating Topics"
 	make kafka-topics-create
 
+.PHONY: compose-run
+compose-run: ## Start up service container depdencies, without initial data migrations.
+	$(COMPOSE_COMMAND) up --detach
+	$(PULP_COMPOSE_COMMAND)
+	$(MAKE) .db-health-wait
+
 .PHONY: compose-down
 compose-down: ## Shut down service  depdencies using podman(docker)-compose
 	$(COMPOSE_COMMAND) down

--- a/mk/repos.mk
+++ b/mk/repos.mk
@@ -18,3 +18,10 @@ repos-import-rhel9: ## Import only rhel 9 repos
 .PHONY: repos-import-rhel10
 repos-import-rhel10: ## Import only rhel 10 repos
 	OPTIONS_REPOSITORY_IMPORT_FILTER=rhel10 go run ./cmd/external-repos/main.go import
+
+.PHONY: repos-minimal
+repos-minimal: ## Import and snapshot repos needed for a minimal setup, usefull for Playwright testing, currently: SMALL + EPEL10
+	OPTIONS_REPOSITORY_IMPORT_FILTER=small go run ./cmd/external-repos/main.go import
+	go run cmd/external-repos/main.go snapshot --url https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/ --force
+	OPTIONS_REPOSITORY_IMPORT_FILTER=epel10 go run ./cmd/external-repos/main.go import
+	go run cmd/external-repos/main.go snapshot --url https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/ --force


### PR DESCRIPTION
## Summary
This adds 2 new helper make commands.
- `make compose-run`, that starts the container dependencies without initializing any
- `make repos-mvp`, which will import 2 repos needed for a minimal local setup and force them to snapshot

## Testing steps
Verify those commands do what they should.
