### PR TITLE
Test: Pin kin-openapi ">=0.136.0"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,10 @@ updates:
     commit-message:
       prefix: "Build: "
     ignore:
-      - dependency-name: "go"
+      # v0.136.0+ declares go >= 1.26, which would force the go directive past our pin.
+      - dependency-name: "github.com/getkin/kin-openapi"
         versions:
-          - ">=1.26"
+          - ">=0.136.0"
     groups:
       go:
         patterns:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/content-services/content-sources-backend
 
-go 1.25.0
-toolchain go1.25.8
+go 1.25.8
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1


### PR DESCRIPTION


## Summary

Pin kin-openapi ">=0.136.0"
Required to prevent Go update of >= 1.26
Set  Go to 1.25.8

## Testing steps

CI checks pass