### PR TITLE
HMS-10325: allow minor and major versions in version filter

### DIFF
--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -147,3 +147,20 @@ func checkForValidSnapshotUuids(ctx context.Context, uuids []string, db *gorm.DB
 	}
 	return true, ""
 }
+
+func splitVersionFilters(values []string) (majors []string, minors []string) {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		if strings.Contains(value, ".") {
+			minors = append(minors, value)
+		} else {
+			majors = append(majors, value)
+		}
+	}
+
+	return majors, minors
+}

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/utils"
 	"github.com/content-services/yummy/pkg/yum"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -648,12 +649,24 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 	}
 
 	if filterData.Version != "" {
-		versions := strings.Split(filterData.Version, ",")
-		orGroup := r.db.Where("? = any (versions)", versions[0])
-		for i := 1; i < len(versions); i++ {
-			orGroup = orGroup.Or("? = any (versions)", versions[i])
+		versionFilters := strings.Split(filterData.Version, ",")
+		majorVersions, minorVersions := splitVersionFilters(versionFilters)
+
+		switch {
+		case len(majorVersions) > 0 && len(minorVersions) > 0:
+			filteredDB = filteredDB.Where(
+				"((versions && ? AND (extended_release_version IS NULL OR extended_release_version = '')) OR extended_release_version IN ?)",
+				pq.Array(majorVersions),
+				minorVersions,
+			)
+		case len(majorVersions) > 0:
+			filteredDB = filteredDB.Where(
+				"versions && ? AND (extended_release_version IS NULL OR extended_release_version = '')",
+				pq.Array(majorVersions),
+			)
+		case len(minorVersions) > 0:
+			filteredDB = filteredDB.Where("extended_release_version IN ?", minorVersions)
 		}
-		filteredDB = filteredDB.Where(orGroup)
 	}
 
 	if filterData.Status != "" {

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1866,9 +1866,15 @@ func (suite *RepositoryConfigSuite) TestListFilterUUIDs() {
 func (suite *RepositoryConfigSuite) TestListFilterVersion() {
 	t := suite.T()
 
+	var total int64
+	nonEUSQuantity := 20
+	EUSQuantity := 5
+	extendedRelease := config.EUS
+	extendedReleaseVersion := config.DistributionMinorVersions[4].Label //9.4
+
 	orgID := seeds.RandomOrgId()
 	pageData := api.PaginationData{
-		Limit:  20,
+		Limit:  nonEUSQuantity + EUSQuantity,
 		Offset: 0,
 		SortBy: "name:desc",
 	}
@@ -1879,26 +1885,51 @@ func (suite *RepositoryConfigSuite) TestListFilterVersion() {
 		Origin:  originCustom,
 	}
 
-	var total int64
-	quantity := 20
-
-	_, err := seeds.SeedRepositoryConfigurations(suite.tx, quantity, seeds.SeedOptions{OrgID: orgID, Versions: &[]string{config.El9}})
+	_, err := seeds.SeedRepositoryConfigurations(suite.tx, nonEUSQuantity, seeds.SeedOptions{OrgID: orgID, Versions: &[]string{config.El9}})
+	assert.Nil(t, err)
+	_, err = seeds.SeedRepositoryConfigurations(suite.tx, EUSQuantity, seeds.SeedOptions{OrgID: orgID, Versions: &[]string{config.El9}, ExtendedRelease: &extendedRelease, ExtendedReleaseVersion: &extendedReleaseVersion})
 	assert.Nil(t, err)
 
 	repoConfigDao := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient)
-	suite.mockPulpForListOrFetch(1)
-	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64"}, nil)
+	suite.mockPulpForListOrFetch(3)
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64", "RHEL-EUS-x86_64", "RHEL-E4S-x86_64"}, nil)
 
 	response, total, err := repoConfigDao.List(context.Background(), orgID, pageData, filterData)
 
 	assert.Nil(t, err)
-	assert.Equal(t, quantity, len(response.Data))
-	assert.Equal(t, quantity, int(total))
+	assert.Equal(t, nonEUSQuantity, len(response.Data))
+	assert.Equal(t, nonEUSQuantity, int(total))
 
 	// Asserts that list is sorted by name z-a
 	firstItem := strings.ToLower(response.Data[0].Name)
 	lastItem := strings.ToLower(response.Data[len(response.Data)-1].Name)
 	assert.True(t, firstItem > lastItem)
+
+	filterData = api.FilterData{
+		Search:  "",
+		Arch:    "",
+		Version: extendedReleaseVersion,
+		Origin:  originCustom,
+	}
+
+	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
+
+	assert.Nil(t, err)
+	assert.Equal(t, EUSQuantity, len(response.Data))
+	assert.Equal(t, EUSQuantity, int(total))
+
+	filterData = api.FilterData{
+		Search:  "",
+		Arch:    "",
+		Version: fmt.Sprintf("%v,%v", config.El9, extendedReleaseVersion),
+		Origin:  originCustom,
+	}
+
+	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
+
+	assert.Nil(t, err)
+	assert.Equal(t, EUSQuantity+nonEUSQuantity, len(response.Data))
+	assert.Equal(t, EUSQuantity+nonEUSQuantity, int(total))
 }
 
 func (suite *RepositoryConfigSuite) TestListFilterArch() {

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -397,10 +397,28 @@ func (t templateDaoImpl) filteredDbForList(orgID string, filteredDB *gorm.DB, fi
 	if filterData.Arch != "" {
 		filteredDB = filteredDB.Where("arch = ?", filterData.Arch)
 	}
+
 	if filterData.Version != "" {
-		versions := strings.Split(filterData.Version, ",")
-		filteredDB = filteredDB.Where("version IN ?", versions)
+		versionFilters := strings.Split(filterData.Version, ",")
+		majorVersions, minorVersions := splitVersionFilters(versionFilters)
+
+		switch {
+		case len(majorVersions) > 0 && len(minorVersions) > 0:
+			filteredDB = filteredDB.Where(
+				"((version IN ? AND (extended_release_version IS NULL OR extended_release_version = '')) OR extended_release_version IN ?)",
+				majorVersions,
+				minorVersions,
+			)
+		case len(majorVersions) > 0:
+			filteredDB = filteredDB.Where(
+				"version IN ? AND (extended_release_version IS NULL OR extended_release_version = '')",
+				majorVersions,
+			)
+		case len(minorVersions) > 0:
+			filteredDB = filteredDB.Where("extended_release_version IN ?", minorVersions)
+		}
 	}
+
 	if filterData.ExtendedRelease != "" {
 		streams := strings.Split(filterData.ExtendedRelease, ",")
 		if slices.Contains(streams, "none") {

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -318,9 +318,17 @@ func (s *TemplateSuite) TestListFilters() {
 	_, err = seeds.SeedTemplates(s.tx, 1, options)
 	assert.NoError(s.T(), err)
 
+	arch = config.X8664
+	version = config.El9
+	extendedRelease := config.EUS
+	extendedReleaseVersion := config.DistributionMinorVersions[4].Label
+	options = seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version, ExtendedRelease: &extendedRelease, ExtendedReleaseVersion: &extendedReleaseVersion}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
 	err = s.tx.Where("org_id = ?", orgIDTest).Find(&found).Count(&total).Error
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), int64(2), total)
+	assert.Equal(s.T(), int64(3), total)
 
 	// Test filter by name
 	filterData := api.TemplateFilterData{Name: found[0].Name}
@@ -331,12 +339,12 @@ func (s *TemplateSuite) TestListFilters() {
 	assert.Equal(s.T(), found[0].Name, responses.Data[0].Name)
 
 	// Test filter by version
-	filterData = api.TemplateFilterData{Version: found[0].Version}
+	filterData = api.TemplateFilterData{Version: config.El7}
 	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
-	assert.Equal(s.T(), found[0].Version, responses.Data[0].Version)
+	assert.Equal(s.T(), config.El7, responses.Data[0].Version)
 
 	filter := fmt.Sprintf("%s,%s", config.El7, config.El8)
 	filterData = api.TemplateFilterData{Version: filter}
@@ -344,16 +352,25 @@ func (s *TemplateSuite) TestListFilters() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
-	assert.Equal(s.T(), found[0].Version, responses.Data[0].Version)
-	assert.Equal(s.T(), found[1].Version, responses.Data[1].Version)
+	assert.True(s.T(), config.El7 == responses.Data[0].Version || config.El7 == responses.Data[1].Version)
+	assert.True(s.T(), config.El8 == responses.Data[0].Version || config.El8 == responses.Data[1].Version)
+
+	filter = fmt.Sprintf("%s,%s", config.El8, extendedReleaseVersion)
+	filterData = api.TemplateFilterData{Version: filter}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(2), total)
+	assert.Len(s.T(), responses.Data, 2)
+	assert.True(s.T(), config.El8 == responses.Data[0].Version || config.El8 == responses.Data[1].Version)
+	assert.True(s.T(), extendedReleaseVersion == responses.Data[0].ExtendedReleaseVersion || extendedReleaseVersion == responses.Data[1].ExtendedReleaseVersion)
 
 	// Test filter by arch
-	filterData = api.TemplateFilterData{Arch: found[0].Arch}
+	filterData = api.TemplateFilterData{Arch: config.S390x}
 	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
-	assert.Equal(s.T(), found[0].Arch, responses.Data[0].Arch)
+	assert.Equal(s.T(), config.S390x, responses.Data[0].Arch)
 
 	// Test Filter by RepositoryUUIDs
 	template, rcUUIDs := s.seedWithRepoConfig(orgIDTest, 2, false)

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -16,15 +16,17 @@ import (
 )
 
 type SeedOptions struct {
-	OrgID       string
-	BatchSize   int
-	Arch        *string
-	Versions    *[]string
-	Status      *string
-	ContentType *string
-	Origin      *string
-	Version     *string
-	TaskID      string
+	OrgID                  string
+	BatchSize              int
+	Arch                   *string
+	Versions               *[]string
+	Status                 *string
+	ContentType            *string
+	Origin                 *string
+	Version                *string
+	TaskID                 string
+	ExtendedReleaseVersion *string
+	ExtendedRelease        *string
 }
 
 type IntrospectionStatusMetadata struct {
@@ -101,6 +103,11 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) ([
 			RepositoryUUID:       repos[i].UUID,
 			LastSnapshotTaskUUID: options.TaskID,
 			Snapshot:             true,
+		}
+		if options.ExtendedRelease != nil && *options.ExtendedRelease != "" &&
+			options.ExtendedReleaseVersion != nil && *options.ExtendedReleaseVersion != "" {
+			repoConfig.ExtendedRelease = *options.ExtendedRelease
+			repoConfig.ExtendedReleaseVersion = *options.ExtendedReleaseVersion
 		}
 		repoConfigurations = append(repoConfigurations, repoConfig)
 	}


### PR DESCRIPTION
## Summary

Updates version filtering logic for repos and templates to allow both minor and major versions

## Testing steps

1. Create a few non-EUS and EUS repos and templates 
2. Filtering repos by both major and minor version in the version filter should return the expected repos (e.g. `/repositories/?version=9,8.6` should return only RHEL 9 (non-EUS) and RHEL 8.6)
3. Filtering templates by both major and minor version in the version filter should return the expected templates (e.g. `/templates/?version=9,8.6` should return only RHEL 9 (non-EUS) and RHEL 8.6)
