### PR TITLE
HMS-9531: Remove support for custom epel

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -195,11 +195,7 @@ features:
     accounts: #["adminAccount"]
     users: #["adminUser"]
     organizations: #["adminOrg"]
-  community_repos:
-    enabled: true
   kessel:
     enabled: false
-  allow_custom_epel_creation:
-    enabled: true
   extended_release_repos:
     enabled: false

--- a/deployments/build/env-variables.yaml
+++ b/deployments/build/env-variables.yaml
@@ -51,8 +51,6 @@ env:
     value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
   - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
     value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-  - name: FEATURES_COMMUNITY_REPOS_ENABLED
-    value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
     value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
   - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -173,12 +171,6 @@ env:
         name: content-sources-sso-service-account
         key: client_secret
         optional: true
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-    value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-    value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-    value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
   - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
     value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
   - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -315,8 +307,6 @@ parameters:
     description: Comma separated list of account number that can access the feature
   - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
     description: Comma separated list of org ids that can access the feature
-  - name: FEATURES_COMMUNITY_REPOS_ENABLED
-    description: Whether the shared epel repos should be accessible
   - name: FEATURES_EXTENDED_RELEASE_REPOS_ENABLED
     description: Whether the extended relaese repos should be snapshotted
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -396,11 +386,5 @@ parameters:
     value: ''
   - name: CLIENTS_KESSEL_AUTH_GRPC_INSECURE
     value: 'false'
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-    description: Whether to allow custom EPEL repo creation
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-    description: Organizations to allow custom EPEL repo creation for
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-    description: Accounts to allow custom EPEL repo creation for
   - name: EPEL_ORG_ID_SKIP
     description: comma separated list of org ids to skip when turning snapshotting off

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -137,8 +137,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -259,12 +257,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -396,8 +388,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -518,12 +508,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -623,8 +607,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -745,12 +727,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -838,8 +814,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -960,12 +934,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -1057,8 +1025,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -1179,12 +1145,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -1278,8 +1238,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -1400,12 +1358,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -1497,8 +1449,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -1619,12 +1569,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -1713,8 +1657,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -1835,12 +1777,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -1952,8 +1888,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -2074,12 +2008,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -2169,8 +2097,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -2291,12 +2217,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -2403,8 +2323,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -2525,12 +2443,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -2616,8 +2528,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -2738,12 +2648,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -2829,8 +2733,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -2951,12 +2853,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -3042,8 +2938,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -3164,12 +3058,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -3255,8 +3143,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -3377,12 +3263,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -3468,8 +3348,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -3590,12 +3468,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -3681,8 +3553,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -3803,12 +3673,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -3894,8 +3758,6 @@ objects:
                 value: ${FEATURES_ADMIN_TASKS_ACCOUNTS}
               - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
                 value: ${FEATURES_ADMIN_TASKS_ORGANIZATIONS}
-              - name: FEATURES_COMMUNITY_REPOS_ENABLED
-                value: ${FEATURES_COMMUNITY_REPOS_ENABLED}
               - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
                 value: ${OPTIONS_ALWAYS_RUN_CRON_TASKS}
               - name: OPTIONS_ENABLE_NOTIFICATIONS
@@ -4016,12 +3878,6 @@ objects:
                     name: content-sources-sso-service-account
                     key: client_secret
                     optional: true
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS}
-              - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-                value: ${FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS}
               - name: OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT
                 value: ${OPTIONS_SNAPSHOT_RETAIN_DAYS_LIMIT}
               - name: CLIENTS_PULP_LOG_PARSER_CLOUDWATCH_GROUP
@@ -4197,8 +4053,6 @@ parameters:
     description: Comma separated list of account number that can access the feature
   - name: FEATURES_ADMIN_TASKS_ORGANIZATIONS
     description: Comma separated list of org ids that can access the feature
-  - name: FEATURES_COMMUNITY_REPOS_ENABLED
-    description: Whether the shared epel repos should be accessible
   - name: FEATURES_EXTENDED_RELEASE_REPOS_ENABLED
     description: Whether the extended relaese repos should be snapshotted
   - name: OPTIONS_ALWAYS_RUN_CRON_TASKS
@@ -4279,11 +4133,5 @@ parameters:
     value: ''
   - name: CLIENTS_KESSEL_AUTH_GRPC_INSECURE
     value: 'false'
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ENABLED
-    description: Whether to allow custom EPEL repo creation
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ORGANIZATIONS
-    description: Organizations to allow custom EPEL repo creation for
-  - name: FEATURES_ALLOW_CUSTOM_EPEL_CREATION_ACCOUNTS
-    description: Accounts to allow custom EPEL repo creation for
   - name: EPEL_ORG_ID_SKIP
     description: comma separated list of org ids to skip when turning snapshotting off

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,12 +73,10 @@ type MockKessel struct {
 	UserNoPermissions []string `mapstructure:"user_no_permissions"`
 }
 type FeatureSet struct {
-	Snapshots               Feature
-	AdminTasks              Feature `mapstructure:"admin_tasks"`
-	CommunityRepos          Feature `mapstructure:"community_repos"`
-	Kessel                  Feature `mapstructure:"kessel"`
-	AllowCustomEPELCreation Feature `mapstructure:"allow_custom_epel_creation"`
-	ExtendedReleaseRepos    Feature `mapstructure:"extended_release_repos"`
+	Snapshots            Feature
+	AdminTasks           Feature `mapstructure:"admin_tasks"`
+	Kessel               Feature `mapstructure:"kessel"`
+	ExtendedReleaseRepos Feature `mapstructure:"extended_release_repos"`
 }
 
 type Feature struct {
@@ -422,16 +420,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("features.admin_tasks.accounts", nil)
 	v.SetDefault("features.admin_tasks.organizations", nil)
 	v.SetDefault("features.admin_tasks.users", nil)
-	v.SetDefault("features.community_repos.enabled", false)
 	v.SetDefault("features.extended_release_repos.enabled", false)
 	v.SetDefault("features.kessel.enabled", false)
 	v.SetDefault("features.kessel.accounts", nil)
 	v.SetDefault("features.kessel.organizations", nil)
 	v.SetDefault("features.kessel.users", nil)
-	v.SetDefault("features.allow_custom_epel_creation.enabled", true)
-	v.SetDefault("features.allow_custom_epel_creation.accounts", nil)
-	v.SetDefault("features.allow_custom_epel_creation.organizations", nil)
-	v.SetDefault("features.allow_custom_epel_creation.users", nil)
 
 	v.SetDefault("mocks.kessel.user_read_write", []string{"write-user"})
 	v.SetDefault("mocks.kessel.user_read", []string{"read-user"})

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -30,6 +30,19 @@ import (
 
 var UploadRepositoryWarning = "upload repository was exported from a different organization, make sure to add content to it manually"
 
+const errMsgCustomEpelRepoCreationNotPermitted = "creating of EPEL repositories is not permitted, please use the community repositories"
+
+// rejectsCustomEpelRepository is true when the request would create a duplicate of shared community/EPEL content in the tenant org.
+func rejectsCustomEpelRepository(origin *string, url *string) bool {
+	if origin != nil && *origin == config.OriginCommunity {
+		return true
+	}
+	if url != nil && slices.Contains(config.EPELUrls, models.CleanupURL(*url)) {
+		return true
+	}
+	return false
+}
+
 type repositoryConfigDaoImpl struct {
 	db         *gorm.DB
 	yumRepo    yum.YumRepository
@@ -113,14 +126,11 @@ func (r repositoryConfigDaoImpl) Create(ctx context.Context, newRepoReq api.Repo
 	}
 
 	if *newRepoReq.OrgID == config.CommunityOrg {
-		return api.RepositoryResponse{}, errors.New("creating of EPEL repositories is not permitted, please use the community repositories")
+		return api.RepositoryResponse{}, errors.New(errMsgCustomEpelRepoCreationNotPermitted)
 	}
 
-	if config.Get().Features.CommunityRepos.Enabled && !config.FeatureAccessible(ctx, config.Get().Features.AllowCustomEPELCreation) {
-		if (newRepoReq.Origin != nil && *newRepoReq.Origin == config.OriginCommunity) ||
-			(newRepoReq.URL != nil && slices.Contains(config.EPELUrls, *newRepoReq.URL)) {
-			return api.RepositoryResponse{}, &ce.DaoError{BadValidation: true, Message: "creating of EPEL repositories is not permitted, please use the community repositories"}
-		}
+	if rejectsCustomEpelRepository(newRepoReq.Origin, newRepoReq.URL) {
+		return api.RepositoryResponse{}, &ce.DaoError{BadValidation: true, Message: errMsgCustomEpelRepoCreationNotPermitted}
 	}
 
 	if !isCreatableOrigin(newRepoReq.Origin) {
@@ -226,20 +236,17 @@ func (r repositoryConfigDaoImpl) bulkCreate(ctx context.Context, tx *gorm.DB, ne
 		}
 
 		if *newRepositories[i].OrgID == config.CommunityOrg {
-			dbErr = errors.New("creating of EPEL repositories is not permitted, please use the community repositories")
+			dbErr = errors.New(errMsgCustomEpelRepoCreationNotPermitted)
 			errorList[i] = dbErr
 			tx.RollbackTo("beforecreate")
 			continue
 		}
 
-		if config.Get().Features.CommunityRepos.Enabled && !config.FeatureAccessible(ctx, config.Get().Features.AllowCustomEPELCreation) {
-			if (newRepositories[i].Origin != nil && *newRepositories[i].Origin == config.OriginCommunity) ||
-				(newRepositories[i].URL != nil && slices.Contains(config.EPELUrls, *newRepositories[i].URL)) {
-				dbErr = &ce.DaoError{BadValidation: true, Message: "creating of EPEL repositories is not permitted, please use the community repositories"}
-				errorList[i] = dbErr
-				tx.RollbackTo("beforecreate")
-				continue
-			}
+		if rejectsCustomEpelRepository(newRepositories[i].Origin, newRepositories[i].URL) {
+			dbErr = &ce.DaoError{BadValidation: true, Message: errMsgCustomEpelRepoCreationNotPermitted}
+			errorList[i] = dbErr
+			tx.RollbackTo("beforecreate")
+			continue
 		}
 
 		// Validate origin before other checks
@@ -598,10 +605,7 @@ func (r repositoryConfigDaoImpl) List(
 }
 
 func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gorm.DB, filterData api.FilterData, accessibleFeatures []string) (*gorm.DB, error) {
-	orgs := []string{OrgID, config.RedHatOrg}
-	if config.Get().Features.CommunityRepos.Enabled {
-		orgs = append(orgs, config.CommunityOrg)
-	}
+	orgs := []string{OrgID, config.RedHatOrg, config.CommunityOrg}
 	filteredDB = filteredDB.Where("repository_configurations.org_id in ?", orgs).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
 
@@ -818,10 +822,7 @@ func (r repositoryConfigDaoImpl) fetchRepoConfig(ctx context.Context, orgID stri
 	orgIdsToCheck := []string{orgID}
 
 	if includeSharedRepos {
-		orgIdsToCheck = append(orgIdsToCheck, config.RedHatOrg)
-		if config.Get().Features.CommunityRepos.Enabled {
-			orgIdsToCheck = append(orgIdsToCheck, config.CommunityOrg)
-		}
+		orgIdsToCheck = append(orgIdsToCheck, config.RedHatOrg, config.CommunityOrg)
 	}
 
 	result := r.db.WithContext(ctx).
@@ -1238,7 +1239,7 @@ func (r repositoryConfigDaoImpl) bulkImport(tx *gorm.DB, reposToImport []api.Rep
 			reposToImport[i].Origin = utils.Ptr(config.OriginExternal)
 		}
 
-		if reposToImport[i].URL != nil && config.Get().Features.CommunityRepos.Enabled {
+		if reposToImport[i].URL != nil {
 			isCustomEPEL := *reposToImport[i].Origin == config.OriginExternal && slices.Contains(config.EPELUrls, models.CleanupURL(*reposToImport[i].URL))
 			if *reposToImport[i].Origin == config.OriginCommunity || isCustomEPEL {
 				err := tx.

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -360,14 +360,7 @@ func (suite *RepositoryConfigSuite) TestCreateDuplicateLabel() {
 	assert.Contains(t, resp.Label, found.Label)
 }
 
-func (suite *RepositoryConfigSuite) TestCreateEPELRepositoryShouldFail() {
-	defer func() {
-		config.Get().Features.CommunityRepos.Enabled = false
-		config.Get().Features.AllowCustomEPELCreation.Enabled = true
-	}()
-	config.Get().Features.CommunityRepos.Enabled = true
-	config.Get().Features.AllowCustomEPELCreation.Enabled = false
-
+func (suite *RepositoryConfigSuite) TestCreateRepositoryRejectsCommunityOrg() {
 	toCreate := api.RepositoryRequest{
 		Name:             utils.Ptr("epel-repo-1"),
 		URL:              utils.Ptr("https://epel-repo.org"),
@@ -380,21 +373,26 @@ func (suite *RepositoryConfigSuite) TestCreateEPELRepositoryShouldFail() {
 	dao := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient)
 	_, err := dao.Create(context.Background(), toCreate)
 	assert.ErrorContains(suite.T(), err, "creating of EPEL repositories is not permitted, please use the community repositories")
+}
 
-	toCreate = api.RepositoryRequest{
+func (suite *RepositoryConfigSuite) TestCreateRepositoryRejectsCommunityOrigin() {
+	toCreate := api.RepositoryRequest{
 		Name:             utils.Ptr("epel-repo-2"),
 		URL:              utils.Ptr("https://epel-repo.org"),
-		Origin:           utils.Ptr("community"),
+		Origin:           utils.Ptr(config.OriginCommunity),
 		OrgID:            utils.Ptr(orgIDTest),
 		DistributionArch: utils.Ptr("x86_64"),
 		DistributionVersions: &[]string{
 			config.El9,
 		},
 	}
-	_, err = dao.Create(context.Background(), toCreate)
+	dao := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient)
+	_, err := dao.Create(context.Background(), toCreate)
 	assert.ErrorContains(suite.T(), err, "creating of EPEL repositories is not permitted, please use the community repositories")
+}
 
-	toCreate = api.RepositoryRequest{
+func (suite *RepositoryConfigSuite) TestCreateRepositoryRejectsOfficialEpelURLInUserOrg() {
+	toCreate := api.RepositoryRequest{
 		Name:             utils.Ptr("epel-repo-3"),
 		URL:              utils.Ptr(config.EPEL10Url),
 		OrgID:            utils.Ptr(orgIDTest),
@@ -403,7 +401,8 @@ func (suite *RepositoryConfigSuite) TestCreateEPELRepositoryShouldFail() {
 			config.El10,
 		},
 	}
-	_, err = dao.Create(context.Background(), toCreate)
+	dao := GetRepositoryConfigDao(suite.tx, suite.mockPulpClient, suite.mockFsClient)
+	_, err := dao.Create(context.Background(), toCreate)
 	assert.ErrorContains(suite.T(), err, "creating of EPEL repositories is not permitted, please use the community repositories")
 }
 
@@ -705,49 +704,53 @@ func (suite *RepositoryConfigSuite) TestBulkCreateOneFails() {
 	assert.Equal(t, int64(0), count)
 }
 
-func (suite *RepositoryConfigSuite) TestBulkCreateEPELReposShouldFail() {
-	t := suite.T()
+func (suite *RepositoryConfigSuite) TestBulkCreateRejectsCommunityOrg() {
 	tx := suite.tx
-	defer func() {
-		config.Get().Features.CommunityRepos.Enabled = false
-		config.Get().Features.AllowCustomEPELCreation.Enabled = true
-	}()
-	config.Get().Features.CommunityRepos.Enabled = true
-	config.Get().Features.AllowCustomEPELCreation.Enabled = false
-
 	requests := []api.RepositoryRequest{
 		{
-			Name:  utils.Ptr("epel-repo-1"),
-			URL:   utils.Ptr("https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"),
-			OrgID: utils.Ptr(test_handler.MockOrgId),
-		},
-		{
-			Name:  utils.Ptr("epel-repo-2"),
-			URL:   utils.Ptr("https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"),
-			OrgID: utils.Ptr(test_handler.MockOrgId),
-		},
-		{
-			Name:  utils.Ptr("epel-repo-3"),
-			URL:   utils.Ptr("https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/"),
-			OrgID: utils.Ptr(test_handler.MockOrgId),
-		},
-		{
-			Name:  utils.Ptr("epel-repo-4"),
+			Name:  utils.Ptr("epel-repo-community-org"),
 			URL:   utils.Ptr("https://epel-repo.org"),
 			OrgID: utils.Ptr(config.CommunityOrg),
 		},
+	}
+	_, errs := GetRepositoryConfigDao(tx, suite.mockPulpClient, suite.mockFsClient).BulkCreate(context.Background(), requests)
+	require.Len(suite.T(), errs, 1)
+	assert.ErrorContains(suite.T(), errs[0], "creating of EPEL repositories is not permitted, please use the community repositories")
+}
+
+func (suite *RepositoryConfigSuite) TestBulkCreateRejectsCommunityOrigin() {
+	tx := suite.tx
+	requests := []api.RepositoryRequest{
 		{
-			Name:   utils.Ptr("epel-repo-5"),
+			Name:   utils.Ptr("epel-repo-community-origin"),
 			URL:    utils.Ptr("https://epel-repo.org"),
 			OrgID:  utils.Ptr(test_handler.MockOrgId),
 			Origin: utils.Ptr(config.OriginCommunity),
 		},
 	}
-
 	_, errs := GetRepositoryConfigDao(tx, suite.mockPulpClient, suite.mockFsClient).BulkCreate(context.Background(), requests)
-	assert.NotEmpty(t, errs)
-	for i := 0; i < len(errs); i++ {
-		assert.ErrorContains(t, errs[i], "creating of EPEL repositories is not permitted, please use the community repositories")
+	require.Len(suite.T(), errs, 1)
+	assert.ErrorContains(suite.T(), errs[0], "creating of EPEL repositories is not permitted, please use the community repositories")
+}
+
+func (suite *RepositoryConfigSuite) TestBulkCreateRejectsOfficialEpelURLs() {
+	tx := suite.tx
+	requests := []api.RepositoryRequest{
+		{
+			Name:  utils.Ptr("epel-repo-10"),
+			URL:   utils.Ptr("https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/"),
+			OrgID: utils.Ptr(test_handler.MockOrgId),
+		},
+		{
+			Name:  utils.Ptr("epel-repo-9"),
+			URL:   utils.Ptr("https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/"),
+			OrgID: utils.Ptr(test_handler.MockOrgId),
+		},
+	}
+	_, errs := GetRepositoryConfigDao(tx, suite.mockPulpClient, suite.mockFsClient).BulkCreate(context.Background(), requests)
+	require.Len(suite.T(), errs, 2)
+	for i := range errs {
+		assert.ErrorContains(suite.T(), errs[i], "creating of EPEL repositories is not permitted, please use the community repositories")
 	}
 }
 
@@ -971,9 +974,7 @@ func (suite *RepositoryConfigSuite) TestBulkImportCommunityAndEPELRepos() {
 
 	defer func() {
 		config.EPELUrls = []string{config.EPEL8Url, config.EPEL9Url, config.EPEL10Url}
-		config.Get().Features.CommunityRepos.Enabled = false
 	}()
-	config.Get().Features.CommunityRepos.Enabled = true
 	config.EPELUrls = []string{communityURL}
 
 	communityRepoRequest := api.RepositoryRequest{

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -427,7 +427,6 @@ func (s *DeleteTest) TestDeleteCommunitySnapshot() {
 
 	config.Get().Clients.Pulp.DownloadPolicy = "immediate"
 	config.Get().Features.Snapshots.Enabled = true
-	config.Get().Features.CommunityRepos.Enabled = true
 	err := config.ConfigureTang()
 	assert.NoError(t, err)
 	assert.NotNil(t, config.Tang)

--- a/test/integration/update_latest_snapshot_test.go
+++ b/test/integration/update_latest_snapshot_test.go
@@ -216,7 +216,6 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshotForRedHatRepo() {
 func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshotForCommunityRepo() {
 	config.Get().Clients.Pulp.DownloadPolicy = "immediate" // Set to immediate so fetches don't require the source server running
 	config.Get().Features.Snapshots.Enabled = true
-	config.Get().Features.CommunityRepos.Enabled = true
 	err := config.ConfigureTang()
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), config.Tang)

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -105,7 +105,6 @@ func (s *UpdateTemplateContentSuite) TestUseLatest() {
 }
 
 func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
-	config.Get().Features.CommunityRepos.Enabled = true
 	ctx := context.Background()
 	orgID := uuid2.NewString()
 


### PR DESCRIPTION
## Summary
Remove support for custom epel
HMS-9531: api/ui - remove migration features for unified EPEL

## Testing steps

tests pass

depends on: https://github.com/content-services/content-sources-frontend/pull/997