### PR TITLE
HMS-10346: Add support CSV list of repo features

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4323,7 +4323,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "feature_name": {
-                    "description": "The feature name this repo requires",
+                    "description": "Comma-separated Red Hat feature names; entitlement or import matches if any token applies",
                     "type": "string"
                 },
                 "gpg_key": {
@@ -4630,7 +4630,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "feature_name": {
-                    "description": "The feature name this repo requires",
+                    "description": "Comma-separated Red Hat feature names; entitlement or import matches if any token applies",
                     "type": "string"
                 },
                 "gpg_key": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -615,7 +615,7 @@
                         "type": "integer"
                     },
                     "feature_name": {
-                        "description": "The feature name this repo requires",
+                        "description": "Comma-separated Red Hat feature names; entitlement or import matches if any token applies",
                         "type": "string"
                     },
                     "gpg_key": {
@@ -922,7 +922,7 @@
                         "type": "integer"
                     },
                     "feature_name": {
-                        "description": "The feature name this repo requires",
+                        "description": "Comma-separated Red Hat feature names; entitlement or import matches if any token applies",
                         "type": "string"
                     },
                     "gpg_key": {

--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -36,7 +36,7 @@ type RepositoryResponse struct {
 	LastSnapshotTaskUUID         string            `json:"last_snapshot_task_uuid,omitempty"`   // UUID of the last snapshot task
 	LastSnapshotTask             *TaskInfoResponse `json:"last_snapshot_task,omitempty"`        // Last snapshot task response (contains last snapshot status)
 	LatestSnapshotURL            string            `json:"latest_snapshot_url,omitempty"`       // Latest URL for the snapshot distribution
-	FeatureName                  string            `json:"feature_name,omitempty"`              // The feature name this repo requires
+	FeatureName                  string            `json:"feature_name,omitempty"`              // Comma-separated Red Hat feature names; entitlement or import matches if any token applies
 	ExtendedRelease              string            `json:"extended_release,omitempty"`          // Extended release type (eus, e4s)
 	ExtendedReleaseVersion       string            `json:"extended_release_version,omitempty"`  // Extended release version (9.4, 9.6, etc.)
 }

--- a/pkg/clients/pulp_client/content_guard.go
+++ b/pkg/clients/pulp_client/content_guard.go
@@ -3,7 +3,8 @@ package pulp_client
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"slices"
+	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/config"
@@ -19,8 +20,12 @@ const TURNPIKE_JQ_FILTER = ".identity.x509.subject_dn"
 
 const COMPOSITE_GUARD_NAME = "composite_guard"
 
-func rhelCompositeGuardName(featureName string) string {
-	return fmt.Sprintf("rhel_composite_%s", featureName)
+func rhelCompositeGuardName(features []string) string {
+	return "rhel_composite_" + strings.Join(features, "_")
+}
+
+func featureGuardPulpName(features []string) string {
+	return "feature_" + strings.Join(features, "_")
 }
 
 func (r pulpDaoImpl) CreateOrUpdateGuardsForOrg(ctx context.Context, orgId string) (string, error) {
@@ -41,20 +46,24 @@ func (r pulpDaoImpl) CreateOrUpdateGuardsForOrg(ctx context.Context, orgId strin
 }
 
 func (r pulpDaoImpl) CreateOrUpdateGuardsForRhelRepo(ctx context.Context, featureName string) (string, error) {
-	// First create/update/fetch the Feature Guard
-	FeatureHref, err := r.CreateOrUpdateFeatureGuard(ctx, featureName)
+	features := utils.ParseFeatures(featureName)
+	if len(features) == 0 {
+		return "", fmt.Errorf("feature name required for RHEL composite content guard")
+	}
+	guardHrefs := make([]string, 0, len(features)+1)
+	for _, f := range features {
+		href, err := r.CreateOrUpdateFeatureGuard(ctx, f)
+		if err != nil {
+			return "", err
+		}
+		guardHrefs = append(guardHrefs, href)
+	}
+	turnpikeHref, err := r.CreateOrUpdateTurnpikeGuard(ctx)
 	if err != nil {
 		return "", err
 	}
-	// Second create/update/fetch the guard for turnpike
-	TurnpikeHref, err := r.CreateOrUpdateTurnpikeGuard(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	// lastly join them together with the RHEL composite guard
-	CompositeHref, err := r.createOrUpdateRhelCompositeGuard(ctx, FeatureHref, TurnpikeHref, featureName)
-	return CompositeHref, err
+	guardHrefs = append(guardHrefs, turnpikeHref)
+	return r.createOrUpdateRhelCompositeGuard(ctx, guardHrefs, features)
 }
 
 func (r pulpDaoImpl) CreateOrUpdateOrgIdGuard(ctx context.Context, orgId string) (string, error) {
@@ -174,34 +183,44 @@ func (r pulpDaoImpl) createOrUpdateCompositeGuard(ctx context.Context, guard1hre
 }
 
 func (r pulpDaoImpl) createCompositeGuard(ctx context.Context, guard1 string, guard2 string) (string, error) {
-	ctx, client, err := getZestClient(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	guard := zest.CompositeContentGuard{
-		Name:        COMPOSITE_GUARD_NAME,
-		Description: zest.NullableString{},
-		Guards:      []*string{utils.Ptr(guard1), utils.Ptr(guard2)},
-	}
-	response, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeCreate(ctx, r.domainName).
-		CompositeContentGuard(guard).Execute()
-	if httpResp != nil {
-		defer httpResp.Body.Close()
-	}
-	if err != nil {
-		return "", errorWithResponseBody("error creating composite guard", httpResp, err)
-	}
-	return *response.PulpHref, nil
+	return r.createNamedCompositeGuard(ctx, COMPOSITE_GUARD_NAME, []string{guard1, guard2})
 }
 
 func (r pulpDaoImpl) fetchCompositeContentGuard(ctx context.Context) (*zest.CompositeContentGuardResponse, error) {
+	return r.fetchNamedCompositeContentGuard(ctx, COMPOSITE_GUARD_NAME)
+}
+
+func (r pulpDaoImpl) fetchOrUpdateCompositeGuard(ctx context.Context, guard1 string, guard2 string) (string, error) {
+	return r.fetchOrUpdateNamedCompositeGuard(ctx, COMPOSITE_GUARD_NAME, []string{guard1, guard2})
+}
+
+func ptrStringsFromHrefs(hrefs []string) []*string {
+	out := make([]*string, len(hrefs))
+	for i := range hrefs {
+		out[i] = utils.Ptr(hrefs[i])
+	}
+	return out
+}
+
+func compositeChildHrefsEqual(existing []*string, want []string) bool {
+	if len(existing) != len(want) {
+		return false
+	}
+	for i, w := range want {
+		if existing[i] == nil || *existing[i] != w {
+			return false
+		}
+	}
+	return true
+}
+
+func (r pulpDaoImpl) fetchNamedCompositeContentGuard(ctx context.Context, name string) (*zest.CompositeContentGuardResponse, error) {
 	ctx, client, err := getZestClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeList(ctx, r.domainName).Name(COMPOSITE_GUARD_NAME).Execute()
+	resp, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeList(ctx, r.domainName).Name(name).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -215,20 +234,42 @@ func (r pulpDaoImpl) fetchCompositeContentGuard(ctx context.Context) (*zest.Comp
 	return &guard, nil
 }
 
-func (r pulpDaoImpl) fetchOrUpdateCompositeGuard(ctx context.Context, guard1 string, guard2 string) (string, error) {
+func (r pulpDaoImpl) createNamedCompositeGuard(ctx context.Context, name string, guardHrefs []string) (string, error) {
 	ctx, client, err := getZestClient(ctx)
 	if err != nil {
 		return "", err
 	}
-	guard, err := r.fetchCompositeContentGuard(ctx)
+
+	guard := zest.CompositeContentGuard{
+		Name:        name,
+		Description: zest.NullableString{},
+		Guards:      ptrStringsFromHrefs(guardHrefs),
+	}
+	response, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeCreate(ctx, r.domainName).
+		CompositeContentGuard(guard).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return "", errorWithResponseBody("error creating composite guard", httpResp, err)
+	}
+	return *response.PulpHref, nil
+}
+
+func (r pulpDaoImpl) fetchOrUpdateNamedCompositeGuard(ctx context.Context, name string, guardHrefs []string) (string, error) {
+	ctx, client, err := getZestClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	guard, err := r.fetchNamedCompositeContentGuard(ctx, name)
 	if err != nil {
 		return "", err
 	} else if guard == nil {
 		return "", nil
 	}
-	if len(guard.Guards) != 2 || guard.Guards[0] == nil || *guard.Guards[0] != guard1 || guard.Guards[1] == nil || *guard.Guards[1] != guard2 {
+	if !compositeChildHrefsEqual(guard.Guards, guardHrefs) {
 		update := zest.PatchedCompositeContentGuard{
-			Guards: []*string{utils.Ptr(guard1), utils.Ptr(guard2)},
+			Guards: ptrStringsFromHrefs(guardHrefs),
 		}
 		updateResp, updateHttpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositePartialUpdate(ctx, *guard.PulpHref).
 			PatchedCompositeContentGuard(update).Execute()
@@ -243,99 +284,32 @@ func (r pulpDaoImpl) fetchOrUpdateCompositeGuard(ctx context.Context, guard1 str
 	return *guard.PulpHref, nil
 }
 
-func (r pulpDaoImpl) createOrUpdateRhelCompositeGuard(ctx context.Context, guard1 string, guard2 string, featureName string) (string, error) {
-	pulpHref, err := r.fetchOrUpdateRhelCompositeGuard(ctx, guard1, guard2, featureName)
+func (r pulpDaoImpl) createOrUpdateNamedCompositeGuard(ctx context.Context, name string, guardHrefs []string) (string, error) {
+	pulpHref, err := r.fetchOrUpdateNamedCompositeGuard(ctx, name, guardHrefs)
 	if err != nil || pulpHref != "" {
 		return pulpHref, err
 	}
-	// guard doesn't exist, so create it
-	pulpHref, err = r.createRhelCompositeGuard(ctx, guard1, guard2, featureName)
+	pulpHref, err = r.createNamedCompositeGuard(ctx, name, guardHrefs)
 	if err != nil {
-		guard, _ := r.fetchRhelCompositeContentGuard(ctx, featureName)
+		guard, _ := r.fetchNamedCompositeContentGuard(ctx, name)
 		if guard == nil {
-			return "", fmt.Errorf("failed to create and fetch RHEL composite content guard for feature %s: %w", featureName, err)
+			return "", fmt.Errorf("failed to create and fetch composite content guard %q: %w", name, err)
 		}
 		return *guard.PulpHref, nil
 	}
 	return pulpHref, err
 }
 
-func (r pulpDaoImpl) createRhelCompositeGuard(ctx context.Context, guard1 string, guard2 string, featureName string) (string, error) {
-	ctx, client, err := getZestClient(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	guard := zest.CompositeContentGuard{
-		Name:        rhelCompositeGuardName(featureName),
-		Description: zest.NullableString{},
-		Guards:      []*string{utils.Ptr(guard1), utils.Ptr(guard2)},
-	}
-	response, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeCreate(ctx, r.domainName).
-		CompositeContentGuard(guard).Execute()
-	if httpResp != nil {
-		defer httpResp.Body.Close()
-	}
-	if err != nil {
-		return "", errorWithResponseBody("error creating RHEL composite guard", httpResp, err)
-	}
-	return *response.PulpHref, nil
+func (r pulpDaoImpl) createOrUpdateRhelCompositeGuard(ctx context.Context, guardHrefs []string, features []string) (string, error) {
+	return r.createOrUpdateNamedCompositeGuard(ctx, rhelCompositeGuardName(features), guardHrefs)
 }
 
-func (r pulpDaoImpl) fetchRhelCompositeContentGuard(ctx context.Context, featureName string) (*zest.CompositeContentGuardResponse, error) {
+func (r pulpDaoImpl) fetchFeatureGuard(ctx context.Context, features []string) (*zest.ServiceFeatureContentGuardResponse, error) {
 	ctx, client, err := getZestClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	resp, httpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositeList(ctx, r.domainName).Name(rhelCompositeGuardName(featureName)).Execute()
-	if httpResp != nil {
-		defer httpResp.Body.Close()
-	}
-	if err != nil {
-		return nil, errorWithResponseBody("error listing RHEL composite guards", httpResp, err)
-	}
-	if resp.Count == 0 || resp.Results[0].PulpHref == nil {
-		return nil, nil
-	}
-	guard := resp.Results[0]
-	return &guard, nil
-}
-
-func (r pulpDaoImpl) fetchOrUpdateRhelCompositeGuard(ctx context.Context, guard1 string, guard2 string, featureName string) (string, error) {
-	ctx, client, err := getZestClient(ctx)
-	if err != nil {
-		return "", err
-	}
-	guard, err := r.fetchRhelCompositeContentGuard(ctx, featureName)
-	if err != nil {
-		return "", err
-	} else if guard == nil {
-		return "", nil
-	}
-	if len(guard.Guards) != 2 || guard.Guards[0] == nil || *guard.Guards[0] != guard1 || guard.Guards[1] == nil || *guard.Guards[1] != guard2 {
-		update := zest.PatchedCompositeContentGuard{
-			Guards: []*string{utils.Ptr(guard1), utils.Ptr(guard2)},
-		}
-		updateResp, updateHttpResp, err := client.ContentguardsCompositeAPI.ContentguardsCoreCompositePartialUpdate(ctx, *guard.PulpHref).
-			PatchedCompositeContentGuard(update).Execute()
-		if updateHttpResp != nil {
-			defer updateHttpResp.Body.Close()
-		}
-		if err != nil {
-			return "", errorWithResponseBody("error updating RHEL composite guard", updateHttpResp, err)
-		}
-		return *updateResp.PulpHref, nil
-	}
-	return *guard.PulpHref, nil
-}
-
-func (r pulpDaoImpl) fetchFeatureGuard(ctx context.Context, featureName string) (*zest.ServiceFeatureContentGuardResponse, error) {
-	ctx, client, err := getZestClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resp, httpResp, err := client.ContentguardsFeatureAPI.ContentguardsServiceFeatureList(ctx, r.domainName).Name(featureGuardName(featureName)).Execute()
+	resp, httpResp, err := client.ContentguardsFeatureAPI.ContentguardsServiceFeatureList(ctx, r.domainName).Name(featureGuardPulpName(features)).Execute()
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -349,49 +323,59 @@ func (r pulpDaoImpl) fetchFeatureGuard(ctx context.Context, featureName string) 
 	return &guard, nil
 }
 
-func featureGuardName(featureName string) string {
-	return fmt.Sprintf("feature_%s", featureName)
-}
-
+// CreateOrUpdateFeatureGuard creates or updates one Pulp ServiceFeatureContentGuard for a single feature.
+// Pass one feature token (no comma-separated list); use CreateOrUpdateGuardsForRhelRepo for multiple features.
+// A ServiceFeatureContentGuard with multiple Features uses AND semantics in Pulp, so this API only ever sets one feature per guard.
 func (r pulpDaoImpl) CreateOrUpdateFeatureGuard(ctx context.Context, featureName string) (string, error) {
+	features := utils.ParseFeatures(featureName)
+	if len(features) == 0 {
+		return "", fmt.Errorf("empty feature name for content guard")
+	}
+	if len(features) != 1 {
+		return "", fmt.Errorf("CreateOrUpdateFeatureGuard expects a single feature name, got %d after parsing", len(features))
+	}
+	featureSlice := features
 	ctx, client, err := getZestClient(ctx)
 	if err != nil {
 		return "", err
 	}
-	guard, err := r.fetchFeatureGuard(ctx, featureName)
+	guard, err := r.fetchFeatureGuard(ctx, featureSlice)
 
 	filter := zest.NullableString{}
 	filter.Set(utils.Ptr(".identity.org_id"))
 
 	guardToCreate := zest.ServiceFeatureContentGuard{
-		Name:       featureGuardName(featureName),
+		Name:       featureGuardPulpName(featureSlice),
 		HeaderName: api.IdentityHeader,
 		JqFilter:   filter,
-		Features:   []string{featureName},
+		Features:   featureSlice,
 	}
 
 	if err != nil {
 		return "", err
 	} else if guard != nil { // Already created check for differences
-		if guardToCreate.HeaderName != guard.HeaderName || guardToCreate.JqFilter != guard.JqFilter || !reflect.DeepEqual(guardToCreate.Features, guard.Features) {
+		guardFeat := append([]string(nil), guard.Features...)
+		slices.Sort(guardFeat)
+		wantFeat := append([]string(nil), guardToCreate.Features...)
+		slices.Sort(wantFeat)
+		if guardToCreate.HeaderName != guard.HeaderName || guardToCreate.JqFilter != guard.JqFilter || !slices.Equal(wantFeat, guardFeat) {
 			resp, httpResp, err := client.ContentguardsFeatureAPI.ContentguardsServiceFeatureUpdate(ctx, *guard.PulpHref).ServiceFeatureContentGuard(guardToCreate).Execute()
 			if httpResp != nil {
 				defer httpResp.Body.Close()
-				if err != nil {
-					return "", errorWithResponseBody("error updating feature guard", httpResp, err)
-				}
-				return *resp.PulpHref, nil
 			}
+			if err != nil {
+				return "", errorWithResponseBody("error updating feature guard", httpResp, err)
+			}
+			return *resp.PulpHref, nil
 		}
 		return *guard.PulpHref, nil
-	} else { // create it
-		resp, httpResp, err := client.ContentguardsFeatureAPI.ContentguardsServiceFeatureCreate(ctx, r.domainName).ServiceFeatureContentGuard(guardToCreate).Execute()
-		if httpResp != nil {
-			defer httpResp.Body.Close()
-		}
-		if err != nil {
-			return "", errorWithResponseBody("error creating feature guard", httpResp, err)
-		}
-		return *resp.PulpHref, nil
 	}
+	resp, httpResp, err := client.ContentguardsFeatureAPI.ContentguardsServiceFeatureCreate(ctx, r.domainName).ServiceFeatureContentGuard(guardToCreate).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return "", errorWithResponseBody("error creating feature guard", httpResp, err)
+	}
+	return *resp.PulpHref, nil
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -704,7 +704,15 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 		filteredDB = filteredDB.Where(filterChain)
 	}
 
-	filteredDB = filteredDB.Where("repository_configurations.feature_name IN ? OR repository_configurations.feature_name IS NULL", accessibleFeatures)
+	filteredDB = filteredDB.Where(`(
+		repository_configurations.feature_name IS NULL
+		OR btrim(repository_configurations.feature_name) = ''
+		OR EXISTS (
+			SELECT 1
+			FROM unnest(string_to_array(repository_configurations.feature_name, ',')) AS t(token)
+			WHERE btrim(t.token) IN ?
+		)
+	)`, accessibleFeatures)
 
 	if filterData.ExtendedRelease == "none" {
 		filteredDB = filteredDB.Where("repository_configurations.extended_release IS NULL")

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -2246,6 +2246,38 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	assert.Equal(t, "9.6", response.Data[3].ExtendedReleaseVersion)
 }
 
+func (suite *RepositoryConfigSuite) TestListE4SEntitlementGrantsEEUSFeatureRepos() {
+	t := suite.T()
+	tx := suite.tx
+	orgID := seeds.RandomOrgId()
+
+	repoRow := models.Repository{URL: "https://eeus-overlap.example.com"}
+	err := tx.Create(&repoRow).Error
+	require.NoError(t, err)
+
+	err = tx.Create(&models.RepositoryConfiguration{
+		Name:            "EEUS repo (E4S entitlement overlap)",
+		OrgID:           orgID,
+		RepositoryUUID:  repoRow.UUID,
+		Arch:            config.X8664,
+		Versions:        pq.StringArray{config.El10},
+		ExtendedRelease: config.EEUS,
+		FeatureName:     "RHEL-EEUS-x86_64,RHEL-E4S-x86_64",
+	}).Error
+	require.NoError(t, err)
+
+	repoConfigDao := GetRepositoryConfigDao(tx, suite.mockPulpClient, suite.mockFsClient)
+	pageData := api.PaginationData{Limit: 20, Offset: 0}
+	suite.mockPulpForListOrFetch(1)
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64", "RHEL-E4S-x86_64"}, nil).Once()
+
+	response, total, err := repoConfigDao.List(context.Background(), orgID, pageData, api.FilterData{Origin: config.OriginExternal})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, response.Data, 1)
+	assert.Equal(t, "RHEL-EEUS-x86_64,RHEL-E4S-x86_64", response.Data[0].FeatureName)
+}
+
 func (suite *RepositoryConfigSuite) TestListFilterStatus() {
 	t := suite.T()
 	orgID := seeds.RandomOrgId()

--- a/pkg/external_repos/snapshotted_repos/eeus-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eeus-x86_64.json
@@ -5,7 +5,7 @@
         "url": "https://cdn.redhat.com/content/e4s/rhel10/10.0/x86_64/appstream/os",
         "distribution_arch": "x86_64",
         "distribution_version": "10",
-        "feature_name": "RHEL-EEUS-x86_64",
+        "feature_name": "RHEL-EEUS-x86_64,RHEL-E4S-x86_64",
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"
@@ -16,7 +16,7 @@
         "url": "https://cdn.redhat.com/content/e4s/rhel10/10.0/x86_64/baseos/os",
         "distribution_arch": "x86_64",
         "distribution_version": "10",
-        "feature_name": "RHEL-EEUS-x86_64",
+        "feature_name": "RHEL-EEUS-x86_64,RHEL-E4S-x86_64",
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"

--- a/pkg/external_repos/snapshotted_repos_importer.go
+++ b/pkg/external_repos/snapshotted_repos_importer.go
@@ -49,7 +49,7 @@ type SnapshottedRepo struct {
 	Selector               string `json:"selector"`
 	GpgKey                 string `json:"gpg_key"`
 	Label                  string `json:"content_label"`
-	FeatureName            string `json:"feature_name"`
+	FeatureName            string `json:"feature_name"` // Comma-separated Red Hat feature names (any satisfies import filter / entitlement)
 	Origin                 string `json:"origin"`
 	ExtendedRelease        string `json:"extended_release"`
 	ExtendedReleaseVersion string `json:"extended_release_version"`
@@ -186,13 +186,13 @@ func (rhr *SnapshotRepoImporter) loadFromFile(filename string) ([]SnapshottedRep
 	filteredRepos := []SnapshottedRepo{}
 	filter := config.Get().Options.RepositoryImportFilter
 	filters := strings.Split(filter, ",")
-	features := config.Get().Options.FeatureFilter
+	features := append([]string(nil), config.Get().Options.FeatureFilter...)
 	features = append(features, "RHEL-OS-x86_64")
 	for _, repo := range repos {
 		selectors := strings.Split(repo.Selector, ",")
 		if filter == "" || utils.ContainsAny(filters, selectors) {
-			// If the repo is not from Red Hat or if it matches one of the features, include it
-			if repo.Origin != config.OriginRedHat || utils.Contains(features, repo.FeatureName) {
+			// If the repo is not from Red Hat or if it matches one of the feature tokens, include it
+			if repo.Origin != config.OriginRedHat || utils.AnyFeatureMatch(repo.FeatureName, features) {
 				filteredRepos = append(filteredRepos, repo)
 			}
 		}

--- a/pkg/external_repos/snapshotted_repos_importer_test.go
+++ b/pkg/external_repos/snapshotted_repos_importer_test.go
@@ -175,6 +175,40 @@ func (s *SnapshotRepoImporterSuite) TestLoadFromFilesAssignsCorrectGpgKeys() {
 	assert.True(t, validated["10.0"], "Should have found and validated 10.0 repos")
 }
 
+// TestLoadFromFilesFeatureFilterE4SStillImportsEEUSRepos documents OR-style feature matching:
+// eeus-x86_64.json repos list both RHEL-EEUS-x86_64 and RHEL-E4S-x86_64 in feature_name, so a
+// filter that only includes E4S must still load those EEUS stream repos.
+func (s *SnapshotRepoImporterSuite) TestLoadFromFilesFeatureFilterE4SStillImportsEEUSRepos() {
+	t := s.T()
+
+	originalExtended := config.Get().Features.ExtendedReleaseRepos.Enabled
+	originalFeatureFilter := config.Get().Options.FeatureFilter
+	defer func() {
+		config.Get().Features.ExtendedReleaseRepos.Enabled = originalExtended
+		config.Get().Options.FeatureFilter = originalFeatureFilter
+	}()
+
+	config.Get().Features.ExtendedReleaseRepos.Enabled = true
+	config.Get().Options.FeatureFilter = []string{"RHEL-E4S-x86_64"}
+
+	importer := SnapshotRepoImporter{}
+	repos, err := importer.loadFromFiles()
+	assert.NoError(t, err)
+
+	var eeusX86 []SnapshottedRepo
+	for _, r := range repos {
+		if r.Origin == config.OriginRedHat && r.ExtendedRelease == "eeus" && r.DistributionArch == "x86_64" {
+			eeusX86 = append(eeusX86, r)
+		}
+	}
+	assert.NotEmpty(t, eeusX86,
+		"EEUS x86_64 repos should import when FeatureFilter is E4S-only because feature_name lists both EEUS and E4S")
+	for _, r := range eeusX86 {
+		assert.Contains(t, r.FeatureName, "RHEL-EEUS-x86_64")
+		assert.Contains(t, r.FeatureName, "RHEL-E4S-x86_64")
+	}
+}
+
 func readEmbeddedExtendedReleaseRepos(t *testing.T, filePath string) []SnapshottedRepo {
 	data, err := rhFS.ReadFile(filePath)
 	assert.Nil(t, err, fmt.Sprintf("Failed to read %s", filePath))

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -253,7 +253,7 @@ func (rh *RepositoryHandler) fetch(c echo.Context) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}
 
-	if response.OrgID == config.RedHatOrg && !utils.Contains(features, response.FeatureName) {
+	if response.OrgID == config.RedHatOrg && !utils.AnyFeatureMatch(response.FeatureName, features) {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", "Account does not have access to this repository")
 	}
 

--- a/pkg/models/repository_configuration.go
+++ b/pkg/models/repository_configuration.go
@@ -34,7 +34,7 @@ type RepositoryConfiguration struct {
 	LastSnapshotTaskUUID   string         `json:"last_snapshot_task_uuid" gorm:"default:null"`
 	LastSnapshotTask       *TaskInfo      `json:"last_snapshot_task" gorm:"foreignKey:last_snapshot_task_uuid"`
 	FailedSnapshotCount    int64          `json:"failed_snapshot_count" gorm:"default:0"`
-	FeatureName            string         `json:"feature_name" gorm:"default:null"`
+	FeatureName            string         `json:"feature_name" gorm:"default:null"` // Comma-separated; entitlement matches any token
 	ExtendedRelease        string         `json:"extended_release" gorm:"default:null"`
 	ExtendedReleaseVersion string         `json:"extended_release_version" gorm:"default:null"`
 }

--- a/pkg/tasks/candlepin_helpers.go
+++ b/pkg/tasks/candlepin_helpers.go
@@ -62,13 +62,16 @@ func UnneededOverrides(existingDtos []caliri.ContentOverrideDTO, expectedDTOs []
 	return toDelete
 }
 
-// genOverrideDTOs uses the RepoConfigUUIDs to query the db and generate a mapping of content labels to distribution URLs
-// for the snapshot within the template.  For all repos, we include an override for an 'empty' sslcacert, so it does not use the configured default
-// on the client.  For custom repos, we override the base URL, due to the fact that we use different domains for RH and custom repos.
-func GenOverrideDTO(ctx context.Context, daoReg *dao.DaoRegistry, orgId, domainName, rhDomainName, contentPath string, template api.TemplateResponse) ([]caliri.ContentOverrideDTO, error) {
+// GenOverrideDTO loads repository configs by UUID and returns Candlepin content override DTOs for the template snapshot (e.g. sslcacert, base URL).
+//
+// repoConfigUUIDs must be non-empty (UpdateTemplateContentHandler enforces this). Empty UUIDs would omit the List UUID filter and return unrelated repos.
+func GenOverrideDTO(ctx context.Context, daoReg *dao.DaoRegistry, orgId, domainName, rhDomainName, contentPath string, template api.TemplateResponse, repoConfigUUIDs []string) ([]caliri.ContentOverrideDTO, error) {
 	mapping := []caliri.ContentOverrideDTO{}
 
-	uuids := strings.Join(template.RepositoryUUIDS, ",")
+	uuids := strings.Join(repoConfigUUIDs, ",")
+	if uuids == "" {
+		return nil, fmt.Errorf("refusing to list repository configs for template %s: no repository config UUIDs (unfiltered list would include unrelated orgs)", template.UUID)
+	}
 	origins := strings.Join([]string{config.OriginExternal, config.OriginRedHat, config.OriginUpload, config.OriginCommunity}, ",")
 	repos, _, err := daoReg.RepositoryConfig.List(ctx, orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: origins})
 	if err != nil {

--- a/pkg/tasks/helpers/pulp_distribution_helper.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper.go
@@ -3,11 +3,11 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/utils"
 	zest "github.com/content-services/zest/release/v2026"
 )
 
@@ -163,7 +163,8 @@ func (pdh *PulpDistributionHelper) FetchContentGuard(orgId string, feature strin
 		return nil, nil
 	}
 	if orgId == config.RedHatOrg || orgId == config.CommunityOrg {
-		if !slices.Contains(config.SubscriptionFeaturesIgnored, feature) {
+		names := utils.ParseFeatures(feature)
+		if len(names) > 0 && !utils.AllStringsIn(names, config.SubscriptionFeaturesIgnored) {
 			href, err := pdh.pulpClient.CreateOrUpdateGuardsForRhelRepo(pdh.ctx, feature)
 			if err != nil {
 				return nil, fmt.Errorf("could not fetch/create/update RHEL composite content guard: %w", err)

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -46,7 +46,6 @@ func UpdateTemplateContentHandler(ctx context.Context, task *models.TaskInfo, qu
 	if err := json.Unmarshal(task.Payload, &opts); err != nil {
 		return fmt.Errorf("payload incorrect type for UpdateTemplateDistributions")
 	}
-
 	logger := LogForTask(task.Id.String(), task.Typename, task.RequestID)
 	ctxWithLogger := logger.WithContext(ctx)
 
@@ -55,6 +54,9 @@ func UpdateTemplateContentHandler(ctx context.Context, task *models.TaskInfo, qu
 	template, err := lookupTemplate(ctxWithLogger, daoReg, task.OrgId, opts.TemplateUUID)
 	if template == nil || err != nil {
 		return err
+	}
+	if len(opts.RepoConfigUUIDs) == 0 {
+		return fmt.Errorf("update template content: no repository config UUIDs in task payload (template %s)", opts.TemplateUUID)
 	}
 
 	domainName, err := daoReg.Domain.Fetch(ctxWithLogger, task.OrgId)
@@ -131,7 +133,7 @@ type UpdateTemplateContent struct {
 // when a template is created or updated. Each distribution is under a path that is based on the template uuid. It serves the latest snapshot content up to the
 // date set on the template.
 func (t *UpdateTemplateContent) RunPulp() error {
-	if t.payload.RepoConfigUUIDs == nil {
+	if len(t.payload.RepoConfigUUIDs) == 0 {
 		return nil
 	}
 
@@ -451,7 +453,7 @@ func (t *UpdateTemplateContent) RunCandlepin(env *caliri.EnvironmentDTO) error {
 		return err
 	}
 
-	overrideDtos, err := GenOverrideDTO(t.ctx, t.daoReg, t.orgId, t.domainName, t.rhDomainName, rhContentPath, t.template)
+	overrideDtos, err := GenOverrideDTO(t.ctx, t.daoReg, t.orgId, t.domainName, t.rhDomainName, rhContentPath, t.template, t.payload.RepoConfigUUIDs)
 	if err != nil {
 		return err
 	}
@@ -518,6 +520,9 @@ func (t *UpdateTemplateContent) demoteContent(repoConfigUUIDs []string) error {
 // Returns list of custom content to be created, a list of custom content IDs, a list of red hat content IDs, and an error.
 func (t *UpdateTemplateContent) getContentList() ([]caliri.ContentDTO, []string, []string, error) {
 	uuids := strings.Join(t.payload.RepoConfigUUIDs, ",")
+	if uuids == "" {
+		return nil, nil, nil, fmt.Errorf("update template content: no repository config uuids available for template %s", t.payload.TemplateUUID)
+	}
 	repoConfigs, _, err := t.daoReg.RepositoryConfig.List(t.ctx, t.orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: strings.Join([]string{config.OriginExternal, config.OriginUpload, config.OriginCommunity}, ",")})
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/utils/feature_names.go
+++ b/pkg/utils/feature_names.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"slices"
+	"strings"
+)
+
+// ParseFeatures parses feature names separated by comma or plus sign (both are
+// treated as delimiters; plus is only for readability (not to be used inside a
+// single feature name). Tokens are trimmed, empties dropped, deduplicated,
+// and sorted ascending for stable guard and comparison keys.
+func ParseFeatures(featureNames string) []string {
+	if featureNames == "" {
+		return nil
+	}
+	normalized := strings.ReplaceAll(featureNames, "+", ",")
+	parts := strings.Split(normalized, ",")
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// AnyFeatureMatch returns true if featureNames has no parsed tokens (no feature gate),
+// or if at least one parsed feature appears in list.
+func AnyFeatureMatch(featureNames string, list []string) bool {
+	names := ParseFeatures(featureNames)
+	if len(names) == 0 {
+		return true
+	}
+	for _, n := range names {
+		if slices.Contains(list, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/feature_names_test.go
+++ b/pkg/utils/feature_names_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFeatures(t *testing.T) {
+	assert.Nil(t, ParseFeatures(""))
+	assert.Equal(t, []string{"a", "b"}, ParseFeatures("a, b"))
+	// Underscores stay inside tokens; comma or plus separates (plus is for readability only).
+	assert.Equal(t, []string{"repo_feature_alpha_x86_64", "repo_feature_beta_x86_64"},
+		ParseFeatures("repo_feature_beta_x86_64 + repo_feature_alpha_x86_64"))
+	assert.Equal(t, []string{"repo_feature_alpha_x86_64", "repo_feature_beta_x86_64"},
+		ParseFeatures("repo_feature_alpha_x86_64, repo_feature_beta_x86_64"))
+	assert.Equal(t, []string{"RHEL-E4S-x86_64", "RHEL-EEUS-x86_64"},
+		ParseFeatures("RHEL-EEUS-x86_64,RHEL-E4S-x86_64"))
+	assert.Equal(t, []string{"RHEL-E4S-x86_64", "RHEL-EEUS-x86_64"},
+		ParseFeatures("RHEL-EEUS-x86_64,RHEL-E4S-x86_64,RHEL-EEUS-x86_64"))
+}
+
+func TestAnyFeatureMatch(t *testing.T) {
+	ent := []string{"RHEL-E4S-x86_64"}
+	assert.True(t, AnyFeatureMatch("RHEL-EEUS-x86_64,RHEL-E4S-x86_64", ent))
+	assert.True(t, AnyFeatureMatch("RHEL-EEUS-x86_64 + RHEL-E4S-x86_64", ent))
+	assert.False(t, AnyFeatureMatch("RHEL-EEUS-x86_64", ent))
+	assert.True(t, AnyFeatureMatch("", ent))
+
+	filter := []string{"RHEL-OS-x86_64", "RHEL-E4S-x86_64"}
+	assert.True(t, AnyFeatureMatch("RHEL-EEUS-x86_64,RHEL-E4S-x86_64", filter))
+	assert.False(t, AnyFeatureMatch("RHEL-EEUS-x86_64", filter))
+	assert.True(t, AnyFeatureMatch("", filter))
+
+	under := []string{"svc_feature_one_x86_64"}
+	assert.True(t, AnyFeatureMatch("svc_feature_one_x86_64 + svc_feature_two_x86_64", under))
+	assert.False(t, AnyFeatureMatch("svc_feature_two_x86_64", under))
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -68,6 +68,17 @@ func ContainsAny[T comparable](s1 []T, s2 []T) bool {
 	return false
 }
 
+// AllStringsIn returns true if every value in names is contained in list
+// (vacuously true if names is empty).
+func AllStringsIn(names, list []string) bool {
+	for _, n := range names {
+		if !Contains(list, n) {
+			return false
+		}
+	}
+	return true
+}
+
 // Deduplicate returns deduplicated slice from s
 func Deduplicate[T comparable](s []T) []T {
 	seen := make(map[T]struct{})


### PR DESCRIPTION
## Summary
HMS-10346 support feature filter with overlapping product IDs
 Feature filter can now handle comma separated list.
## Testing steps

On a running backend:

Set both of RHEL-EEUS-x86_64,RHEL-E4S-x86_64 in configs/config.yaml

run `make repos-import`

Expect to see two rows with:

```
    ---------------------|           feature_name           |                                                 
------------------------ | RHEL-EEUS-x86_64,RHEL-E4S-x86_64 | 
```


Set one of RHEL-EEUS-x86_64,RHEL-E4S-x86_64 in  in configs/config.yaml

Expect to see the same two rows.

