### PR TITLE
Build: bump yummy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
 	github.com/content-services/tang v0.0.17
-	github.com/content-services/yummy v1.0.18
+	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
 github.com/content-services/tang v0.0.17 h1:sDL70hDbSmFBCLu9qZ5Mm3npFdA8Yhf+kpn+T3Xheus=
 github.com/content-services/tang v0.0.17/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
-github.com/content-services/yummy v1.0.18 h1:+2O7OuhNbLkJ57X96Rqp2QjA9700lBZH0+TVfQ45Xqs=
-github.com/content-services/yummy v1.0.18/go.mod h1:amF1J0cbrwL19dcRZrvIC6POPEbMV4C6M8kP8kcl/VI=
+github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
+github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.5.1778263552 h1:jvPORpYJQTrFsXo/Kk+fFcl4YyeG6QqdSDiUdOr5kGg=
 github.com/content-services/zest/release/v2026 v2026.5.1778263552/go.mod h1:pThh4a5Qm53BZ5V3WqRkWx7WBrIaeDdAnTmmqi6j8Vw=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=


### PR DESCRIPTION
## Summary

Bump yummy to include increased max XML size that can be parsed for introspection

## Testing steps

Import and introspect the RHEL 9.8 arm baseos repos:

```
make repos-import

go run cmd/external-repos/main.go introspect --url https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os --url https://cdn.redhat.com/content/e4s/rhel9/9.8/aarch64/baseos/os
```

You shouldn't see an introspection error