### PR TITLE
HMS-10539: run remove-custom-epel as cron

### DIFF
--- a/deployments/build/deployment.template.yaml
+++ b/deployments/build/deployment.template.yaml
@@ -252,6 +252,23 @@ objects:
               - transform-pulp-logs
             env:{{ENV_JOB_TRANSFORM_PULP_LOGS}}
 
+        - name: remove-custom-epel-repos
+          # https://crontab.guru/
+          schedule: ${REMOVE_CUSTOM_EPEL_CRON_JOB}
+          suspend: ${{SUSPEND_CRON_JOB}}
+          concurrencyPolicy: "Forbid"
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /jobs
+              - remove-custom-epel-repos
+              - "50"
+            env:{{ENV_VARS}}
+
         - name: hotfix-transform-pulp-logs-fix
           suspend: ${{SUSPEND_TRANSFORM_PULP_LOGS}}
           concurrencyPolicy: "Forbid"

--- a/deployments/build/env-variables.yaml
+++ b/deployments/build/env-variables.yaml
@@ -239,6 +239,8 @@ parameters:
     value: "0 0/1 * * *"
   - name: CLEANUP_CRON_JOB
     value: "0 */6 * * *"
+  - name: REMOVE_CUSTOM_EPEL_CRON_JOB
+    value: "0 */3 * * *"
   - name: SUSPEND_CRON_JOB
     value: "false"
   - name: IMAGE_TAG

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -1885,6 +1885,224 @@ objects:
                     name: ${FLOORIST_BUCKET_SECRET_NAME}
                     key: aws_region
 
+        - name: remove-custom-epel-repos
+          # https://crontab.guru/
+          schedule: ${REMOVE_CUSTOM_EPEL_CRON_JOB}
+          suspend: ${{SUSPEND_CRON_JOB}}
+          concurrencyPolicy: "Forbid"
+          podSpec:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            image: ${IMAGE}:${IMAGE_TAG}
+            inheritEnv: true
+            command:
+              - /jobs
+              - remove-custom-epel-repos
+              - "50"
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: RH_CDN_CERT_PAIR
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-certs
+                    key: cdn.redhat.com
+              - name: CLIENTS_PULP_SERVER
+                value: ${{CLIENTS_PULP_SERVER}}
+              - name: CLIENTS_PULP_CONTENT_ORIGIN
+                value: ${{CLIENTS_PULP_CONTENT_ORIGIN}}
+              - name: CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS
+                value: ${CLIENTS_PULP_CUSTOM_REPO_CONTENT_GUARDS}
+              - name: CLIENTS_PULP_GUARD_SUBJECT_DN
+                value: ${{CLIENTS_PULP_GUARD_SUBJECT_DN}}
+              - name: CLIENTS_PULP_DOWNLOAD_POLICY
+                value: ${{CLIENTS_PULP_DOWNLOAD_POLICY}}
+              - name: CLIENTS_PULP_USERNAME
+                value: ${{CLIENTS_PULP_USERNAME}}
+              - name: CLIENTS_PULP_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_PULP_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
+              - name: CLIENTS_PULP_PROXY
+                value: ${{CLIENTS_PULP_PROXY}}
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: CLIENTS_RBAC_BASE_URL
+                value: ${{CLIENTS_RBAC_BASE_URL}}
+              - name: OPTIONS_EXTERNAL_URL
+                value: ${OPTIONS_EXTERNAL_URL}
+              - name: FEATURES_SNAPSHOTS_ENABLED
+                value: ${FEATURES_SNAPSHOTS_ENABLED}
+              - name: FEATURES_SNAPSHOTS_ACCOUNTS
+                value: ${FEATURES_SNAPSHOTS_ACCOUNTS}
+              - name: FEATURES_SNAPSHOTS_ORGANIZATIONS
+                value: ${FEATURES_SNAPSHOTS_ORGANIZATIONS}
+              - name: FEATURES_ADMIN_TASKS_ENABLED
+                value: ${FEATURES_ADMIN_TASKS_ENABLED}
+              - name: FEATURES_ADMIN_TASKS_ACCOUNTS
+                value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
+              - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
+                value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
+              - name: FEATURES_COMMUNITY_REPOS_ENABLED
+                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
+              - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
+                value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
+              - name: OPTIONS_ENABLE_NOTIFICATIONS
+                value: ${OPTIONS_ENABLE_NOTIFICATIONS}
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-glitchtip
+                    key: dsn
+                    optional: true
+              - name: CLIENTS_PULP_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-content-sources-password
+                    key: password
+                    optional: true
+              - name: OPTIONS_REPOSITORY_IMPORT_FILTER
+                value: ${OPTIONS_REPOSITORY_IMPORT_FILTER}
+              - name: OPTIONS_FEATURE_FILTER
+                value: ${OPTIONS_FEATURE_FILTER}
+              - name: OPTIONS_ENTITLE_ALL
+                value: ${OPTIONS_ENTITLE_ALL}
+              - name: TASKING_WORKER_COUNT
+                value: ${TASKING_WORKER_COUNT}
+              - name: TASKING_POOL_LIMIT
+                value: ${TASKING_POOL_LIMIT}
+              - name: FEATURES_EXTENDED_RELEASE_REPOS_ENABLED
+                value: ${FEATURES_EXTENDED_RELEASE_REPOS_ENABLED}
+              - name: CLIENTS_PULP_DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-db
+                    key: db.host
+                    optional: false
+              - name: CLIENTS_PULP_DATABASE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-db
+                    key: db.port
+                    optional: false
+              - name: CLIENTS_PULP_DATABASE_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-db
+                    key: db.user
+                    optional: false
+              - name: CLIENTS_PULP_DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-db
+                    key: db.password
+                    optional: false
+              - name: CLIENTS_PULP_DATABASE_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: pulp-db
+                    key: db.name
+                    optional: false
+              - name: CLIENTS_CANDLEPIN_SERVER
+                value: ${CLIENTS_CANDLEPIN_SERVER}
+              - name: CLIENTS_CANDLEPIN_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
+              - name: CLIENTS_CANDLEPIN_CA_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: ca
+                    optional: true
+              - name: CLIENTS_FEATURE_SERVICE_SERVER
+                value: ${CLIENTS_FEATURE_SERVICE_SERVER}
+              - name: CLIENTS_FEATURE_SERVICE_CLIENT_CERT
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: cert
+                    optional: true
+              - name: CLIENTS_FEATURE_SERVICE_CLIENT_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-candlepin
+                    key: key
+                    optional: true
+              - name: CLIENTS_ROADMAP_SERVER
+                value: ${CLIENTS_ROADMAP_SERVER}
+              - name: FEATURES_KESSEL_ENABLED
+                value: ${FEATURES_KESSEL_ENABLED}
+              - name: FEATURES_KESSEL_ORGANIZATIONS
+                value: ${FEATURES_KESSEL_ORGANIZATIONS}
+              - name: FEATURES_KESSEL_ACCOUNTS
+                value: ${FEATURES_KESSEL_ACCOUNTS}
+              - name: CLIENTS_KESSEL_SERVER
+                value: ${CLIENTS_KESSEL_SERVER}
+              - name: CLIENTS_KESSEL_AUTH_ENABLED
+                value: ${CLIENTS_KESSEL_AUTH_ENABLED}
+              - name: CLIENTS_KESSEL_AUTH_GRPC_INSECURE
+                value: ${CLIENTS_KESSEL_AUTH_GRPC_INSECURE}
+              - name: CLIENTS_KESSEL_AUTH_OIDC_ISSUER
+                value: ${CLIENTS_KESSEL_AUTH_OIDC_ISSUER}
+              - name: CLIENTS_KESSEL_AUTH_CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-sso-service-account
+                    key: client_id
+                    optional: true
+              - name: CLIENTS_KESSEL_AUTH_CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-sso-service-account
+                    key: client_secret
+                    optional: true
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
+              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
+                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
+              - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
+                value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
+                value: ${CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_REGION
+                value: ${CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_REGION}
+              - name: CLIENTS_PULP_LOG_PARSER_S3_FILE_PREFIX
+                value: ${CLIENTS_PULP_LOG_PARSER_S3_FILE_PREFIX}
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-appsre-log-access-pulp
+                    key: aws_access_key_id
+                    optional: true
+              - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: content-sources-appsre-log-access-pulp
+                    key: aws_secret_access_key
+                    optional: true
+              - name: EPEL_ORG_ID_SKIP
+                value: ${EPEL_ORG_ID_SKIP}
+
         - name: hotfix-transform-pulp-logs-fix
           suspend: ${{SUSPEND_TRANSFORM_PULP_LOGS}}
           concurrencyPolicy: "Forbid"
@@ -3903,6 +4121,8 @@ parameters:
     value: 0 0/1 * * *
   - name: CLEANUP_CRON_JOB
     value: 0 */6 * * *
+  - name: REMOVE_CUSTOM_EPEL_CRON_JOB
+    value: 0 */3 * * *
   - name: SUSPEND_CRON_JOB
     value: 'false'
   - name: IMAGE_TAG

--- a/deployments/jobs-prod.yaml
+++ b/deployments/jobs-prod.yaml
@@ -68,16 +68,6 @@ objects:
     metadata:
       labels:
         app: content-sources-backend
-      name: remove-custom-epel-repos-2026-02-26
-    spec:
-      appName: content-sources-backend
-      jobs:
-        - remove-custom-epel-repos
-  - apiVersion: cloud.redhat.com/v1alpha1
-    kind: ClowdJobInvocation
-    metadata:
-      labels:
-        app: content-sources-backend
       name: cancel-tasks-2026-04-13
     spec:
       appName: content-sources-backend

--- a/deployments/jobs-stage.yaml
+++ b/deployments/jobs-stage.yaml
@@ -68,16 +68,6 @@ objects:
     metadata:
       labels:
         app: content-sources-backend
-      name: remove-custom-epel-repos-2026-04-06
-    spec:
-      appName: content-sources-backend
-      jobs:
-        - remove-custom-epel-repos
-  - apiVersion: cloud.redhat.com/v1alpha1
-    kind: ClowdJobInvocation
-    metadata:
-      labels:
-        app: content-sources-backend
       name: retry-failed-delete-snapshots-2026-04-06
     spec:
       appName: content-sources-backend

--- a/pkg/jobs/remove_custom_epel_repos.go
+++ b/pkg/jobs/remove_custom_epel_repos.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
@@ -14,7 +15,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func RemoveCustomEpelRepos(_ []string) {
+func RemoveCustomEpelRepos(args []string) {
+	batchSize := 50
+
+	if len(args) > 0 {
+		parsedBatchSize, err := strconv.Atoi(args[0])
+		if err != nil {
+			log.Fatal().Err(err).Msg("Invalid batch size parameter. Must be an integer.")
+		}
+		batchSize = parsedBatchSize
+	}
+
 	ctx := context.Background()
 
 	pgQueue, err := queue.NewPgQueue(ctx, db.GetUrl())
@@ -44,17 +55,15 @@ func RemoveCustomEpelRepos(_ []string) {
 		Where("repository_configurations.org_id NOT IN (?)", []string{config.CommunityOrg}).
 		Unscoped().
 		Preload("Repository")
-	res := query.Find(&reposToDelete)
+	res := query.Limit(batchSize).Find(&reposToDelete)
 	if res.Error != nil {
 		log.Fatal().Err(res.Error).Msg("failed to query custom EPEL repositories")
 	}
 
 	if len(reposToDelete) == 0 {
-		log.Info().Msg("No custom EPEL repositories found to delete")
+		log.Info().Int("batch_size", batchSize).Msg("No custom EPEL repositories found to delete")
 		return
 	}
-
-	log.Info().Msgf("Found %d custom EPEL repositories to delete", len(reposToDelete))
 
 	daoReg := dao.GetDaoRegistry(db.DB)
 
@@ -62,6 +71,17 @@ func RemoveCustomEpelRepos(_ []string) {
 		log.Warn().Msgf("Deleting custom EPEL repository UUID: %s, ORG_ID: %s, URL: %s, Name: %s, Origin: %s",
 			repo.UUID, repo.OrgID, repo.Repository.URL, repo.Name, repo.Repository.Origin)
 
+		deletionTaskIDs, err := daoReg.TaskInfo.FetchActiveTasks(ctx, repo.OrgID, repo.RepositoryUUID, config.DeleteRepositorySnapshotsTask)
+		if err != nil {
+			log.Error().Err(err).Msg("RemoveCustomEpelRepos: failed to check for existing deletion tasks")
+		}
+
+		if len(deletionTaskIDs) > 0 {
+			log.Info().Msgf("Skipping repository %s - deletion task already exists: %v", repo.UUID, deletionTaskIDs)
+			continue
+		}
+
+		// Cancel any active snapshot/introspect tasks
 		taskIDs, err := daoReg.TaskInfo.FetchActiveTasks(ctx, repo.OrgID, repo.RepositoryUUID, config.RepositorySnapshotTask, config.IntrospectTask)
 		if err != nil {
 			log.Error().Err(err).Msg("RemoveCustomEpelRepos: failed to fetch active tasks")
@@ -97,5 +117,5 @@ func RemoveCustomEpelRepos(_ []string) {
 		}
 	}
 
-	log.Info().Msgf("Successfully processed %d custom EPEL repositories for deletion", len(reposToDelete))
+	log.Info().Int("processed_count", len(reposToDelete)).Int("batch_size", batchSize).Msgf("Successfully processed %d custom EPEL repositories for deletion", len(reposToDelete))
 }


### PR DESCRIPTION
## Summary
Spreads removing the remaining custom epel repos to 8x a day, 50 at a time, so the tasking system does not get a huge backlog of deletion tasks.

## Testing steps
1. Create two custom epel repos
2. You can run `cmd/jobs/main.go remove-custom-epel-repos 2` just to make sure the batching works
3. This job has otherwise already run in stage/prod to success

