### PR TITLE
HMS-10698: improve rbac 401 logging

### DIFF
--- a/pkg/middleware/extract_status.go
+++ b/pkg/middleware/extract_status.go
@@ -25,6 +25,11 @@ func ExtractStatus(next echo.HandlerFunc) echo.HandlerFunc {
 					}
 				}
 				c.Response().Status = largest
+			} else {
+				var echoErr *echo.HTTPError
+				if errors.As(err, &echoErr) {
+					c.Response().Status = echoErr.Code
+				}
 			}
 			return err
 		}

--- a/pkg/middleware/rbac.go
+++ b/pkg/middleware/rbac.go
@@ -8,6 +8,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/rbac"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/rs/zerolog"
 )
 
@@ -71,12 +72,15 @@ func NewRbac(rbacConfig Rbac) echo.MiddlewareFunc {
 				allowed, err = rbacConfig.RbacClient.Allowed(c.Request().Context(), resource, verb)
 			}
 
+			data := identity.GetIdentity(c.Request().Context())
+			orgID := data.Identity.Internal.OrgID
+
 			if err != nil {
-				logger.Error().Err(err).Msg("error checking permissions")
+				logger.Error().Err(err).Str("org_id", orgID).Str("resource", string(resource)).Str("verb", string(verb)).Msg("error checking permissions")
 				return echo.ErrUnauthorized
 			}
 			if !allowed {
-				logger.Debug().Msg("request not allowed")
+				logger.Warn().Str("org_id", orgID).Str("resource", string(resource)).Str("verb", string(verb)).Msg("request not allowed")
 				return echo.ErrUnauthorized
 			}
 


### PR DESCRIPTION
## Summary
Fixes the logging so that 401 is returned in the status field. Also adds the org, resources, and verb to the log for additional debugging information.

## Testing steps
1. Enable mock_rbac
2. Make sure the user name in your identity header has no permissions
3. Make a request to an endpoint, you should get a 401
4. Check the logs, you should see the logs say `status:401` and also show the org, resource, and verb for the denied permission request
