### PR TITLE
HMS-10537: add none filter for extended release version

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -478,7 +478,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6)",
+                        "description": "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6). Use 'none' to filter repositories without extended release versions.",
                         "name": "extended_release_version",
                         "in": "query"
                     }
@@ -2954,7 +2954,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter templates by extended release version (e.g., 9.4)",
+                        "description": "Filter templates by extended release version (e.g., 9.4). Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions.",
                         "name": "extended_release_version",
                         "in": "query"
                     },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2717,7 +2717,7 @@
                         }
                     },
                     {
-                        "description": "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6)",
+                        "description": "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6). Use 'none' to filter repositories without extended release versions.",
                         "in": "query",
                         "name": "extended_release_version",
                         "schema": {
@@ -5934,7 +5934,7 @@
                         }
                     },
                     {
-                        "description": "Filter templates by extended release version (e.g., 9.4)",
+                        "description": "Filter templates by extended release version (e.g., 9.4). Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions.",
                         "in": "query",
                         "name": "extended_release_version",
                         "schema": {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,7 +35,7 @@ type FilterData struct {
 	Origin                 string `query:"origin" json:"origin"`                                     // Comma separated list of origins to filter on (e.g. external, red_hat, upload)
 	ContentType            string `query:"content_type" json:"content_type"`                         // Filter repositories by content type (e.g. rpm)
 	ExtendedRelease        string `query:"extended_release" json:"extended_release"`                 // Comma separated list of extended release types to filter on (eus, e4s)
-	ExtendedReleaseVersion string `query:"extended_release_version" json:"extended_release_version"` // Comma separated list of extended release versions to filter on (9.4, 9.6, etc.)
+	ExtendedReleaseVersion string `query:"extended_release_version" json:"extended_release_version"` // Comma separated list of extended release versions to filter on (9.4, 9.6, etc.). Use 'none' to filter repositories without extended release versions.
 }
 
 type ResponseMetadata struct {

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -78,7 +78,7 @@ type TemplateFilterData struct {
 	Arch                   string   `json:"arch"`                     // Filter templates by arch using an exact match.
 	Version                string   `json:"version"`                  // Filter templates by version using an exact match.
 	ExtendedRelease        string   `json:"extended_release"`         // Filter templates by extended release type. Supports comma-separated lists (e.g., 'eus,e4s'). Use 'none' to filter templates without extended release.
-	ExtendedReleaseVersion string   `json:"extended_release_version"` // Filter templates by extended release version. Supports comma-separated lists (e.g., '9.4,9.6').
+	ExtendedReleaseVersion string   `json:"extended_release_version"` // Filter templates by extended release version. Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions.
 	Search                 string   `json:"search"`                   // Search string based query to optionally filter on
 	RepositoryUUIDs        []string `json:"repository_uuids"`         // List templates that contain one or more of these Repositories
 	SnapshotUUIDs          []string `json:"snapshot_uuids"`           // List templates that contain one or more of these Snapshots

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -696,7 +696,11 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 
 	if filterData.ExtendedReleaseVersion != "" {
 		versions := strings.Split(filterData.ExtendedReleaseVersion, ",")
-		filteredDB = filteredDB.Where("repository_configurations.extended_release_version IN ?", versions)
+		if slices.Contains(versions, "none") {
+			filteredDB = filteredDB.Where("repository_configurations.extended_release_version IN ? OR repository_configurations.extended_release_version IS NULL OR repository_configurations.extended_release_version = ?", versions, "")
+		} else {
+			filteredDB = filteredDB.Where("repository_configurations.extended_release_version IN ?", versions)
+		}
 	}
 
 	return filteredDB, nil

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -2174,6 +2174,30 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, 1, len(response.Data))
 	assert.Equal(t, "Regular Repo", response.Data[0].Name)
+
+	// Test 8: Filter by extended_release_version=none
+	suite.mockPulpForListOrFetch(1)
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64", "RHEL-EUS-x86_64", "RHEL-E4S-x86_64"}, nil).Once()
+	filterData = api.FilterData{ExtendedReleaseVersion: "none", Origin: config.OriginExternal}
+	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, "Regular Repo", response.Data[0].Name)
+	assert.Equal(t, "", response.Data[0].ExtendedReleaseVersion)
+
+	// Test 9: Filter by extended_release_version=9.4,none - should return 9.4 repos and regular repo
+	suite.mockPulpForListOrFetch(1)
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64", "RHEL-EUS-x86_64", "RHEL-E4S-x86_64"}, nil).Once()
+	filterData = api.FilterData{ExtendedReleaseVersion: "9.4,none", Origin: config.OriginExternal}
+	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Equal(t, 3, len(response.Data))
+	// Should contain either 9.4 or empty string
+	for _, repo := range response.Data {
+		assert.Contains(t, []string{"9.4", ""}, repo.ExtendedReleaseVersion)
+	}
 }
 
 func (suite *RepositoryConfigSuite) TestListFilterStatus() {

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -411,7 +411,11 @@ func (t templateDaoImpl) filteredDbForList(orgID string, filteredDB *gorm.DB, fi
 	}
 	if filterData.ExtendedReleaseVersion != "" {
 		minorVersions := strings.Split(filterData.ExtendedReleaseVersion, ",")
-		filteredDB = filteredDB.Where("extended_release_version IN ?", minorVersions)
+		if slices.Contains(minorVersions, "none") {
+			filteredDB = filteredDB.Where("extended_release_version IN ? OR extended_release_version IS NULL OR extended_release_version = ?", minorVersions, "")
+		} else {
+			filteredDB = filteredDB.Where("extended_release_version IN ?", minorVersions)
+		}
 	}
 	if filterData.Search != "" {
 		containsSearch := "%" + filterData.Search + "%"

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -449,6 +449,26 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	assert.Len(s.T(), responses.Data, 2)
 	assert.Contains(s.T(), filter, responses.Data[0].ExtendedReleaseVersion)
 	assert.Contains(s.T(), filter, responses.Data[1].ExtendedReleaseVersion)
+
+	// Test filter by extended_release_version="none"
+	filterData = api.TemplateFilterData{ExtendedReleaseVersion: "none"}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(1), total)
+	assert.Len(s.T(), responses.Data, 1)
+	assert.Equal(s.T(), "", responses.Data[0].ExtendedReleaseVersion)
+
+	// Test filter by extended_release_version="9.4,none" - should return EUS template and standard template
+	filter = fmt.Sprintf("%s,%s", config.DistributionMinorVersions[4].Label, "none")
+	filterData = api.TemplateFilterData{ExtendedReleaseVersion: filter}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(2), total)
+	assert.Len(s.T(), responses.Data, 2)
+	// Should contain either 9.4 or empty string
+	expectedValues = fmt.Sprintf("%s,%s", config.DistributionMinorVersions[4].Label, "")
+	assert.Contains(s.T(), expectedValues, responses.Data[0].ExtendedReleaseVersion)
+	assert.Contains(s.T(), expectedValues, responses.Data[1].ExtendedReleaseVersion)
 }
 
 func (s *TemplateSuite) TestListFilterSearch() {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -99,7 +99,7 @@ func getAccountIdOrgId(c echo.Context) (string, string) {
 // @Param		 origin query string false "A comma separated list of origins to filter api response. Origins can include `red_hat` and `external`."
 // @Param		 content_type query string false "content type of a repository to filter on (rpm)"
 // @Param		 extended_release query string false "A comma separated list of extended release types to filter on (eus, e4s), or 'none' to filter out extended release repositories"
-// @Param		 extended_release_version query string false "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6)"
+// @Param		 extended_release_version query string false "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6). Use 'none' to filter repositories without extended release versions."
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.RepositoryCollectionResponse

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -129,7 +129,7 @@ func (th *TemplateHandler) fetch(c echo.Context) error {
 // @Param		 repository_uuids query string false "Filter templates by associated repositories using a comma separated list of repository UUIDs"
 // @Param		 snapshot_uuids query string false "Filter templates by associated snapshots using a comma separated list of snapshot UUIDs"
 // @Param        extended_release query string false "Filter templates by extended release type. Valid values: eus, e4s, eeus. Supports comma-separated lists (e.g., 'eus,e4s'). Use 'none' to filter templates without extended release."
-// @Param        extended_release_version query string false "Filter templates by extended release version (e.g., 9.4)"
+// @Param        extended_release_version query string false "Filter templates by extended release version (e.g., 9.4). Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions."
 // @Param		 sort_by query string false "Sort the response data based on specific parameters. Sort criteria can include `name`, `arch`, and `version`."
 // @Accept       json
 // @Produce      json


### PR DESCRIPTION
## Summary
Adds a "none" filter to extended release version so it is possible to filter by major version only

## Testing steps
1. Create a template with an extended release version and import an extended support repository
2. Filtering by `/templates?version=9&extended_release_version=none`. Should return only templates with major version 9 that are not extended support templates.
3. Filtering by `/repositories?distribution_version=9&extended_release_version=none` should return only repositories with major version 9 that are not extended release repositories.

