### PR TITLE
HMS-10637: Include EUS in template filter by major version

### DIFF
--- a/_playwright-tests/test-utils/src/client/apis/TemplatesApi.ts
+++ b/_playwright-tests/test-utils/src/client/apis/TemplatesApi.ts
@@ -79,6 +79,7 @@ export interface ListTemplatesRequest {
     snapshotUuids?: string;
     extendedRelease?: string;
     extendedReleaseVersion?: string;
+    restrictToMajor?: boolean;
     sortBy?: string;
 }
 
@@ -455,6 +456,10 @@ export class TemplatesApi extends runtime.BaseAPI {
 
         if (requestParameters['extendedReleaseVersion'] != null) {
             queryParameters['extended_release_version'] = requestParameters['extendedReleaseVersion'];
+        }
+
+        if (requestParameters['restrictToMajor'] != null) {
+            queryParameters['restrict_to_major'] = requestParameters['restrictToMajor'];
         }
 
         if (requestParameters['sortBy'] != null) {

--- a/api/docs.go
+++ b/api/docs.go
@@ -2959,6 +2959,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "boolean",
+                        "description": "When true, major versions in the version filter only match templates without an extended release version. Specific minor versions in the version filter are still matched.",
+                        "name": "restrict_to_major",
+                        "in": "query"
+                    },
+                    {
                         "type": "string",
                         "description": "Sort the response data based on specific parameters. Sort criteria can include ` + "`" + `name` + "`" + `, ` + "`" + `arch` + "`" + `, and ` + "`" + `version` + "`" + `.",
                         "name": "sort_by",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5942,6 +5942,14 @@
                         }
                     },
                     {
+                        "description": "When true, major versions in the version filter only match templates without an extended release version. Specific minor versions in the version filter are still matched.",
+                        "in": "query",
+                        "name": "restrict_to_major",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
                         "description": "Sort the response data based on specific parameters. Sort criteria can include `name`, `arch`, and `version`.",
                         "in": "query",
                         "name": "sort_by",

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -79,6 +79,7 @@ type TemplateFilterData struct {
 	Version                string   `json:"version"`                  // Filter templates by version. Supports comma-separated lists (e.g., '8,9').
 	ExtendedRelease        string   `json:"extended_release"`         // Filter templates by extended release type. Supports comma-separated lists (e.g., 'eus,e4s'). Use 'none' to filter templates without extended release.
 	ExtendedReleaseVersion string   `json:"extended_release_version"` // Filter templates by extended release version. Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions.
+	RestrictToMajor        bool     `json:"restrict_to_major"`        // When true, major versions in the version filter only match templates without an extended release version.
 	Search                 string   `json:"search"`                   // Search string based query to optionally filter on
 	RepositoryUUIDs        []string `json:"repository_uuids"`         // List templates that contain one or more of these Repositories
 	SnapshotUUIDs          []string `json:"snapshot_uuids"`           // List templates that contain one or more of these Snapshots

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -148,6 +148,43 @@ func checkForValidSnapshotUuids(ctx context.Context, uuids []string, db *gorm.DB
 	return true, ""
 }
 
+const noMinorVersion = "extended_release_version IS NULL OR extended_release_version = ''"
+
+// applyVersionFilter filters templates by version. When restrictToMajor is true,
+// major versions only match templates without an extended_release_version.
+// Specific minor versions are always matched by extended_release_version.
+func applyVersionFilter(filteredDB *gorm.DB, version string, restrictToMajor bool) *gorm.DB {
+	if version == "" {
+		if restrictToMajor {
+			return filteredDB.Where(noMinorVersion)
+		}
+		return filteredDB
+	}
+
+	versionFilters := strings.Split(version, ",")
+	majorVersions, minorVersions := splitVersionFilters(versionFilters)
+
+	switch {
+	case len(majorVersions) > 0 && len(minorVersions) > 0:
+		if restrictToMajor {
+			// e.g. version=9,9.4,10 → RHEL 9 major-only + RHEL 9.4 + RHEL 10 major-only
+			return filteredDB.Where(
+				"((version IN ? AND ("+noMinorVersion+")) OR extended_release_version IN ?)",
+				majorVersions, minorVersions,
+			)
+		}
+		return filteredDB.Where("(version IN ? OR extended_release_version IN ?)", majorVersions, minorVersions)
+	case len(majorVersions) > 0:
+		if restrictToMajor {
+			return filteredDB.Where("version IN ? AND ("+noMinorVersion+")", majorVersions)
+		}
+		return filteredDB.Where("version IN ?", majorVersions)
+	case len(minorVersions) > 0:
+		return filteredDB.Where("extended_release_version IN ?", minorVersions)
+	}
+	return filteredDB
+}
+
 func splitVersionFilters(values []string) (majors []string, minors []string) {
 	for _, value := range values {
 		value = strings.TrimSpace(value)

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -400,37 +400,17 @@ func (t templateDaoImpl) filteredDbForList(orgID string, filteredDB *gorm.DB, fi
 		filteredDB = filteredDB.Where("arch = ?", filterData.Arch)
 	}
 
-	if filterData.Version != "" {
-		versionFilters := strings.Split(filterData.Version, ",")
-		majorVersions, minorVersions := splitVersionFilters(versionFilters)
-
-		switch {
-		case len(majorVersions) > 0 && len(minorVersions) > 0:
-			filteredDB = filteredDB.Where(
-				"((version IN ? AND (extended_release_version IS NULL OR extended_release_version = '')) OR extended_release_version IN ?)",
-				majorVersions,
-				minorVersions,
-			)
-		case len(majorVersions) > 0:
-			filteredDB = filteredDB.Where(
-				"version IN ? AND (extended_release_version IS NULL OR extended_release_version = '')",
-				majorVersions,
-			)
-		case len(minorVersions) > 0:
-			filteredDB = filteredDB.Where("extended_release_version IN ?", minorVersions)
-		}
-	}
+	filteredDB = applyVersionFilter(filteredDB, filterData.Version, filterData.RestrictToMajor)
 
 	if filterData.ExtendedRelease != "" {
 		streams := strings.Split(filterData.ExtendedRelease, ",")
 		if slices.Contains(streams, "none") {
-			// "none" is a marker to include standard templates
 			filteredDB = filteredDB.Where("extended_release IN ? OR extended_release IS NULL OR extended_release = ?", streams, "")
 		} else {
 			filteredDB = filteredDB.Where("extended_release IN ?", streams)
 		}
 	}
-	if filterData.ExtendedReleaseVersion != "" {
+	if filterData.ExtendedReleaseVersion != "" && !filterData.RestrictToMajor {
 		minorVersions := strings.Split(filterData.ExtendedReleaseVersion, ",")
 		if slices.Contains(minorVersions, "none") {
 			filteredDB = filteredDB.Where("extended_release_version IN ? OR extended_release_version IS NULL OR extended_release_version = ?", minorVersions, "")

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -364,6 +364,23 @@ func (s *TemplateSuite) TestListFilters() {
 	assert.True(s.T(), config.El8 == responses.Data[0].Version || config.El8 == responses.Data[1].Version)
 	assert.True(s.T(), extendedReleaseVersion == responses.Data[0].ExtendedReleaseVersion || extendedReleaseVersion == responses.Data[1].ExtendedReleaseVersion)
 
+	// Test filter by major version includes EUS templates with that major version
+	filterData = api.TemplateFilterData{Version: config.El9}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(1), total)
+	assert.Len(s.T(), responses.Data, 1)
+	assert.Equal(s.T(), config.El9, responses.Data[0].Version)
+	assert.Equal(s.T(), extendedReleaseVersion, responses.Data[0].ExtendedReleaseVersion)
+
+	// Test filter by minor version only returns matching EUS template
+	filterData = api.TemplateFilterData{Version: extendedReleaseVersion}
+	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(1), total)
+	assert.Len(s.T(), responses.Data, 1)
+	assert.Equal(s.T(), extendedReleaseVersion, responses.Data[0].ExtendedReleaseVersion)
+
 	// Test filter by arch
 	filterData = api.TemplateFilterData{Arch: config.S390x}
 	responses, total, err = templateDao.List(context.Background(), orgIDTest, false, api.PaginationData{Limit: -1}, filterData)
@@ -509,6 +526,58 @@ func (s *TemplateSuite) TestListFilterExtendedRelease() {
 	assert.Equal(s.T(), "8.6", responses.Data[0].ExtendedReleaseVersion)
 	assert.Equal(s.T(), "", responses.Data[1].ExtendedReleaseVersion)
 	assert.Equal(s.T(), "9.4", responses.Data[2].ExtendedReleaseVersion)
+}
+
+func (s *TemplateSuite) TestListFilterVersionRestrictToMajor() {
+	templateDao := s.templateDao()
+	var err error
+	var total int64
+
+	arch := config.X8664
+	version := config.El9
+	options := seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
+	extendedRelease := config.EUS
+	extendedReleaseVersion := "9.4"
+	options = seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version, ExtendedRelease: &extendedRelease, ExtendedReleaseVersion: &extendedReleaseVersion}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
+	extendedReleaseVersion = "9.6"
+	options = seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version, ExtendedRelease: &extendedRelease, ExtendedReleaseVersion: &extendedReleaseVersion}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
+	version = config.El10
+	extendedReleaseVersion = "10.0"
+	options = seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
+	options = seeds.TemplateSeedOptions{OrgID: orgIDTest, Arch: &arch, Version: &version, ExtendedRelease: &extendedRelease, ExtendedReleaseVersion: &extendedReleaseVersion}
+	_, err = seeds.SeedTemplates(s.tx, 1, options)
+	assert.NoError(s.T(), err)
+
+	pageData := api.PaginationData{Limit: -1}
+
+	// version=9,9.4,10, erv=none
+	// Returns: RHEL 9 major-only + 9.4 + RHEL 10 major-only (9.6 and 10.0 excluded)
+	filterData := api.TemplateFilterData{Version: "9,9.4,10", RestrictToMajor: true}
+	_, total, err = templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(3), total)
+
+	// version=9,9.4, erv=none
+	// Returns: RHEL 9 major-only + 9.4 (9.6 excluded)
+	filterData = api.TemplateFilterData{Version: "9,9.4", RestrictToMajor: true}
+	responses, total, err := templateDao.List(context.Background(), orgIDTest, false, pageData, filterData)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(2), total)
+	ervValues := []string{responses.Data[0].ExtendedReleaseVersion, responses.Data[1].ExtendedReleaseVersion}
+	assert.Contains(s.T(), ervValues, "")
+	assert.Contains(s.T(), ervValues, "9.4")
 }
 
 func (s *TemplateSuite) TestListFilterSearch() {

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -130,6 +130,7 @@ func (th *TemplateHandler) fetch(c echo.Context) error {
 // @Param		 snapshot_uuids query string false "Filter templates by associated snapshots using a comma separated list of snapshot UUIDs"
 // @Param        extended_release query string false "Filter templates by extended release type. Valid values: eus, e4s, eeus. Supports comma-separated lists (e.g., 'eus,e4s'). Use 'none' to filter templates without extended release."
 // @Param        extended_release_version query string false "Filter templates by extended release version (e.g., 9.4). Supports comma-separated lists (e.g., '9.4,9.6'). Use 'none' to filter templates without extended release versions."
+// @Param        restrict_to_major query bool false "When true, major versions in the version filter only match templates without an extended release version. Specific minor versions in the version filter are still matched."
 // @Param		 sort_by query string false "Sort the response data based on specific parameters. Sort criteria can include `name`, `arch`, and `version`."
 // @Accept       json
 // @Produce      json
@@ -246,6 +247,7 @@ func ParseTemplateFilters(c echo.Context) api.TemplateFilterData {
 		Bool("use_latest", &filterData.UseLatest).
 		String("extended_release", &filterData.ExtendedRelease).
 		String("extended_release_version", &filterData.ExtendedReleaseVersion).
+		Bool("restrict_to_major", &filterData.RestrictToMajor).
 		BindError()
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Template filtering on the major version only needs to include EUS templates to compatible with image builder. But this adds an option to exclude it so it is still compatible with our UI.

## Testing steps
1. Import and snapshot the extended release repos
2. Create templates of varying versions (9, 9.4, 9.6, 10, 10.0, etc)
3. Checkout the frontend PR as well: https://github.com/content-services/content-sources-frontend/pull/993
4. Use the version filtering in various combinations and make sure it works as you'd expect

