### PR TITLE
Test: Get Go version from go.mod in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Build: "
+    ignore:
+      - dependency-name: "go"
+        versions:
+          - ">=1.26"
     groups:
       go:
         patterns:

--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
       - run: |
           make openapi
       - run: |
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
       - name: unit tests
         run: |
           make get-deps ${PWD}/release/dbmigrate db-migrate-up test-unit

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/content-services/content-sources-backend
 
 go 1.25.0
+toolchain go1.25.8
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1


### PR DESCRIPTION
## Summary
Get Go version from go.mod in CI
Ignore updates of Go ">=1.26"
## Testing steps

All CI build and lint checks pass
