### PR TITLE
Test: exclude EPEL, RH repos from BulkCreateCleanupURL test

### DIFF
--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -273,7 +273,7 @@ func (suite *RepositoryConfigSuite) TestCreateAlreadyExists() {
 	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
+	_, err = seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
 	assert.NoError(t, err)
 	var repo []models.Repository
 	err = tx.Limit(1).Find(&repo).Error
@@ -333,7 +333,7 @@ func (suite *RepositoryConfigSuite) TestCreateDuplicateLabel() {
 	orgID := seeds.RandomOrgId()
 	var err error
 
-	err = seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
+	_, err = seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
 	assert.NoError(t, err)
 	var repo []models.Repository
 	err = tx.Limit(1).Find(&repo).Error
@@ -529,10 +529,10 @@ func (suite *RepositoryConfigSuite) TestBulkCreateCleanupURL() {
 	orgID := seeds.RandomOrgId()
 	var repository models.Repository
 
-	err := seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
+	repo, err := seeds.SeedRepository(tx, 1, seeds.SeedOptions{})
 	require.NoError(t, err)
 
-	err = tx.Where("origin != ?", config.OriginUpload).Where("url IS NOT NULL").First(&repository).Error
+	err = tx.Where("origin not in ?", []string{config.OriginUpload, config.OriginCommunity, config.OriginRedHat}).Where("url = ?", repo[0].URL).First(&repository).Error
 	require.NoError(t, err)
 	assert.NotEmpty(t, repository)
 	urlNoSlash := repository.URL[0 : len(repository.URL)-1]

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -151,7 +151,7 @@ func getIntrospectionTimestamps(lastIntrospectionStatus string) IntrospectionSta
 	return metadata
 }
 
-func SeedRepository(db *gorm.DB, size int, options SeedOptions) error {
+func SeedRepository(db *gorm.DB, size int, options SeedOptions) ([]models.Repository, error) {
 	var repos []models.Repository
 
 	// Add size random Repository entries
@@ -171,7 +171,7 @@ func SeedRepository(db *gorm.DB, size int, options SeedOptions) error {
 		repos = append(repos, repo)
 		if len(repos) >= batchSize {
 			if r := db.Create(repos); r != nil && r.Error != nil {
-				return r.Error
+				return nil, r.Error
 			}
 			countRecords += len(repos)
 			repos = []models.Repository{}
@@ -183,13 +183,13 @@ func SeedRepository(db *gorm.DB, size int, options SeedOptions) error {
 	if len(repos) > 0 {
 		r := db.Create(&repos)
 		if r.Error != nil {
-			return r.Error
+			return nil, r.Error
 		}
 		countRecords += len(repos)
 		fmt.Printf("repoConfig: %d        \r", countRecords)
 	}
 
-	return nil
+	return repos, nil
 }
 
 func SeedSnapshots(db *gorm.DB, repoConfigUuid string, size int) ([]models.Snapshot, error) {

--- a/pkg/seeds/seeds_test.go
+++ b/pkg/seeds/seeds_test.go
@@ -30,7 +30,7 @@ func (s *SeedSuite) TestSeedRepository() {
 	var err error
 	tx := s.tx
 
-	err = SeedRepository(tx, 505, SeedOptions{})
+	_, err = SeedRepository(tx, 505, SeedOptions{})
 	assert.Nil(t, err, "Error seeding Repositories")
 }
 


### PR DESCRIPTION
## Summary

Excludes EPEL and RH repos from the query in BulkCreateCleanupURL so the test does not intermittently fail if one of the seeded repos is found first

## Testing steps

TestBulkCreateCleanupURL passes consistently