### PR TITLE
HMS-10636: add RHEL 9.8/10.2 eus/e4s/eeus releases

### DIFF
--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -102,7 +102,9 @@ var DistributionMinorVersions = [...]DistributionMinorVersion{
 	{Name: "RHEL 9.2", Label: "9.2", Major: El9, ExtendedReleaseStreams: []string{E4S, EEUS}},
 	{Name: "RHEL 9.4", Label: "9.4", Major: El9, ExtendedReleaseStreams: []string{EUS, E4S, EEUS}},
 	{Name: "RHEL 9.6", Label: "9.6", Major: El9, ExtendedReleaseStreams: []string{EUS, E4S, EEUS}},
+	{Name: "RHEL 9.8", Label: "9.8", Major: El9, ExtendedReleaseStreams: []string{EUS, E4S, EEUS}},
 	{Name: "RHEL 10.0", Label: "10.0", Major: El10, ExtendedReleaseStreams: []string{EUS, EEUS}},
+	{Name: "RHEL 10.2", Label: "10.2", Major: El10, ExtendedReleaseStreams: []string{EUS, EEUS}},
 }
 
 const ANY_ARCH = "any"

--- a/pkg/external_repos/snapshotted_repos/e4s-sap-solutions-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/e4s-sap-solutions-x86_64.json
@@ -64,5 +64,16 @@
         "origin": "red_hat",
         "extended_release": "e4s",
         "extended_release_version": "9.6"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - SAP Solutions - Update Services for SAP Solutions (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-sap-solutions-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/x86_64/sap-solutions/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-SAP_SOLUTIONS-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "e4s",
+        "extended_release_version": "9.8"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/e4s-sap-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/e4s-sap-x86_64.json
@@ -64,5 +64,16 @@
         "origin": "red_hat",
         "extended_release": "e4s",
         "extended_release_version": "9.6"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - SAP NetWeaver - Update Services for SAP Solutions (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-sap-netweaver-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/x86_64/sap/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-SAP-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "e4s",
+        "extended_release_version": "9.8"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/e4s-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/e4s-x86_64.json
@@ -130,5 +130,27 @@
         "origin": "red_hat",
         "extended_release": "e4s",
         "extended_release_version": "9.6"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - AppStream - Update Services for SAP Solutions (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-appstream-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/x86_64/appstream/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "e4s",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - BaseOS - Update Services for SAP Solutions (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-baseos-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/x86_64/baseos/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "e4s",
+        "extended_release_version": "9.8"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eeus-aarch64.json
+++ b/pkg/external_repos/snapshotted_repos/eeus-aarch64.json
@@ -88,6 +88,28 @@
         "extended_release_version": "9.6"
     },
     {
+        "name": "Red Hat Enterprise Linux 9.8 for ARM 64 - AppStream - 4 years of updates (RPMs)",
+        "content_label": "rhel-9.8-for-aarch64-appstream-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/aarch64/appstream/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EEUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for ARM 64 - BaseOS - 4 years of updates (RPMs)",
+        "content_label": "rhel-9.8-for-aarch64-baseos-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EEUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "9.8"
+    },
+    {
         "name": "Red Hat Enterprise Linux 10.0 for ARM 64 - AppStream - 4 years of updates (RPMs)",
         "content_label": "rhel-10.0-for-aarch64-appstream-e4s-rpms",
         "url": "https://cdn.redhat.com/content/e4s/rhel10/10.0/aarch64/appstream/os",
@@ -108,5 +130,27 @@
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for ARM 64 - AppStream - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-aarch64-appstream-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/aarch64/appstream/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EEUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for ARM 64 - BaseOS - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-aarch64-baseos-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/aarch64/baseos/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EEUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eeus-sap-solutions-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eeus-sap-solutions-x86_64.json
@@ -9,5 +9,16 @@
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - SAP Solutions - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-sap-solutions-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/x86_64/sap-solutions/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-SAP_SOLUTIONS-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eeus-sap-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eeus-sap-x86_64.json
@@ -9,5 +9,16 @@
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - SAP NetWeaver - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-sap-netweaver-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/x86_64/sap/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-SAP-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eeus-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eeus-x86_64.json
@@ -20,5 +20,27 @@
         "origin": "red_hat",
         "extended_release": "eeus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - AppStream - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-appstream-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/x86_64/appstream/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EEUS-x86_64,RHEL-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - BaseOS - 4 years of updates (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-baseos-e4s-rpms",
+        "url": "https://cdn.redhat.com/content/e4s/rhel10/10.2/x86_64/baseos/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EEUS-x86_64,RHEL-E4S-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eeus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eus-aarch64.json
+++ b/pkg/external_repos/snapshotted_repos/eus-aarch64.json
@@ -66,6 +66,39 @@
         "extended_release_version": "9.6"
     },
     {
+        "name": "Red Hat Enterprise Linux 9.8 for ARM 64 - AppStream - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-aarch64-appstream-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/appstream/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for ARM 64 - BaseOS - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-aarch64-baseos-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for ARM 64 - Supplementary - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-aarch64-supplementary-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/supplementary/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
         "name": "Red Hat Enterprise Linux 10.0 for ARM 64 - AppStream - Extended Update Support (RPMs)",
         "content_label": "rhel-10.0-for-aarch64-appstream-eus-rpms",
         "url": "https://cdn.redhat.com/content/eus/rhel10/10.0/aarch64/appstream/os",
@@ -97,5 +130,38 @@
         "origin": "red_hat",
         "extended_release": "eus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for ARM 64 - AppStream - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-aarch64-appstream-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/aarch64/appstream/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for ARM 64 - BaseOS - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-aarch64-baseos-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/aarch64/baseos/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for ARM 64 - Supplementary - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-aarch64-supplementary-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/aarch64/supplementary/os",
+        "distribution_arch": "aarch64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-aarch64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eus-sap-solutions-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eus-sap-solutions-x86_64.json
@@ -22,6 +22,17 @@
         "extended_release_version": "9.6"
     },
     {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - SAP Solutions - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-sap-solutions-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/sap-solutions/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-SAP_SOLUTIONS-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
         "name": "Red Hat Enterprise Linux 10.0 for x86_64 - SAP Solutions - Extended Update Support (RPMs)",
         "content_label": "rhel-10.0-for-x86_64-sap-solutions-eus-rpms",
         "url": "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/sap-solutions/os",
@@ -31,5 +42,16 @@
         "origin": "red_hat",
         "extended_release": "eus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - SAP Solutions - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-sap-solutions-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/x86_64/sap-solutions/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-SAP_SOLUTIONS-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eus-sap-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eus-sap-x86_64.json
@@ -22,6 +22,17 @@
         "extended_release_version": "9.6"
     },
     {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - SAP NetWeaver - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-sap-netweaver-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/sap/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-SAP-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
         "name": "Red Hat Enterprise Linux 10.0 for x86_64 - SAP NetWeaver - Extended Update Support (RPMs)",
         "content_label": "rhel-10.0-for-x86_64-sap-netweaver-eus-rpms",
         "url": "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/sap/os",
@@ -31,5 +42,16 @@
         "origin": "red_hat",
         "extended_release": "eus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - SAP NetWeaver - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-sap-netweaver-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/x86_64/sap/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-SAP-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
     }
 ]

--- a/pkg/external_repos/snapshotted_repos/eus-x86_64.json
+++ b/pkg/external_repos/snapshotted_repos/eus-x86_64.json
@@ -66,6 +66,39 @@
         "extended_release_version": "9.6"
     },
     {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - AppStream - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-appstream-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/appstream/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - BaseOS - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-baseos-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/baseos/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 9.8 for x86_64 - Supplementary - Extended Update Support (RPMs)",
+        "content_label": "rhel-9.8-for-x86_64-supplementary-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel9/9.8/x86_64/supplementary/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "9",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "9.8"
+    },
+    {
         "name": "Red Hat Enterprise Linux 10.0 for x86_64 - AppStream - Extended Update Support (RPMs)",
         "content_label": "rhel-10.0-for-x86_64-appstream-eus-rpms",
         "url": "https://cdn.redhat.com/content/eus/rhel10/10.0/x86_64/appstream/os",
@@ -97,5 +130,38 @@
         "origin": "red_hat",
         "extended_release": "eus",
         "extended_release_version": "10.0"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - AppStream - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-appstream-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/x86_64/appstream/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - BaseOS - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-baseos-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/x86_64/baseos/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
+    },
+    {
+        "name": "Red Hat Enterprise Linux 10.2 for x86_64 - Supplementary - Extended Update Support (RPMs)",
+        "content_label": "rhel-10.2-for-x86_64-supplementary-eus-rpms",
+        "url": "https://cdn.redhat.com/content/eus/rhel10/10.2/x86_64/supplementary/os",
+        "distribution_arch": "x86_64",
+        "distribution_version": "10",
+        "feature_name": "RHEL-EUS-x86_64",
+        "origin": "red_hat",
+        "extended_release": "eus",
+        "extended_release_version": "10.2"
     }
 ]


### PR DESCRIPTION
## Summary

Adds RHEL 9.8/10.2 eus/e4s/eeus releases

## Testing steps

9.8 and 10.2 repos should be snapshotted and usable

<img width="1544" height="296" alt="Screenshot From 2026-05-19 10-12-35" src="https://github.com/user-attachments/assets/16cf6270-26ac-44f5-a440-bba119619814" />
<img width="1559" height="475" alt="Screenshot From 2026-05-19 10-13-26" src="https://github.com/user-attachments/assets/77a3a2cc-5044-4827-a1de-688f93e27fb5" />


