### PR TITLE
HMS-10534: support multi-filtering templates by version

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2918,7 +2918,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter templates by version.",
+                        "description": "Filter templates by version. Supports comma-separated lists (e.g. '8,9').",
                         "name": "version",
                         "in": "query"
                     },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5886,7 +5886,7 @@
                         }
                     },
                     {
-                        "description": "Filter templates by version.",
+                        "description": "Filter templates by version. Supports comma-separated lists (e.g. '8,9').",
                         "in": "query",
                         "name": "version",
                         "schema": {

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -76,7 +76,7 @@ func (r *TemplateCollectionResponse) SetMetadata(meta ResponseMetadata, links Li
 type TemplateFilterData struct {
 	Name                   string   `json:"name"`                     // Filter templates by name using an exact match.
 	Arch                   string   `json:"arch"`                     // Filter templates by arch using an exact match.
-	Version                string   `json:"version"`                  // Filter templates by version using an exact match.
+	Version                string   `json:"version"`                  // Filter templates by version. Supports comma-separated lists (e.g., '8,9').
 	ExtendedRelease        string   `json:"extended_release"`         // Filter templates by extended release type. Supports comma-separated lists (e.g., 'eus,e4s'). Use 'none' to filter templates without extended release.
 	ExtendedReleaseVersion string   `json:"extended_release_version"` // Filter templates by extended release version. Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions.
 	Search                 string   `json:"search"`                   // Search string based query to optionally filter on

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -398,7 +398,8 @@ func (t templateDaoImpl) filteredDbForList(orgID string, filteredDB *gorm.DB, fi
 		filteredDB = filteredDB.Where("arch = ?", filterData.Arch)
 	}
 	if filterData.Version != "" {
-		filteredDB = filteredDB.Where("version = ?", filterData.Version)
+		versions := strings.Split(filterData.Version, ",")
+		filteredDB = filteredDB.Where("version IN ?", versions)
 	}
 	if filterData.ExtendedRelease != "" {
 		streams := strings.Split(filterData.ExtendedRelease, ",")

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -338,6 +338,15 @@ func (s *TemplateSuite) TestListFilters() {
 	assert.Len(s.T(), responses.Data, 1)
 	assert.Equal(s.T(), found[0].Version, responses.Data[0].Version)
 
+	filter := fmt.Sprintf("%s,%s", config.El7, config.El8)
+	filterData = api.TemplateFilterData{Version: filter}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(2), total)
+	assert.Len(s.T(), responses.Data, 2)
+	assert.Equal(s.T(), found[0].Version, responses.Data[0].Version)
+	assert.Equal(s.T(), found[1].Version, responses.Data[1].Version)
+
 	// Test filter by arch
 	filterData = api.TemplateFilterData{Arch: found[0].Arch}
 	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -123,7 +123,7 @@ func (th *TemplateHandler) fetch(c echo.Context) error {
 // @Param		 search query string false "Term to filter and retrieve items that match the specified search criteria. Search term can include name."
 // @Param		 offset query int false "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`."
 // @Param		 limit query int false "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`."
-// @Param		 version query string false "Filter templates by version."
+// @Param		 version query string false "Filter templates by version. Supports comma-separated lists (e.g. '8,9')."
 // @Param		 arch query string false "Filter templates by architecture."
 // @Param		 name query string false "Filter templates by name."
 // @Param		 repository_uuids query string false "Filter templates by associated repositories using a comma separated list of repository UUIDs"


### PR DESCRIPTION
## Summary

Adds support for filtering templates by multiple major versions

## Testing steps

1. Create templates with different versions
2. Filtering by multiple versions should work (e.g. `GET /templates/?version=8,9&extended_release_version=none`)