### PR TITLE
HMS-10524: unpin candlepin from dev setup

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -20,12 +20,13 @@ services:
       retries: 10
       timeout: 3s
   candlepin:
-    image: quay.io/candlepin/candlepin:dev-4.7.5-1
+    image: quay.io/candlepin/candlepin:dev-latest
     ports:
       - 8181:8080
       - 8444:8443
     environment:
       JPA_CONFIG_HIBERNATE_CONNECTION_URL: jdbc:postgresql://postgres-content/candlepin
+      ORG_QUARTZ_DATASOURCE_MYDS_URL: jdbc:postgresql://postgres-content/candlepin
     depends_on:
       - postgres-content
     healthcheck:


### PR DESCRIPTION
## Summary

- Reverts the dev candlepin tag back to dev-latest
- Adds environment variable required for our setup with the new image

## Testing steps

Tests should pass when a fixed image is pushed