### PR TITLE
HMS-10532: sort repos and templates by minor version

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -541,11 +541,13 @@ func (r repositoryConfigDaoImpl) List(
 		return api.RepositoryCollectionResponse{}, totalRepos, err
 	}
 
+	versionSortExpr := "(CASE WHEN extended_release_version IS NOT NULL AND extended_release_version != '' THEN split_part(extended_release_version, '.', 1)::int * 10000 + split_part(extended_release_version, '.', 2)::int ELSE (SELECT min(v::int * 10000 - 1) FROM unnest(versions) AS v WHERE v <> 'any') END, cardinality(versions))"
+
 	sortMap := map[string]string{
 		"name":                      "name",
 		"url":                       "url",
 		"distribution_arch":         "arch",
-		"distribution_versions":     "((SELECT min(v::int) FROM unnest(versions) AS v WHERE v <> 'any'), cardinality(versions))", // sort by lowest version numerically (excluding 'any'), then by number of versions
+		"distribution_versions":     versionSortExpr,
 		"package_count":             "package_count",
 		"last_introspection_time":   "last_introspection_time",
 		"last_introspection_status": "last_introspection_status",

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -2078,7 +2078,7 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	require.NoError(t, err)
 
 	err = tx.Create(&models.RepositoryConfiguration{
-		Name:           "Regular Repo",
+		Name:           "Regular Repo - RHEL 9",
 		OrgID:          orgID,
 		RepositoryUUID: repoRegular.UUID,
 		Arch:           config.X8664,
@@ -2173,7 +2173,7 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, 1, len(response.Data))
-	assert.Equal(t, "Regular Repo", response.Data[0].Name)
+	assert.Equal(t, "Regular Repo - RHEL 9", response.Data[0].Name)
 
 	// Test 8: Filter by extended_release_version=none
 	suite.mockPulpForListOrFetch(1)
@@ -2183,7 +2183,7 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), total)
 	assert.Equal(t, 1, len(response.Data))
-	assert.Equal(t, "Regular Repo", response.Data[0].Name)
+	assert.Equal(t, "Regular Repo - RHEL 9", response.Data[0].Name)
 	assert.Equal(t, "", response.Data[0].ExtendedReleaseVersion)
 
 	// Test 9: Filter by extended_release_version=9.4,none - should return 9.4 repos and regular repo
@@ -2198,6 +2198,20 @@ func (suite *RepositoryConfigSuite) TestListFilterExtendedRelease() {
 	for _, repo := range response.Data {
 		assert.Contains(t, []string{"9.4", ""}, repo.ExtendedReleaseVersion)
 	}
+
+	// Test 10: Sort by OS version (ascending) - should return regular repo (9), 9.4, 9.4, and 9.6 repo
+	suite.mockPulpForListOrFetch(1)
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64", "RHEL-EUS-x86_64", "RHEL-E4S-x86_64"}, nil).Once()
+	filterData = api.FilterData{ExtendedReleaseVersion: "9.4,9.6,none", Origin: config.OriginExternal}
+	pageData = api.PaginationData{Limit: 20, Offset: 0, SortBy: "distribution_versions"}
+	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), total)
+	assert.Equal(t, 4, len(response.Data))
+	assert.Equal(t, "", response.Data[0].ExtendedReleaseVersion)
+	assert.Equal(t, "9.4", response.Data[1].ExtendedReleaseVersion)
+	assert.Equal(t, "9.4", response.Data[2].ExtendedReleaseVersion)
+	assert.Equal(t, "9.6", response.Data[3].ExtendedReleaseVersion)
 }
 
 func (suite *RepositoryConfigSuite) TestListFilterStatus() {

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -332,11 +332,13 @@ func (t templateDaoImpl) List(ctx context.Context, orgID string, includeSoftDel 
 		filteredDB = filteredDB.Unscoped()
 	}
 
+	versionSortExpr := "CASE WHEN extended_release_version IS NOT NULL AND extended_release_version != '' THEN split_part(extended_release_version, '.', 1)::int * 10000 + split_part(extended_release_version, '.', 2)::int ELSE version::int * 10000 - 1 END"
+
 	sortMap := map[string]string{
 		"name":    "name",
 		"url":     "url",
 		"arch":    "arch",
-		"version": "version",
+		"version": versionSortExpr,
 	}
 
 	order := convertSortByToSQL(paginationData.SortBy, sortMap, "name asc")
@@ -350,7 +352,7 @@ func (t templateDaoImpl) List(ctx context.Context, orgID string, includeSoftDel 
 	}
 
 	if filteredDB.
-		Distinct("templates.*").
+		Distinct("templates.*, "+versionSortExpr+" AS version_sort_order").
 		Preload("TemplateRepositoryConfigurations").
 		Preload("LastUpdateTask").
 		Order(order).

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -403,10 +403,12 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(3), total)
 
+	pageData := api.PaginationData{Limit: -1}
+
 	// Test filter by extended_release="eus,e4s"
 	filter = fmt.Sprintf("%s,%s", config.EUS, config.E4S)
 	filterData := api.TemplateFilterData{ExtendedRelease: filter}
-	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -416,7 +418,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	// Test filter by extended_release="eus,none" - should return both standard and EUS templates
 	filter = fmt.Sprintf("%s,%s", config.EUS, "none")
 	filterData = api.TemplateFilterData{ExtendedRelease: filter}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -427,7 +429,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 
 	// Test filter by extended_release="eus"
 	filterData = api.TemplateFilterData{ExtendedRelease: config.EUS}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -435,7 +437,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 
 	// Test filter by extended_release="none"
 	filterData = api.TemplateFilterData{ExtendedRelease: "none"}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -443,7 +445,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 
 	// Test filter by extended_release_version="8.6"
 	filterData = api.TemplateFilterData{ExtendedReleaseVersion: config.DistributionMinorVersions[0].Label}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -452,7 +454,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	// Test filter by extended_release_version="8.6,9.4"
 	filter = fmt.Sprintf("%s,%s", config.DistributionMinorVersions[0].Label, config.DistributionMinorVersions[4].Label)
 	filterData = api.TemplateFilterData{ExtendedReleaseVersion: filter}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -461,7 +463,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 
 	// Test filter by extended_release_version="none"
 	filterData = api.TemplateFilterData{ExtendedReleaseVersion: "none"}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(1), total)
 	assert.Len(s.T(), responses.Data, 1)
@@ -470,7 +472,7 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	// Test filter by extended_release_version="9.4,none" - should return EUS template and standard template
 	filter = fmt.Sprintf("%s,%s", config.DistributionMinorVersions[4].Label, "none")
 	filterData = api.TemplateFilterData{ExtendedReleaseVersion: filter}
-	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(2), total)
 	assert.Len(s.T(), responses.Data, 2)
@@ -478,6 +480,18 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	expectedValues = fmt.Sprintf("%s,%s", config.DistributionMinorVersions[4].Label, "")
 	assert.Contains(s.T(), expectedValues, responses.Data[0].ExtendedReleaseVersion)
 	assert.Contains(s.T(), expectedValues, responses.Data[1].ExtendedReleaseVersion)
+
+	// Sort by OS version (ascending) - should return 8.6 template, regular template (9), and 9.4 template
+	filter = fmt.Sprintf("%s,%s,%s", config.EUS, config.E4S, "none")
+	filterData = api.TemplateFilterData{ExtendedRelease: filter}
+	pageData = api.PaginationData{Limit: -1, SortBy: "version"}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(3), total)
+	assert.Len(s.T(), responses.Data, 3)
+	assert.Equal(s.T(), "8.6", responses.Data[0].ExtendedReleaseVersion)
+	assert.Equal(s.T(), "", responses.Data[1].ExtendedReleaseVersion)
+	assert.Equal(s.T(), "9.4", responses.Data[2].ExtendedReleaseVersion)
 }
 
 func (s *TemplateSuite) TestListFilterSearch() {


### PR DESCRIPTION
## Summary

- Enhanced version sorting for repos and templates to handle minor and major versions. The order follows RHEL versioning: 8, 8.0, 8.1, ..., 9, 9.0, 9.1, ...
- Uses `extended_release_version` for minor version repos/templates, with this formula `major * 10000 + minor (or major * 10000 - 1 for major-only)` to compute an integer sort key

<img width="1303" height="1088" alt="Screenshot From 2026-04-20 00-19-48" src="https://github.com/user-attachments/assets/a97ea38f-090c-49aa-b988-155e5ea4d7f5" />


## Testing steps

- Existing tests pass
- Repositories sorted by version return "", "9.4", "9.4", "9.6" in ascending order
- Templates sorted by version return "8.6", "", "9.4" in ascending order