### PR TITLE
HMS-10467: Making deletions tasks more resilient

### DIFF
--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -33,7 +33,9 @@ type DeleteRepositorySnapshots struct {
 
 // This org may or may not have a domain created in pulp, so make sure the domain exists and if not, return a nil pulpClient
 func lookupOptionalPulpClient(ctx context.Context, globalClient pulp_client.PulpGlobalClient, task *models.TaskInfo, daoReg *dao.DaoRegistry) (*pulp_client.PulpClient, error) {
+	logger := LogForTask(task.Id.String(), task.Typename, task.RequestID)
 	if !config.PulpConfigured() {
+		logger.Debug().Msg("pulp not configured, skipping pulp client setup")
 		return nil, nil
 	}
 	domainName, err := daoReg.Domain.FetchOrCreateDomain(ctx, task.OrgId)
@@ -51,6 +53,10 @@ func lookupOptionalPulpClient(ctx context.Context, globalClient pulp_client.Pulp
 		client := pulp_client.GetPulpClientWithDomain(domainName)
 		return &client, nil
 	}
+	logger.Debug().
+		Str("org_id", task.OrgId).
+		Str("domain_name", domainName).
+		Msg("no pulp domain found for org, org has never snapshotted, skipping pulp cleanup")
 	return nil, nil
 }
 
@@ -100,13 +106,13 @@ func (d *DeleteRepositorySnapshots) Run() error {
 		// Do not throw an error if not found
 		latestDistro, err := d.getPulpClient().FindDistributionByPath(d.ctx, latestPathIdent)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to find latest distribution by path %v: %w", latestPathIdent, err)
 		}
 
 		if latestDistro != nil {
 			_, err := d.deleteRpmDistribution(*latestDistro.PulpHref)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to delete latest distribution %v: %w", *latestDistro.PulpHref, err)
 			}
 		}
 
@@ -115,20 +121,25 @@ func (d *DeleteRepositorySnapshots) Run() error {
 			return err
 		}
 
+		var snapErrs []error
 		for _, snap := range snaps {
 			_, err = d.deleteRpmDistribution(snap.DistributionHref)
 			if err != nil {
-				return err
+				snapErrs = append(snapErrs, err)
+				continue
 			}
-			err = d.deleteTemplateSnapshot(snap.UUID)
-			if err != nil {
-				return err
+			if err = d.deleteTemplateSnapshot(snap.UUID); err != nil {
+				snapErrs = append(snapErrs, err)
+				continue
 			}
-			err = d.deleteSnapshot(snap.UUID)
-			if err != nil {
-				return err
+			if err = d.deleteSnapshot(snap.UUID); err != nil {
+				snapErrs = append(snapErrs, err)
 			}
 		}
+		if err = errors.Join(snapErrs...); err != nil {
+			return err
+		}
+		// only runs if all snaps deletes succeed
 		_, _, err = d.deleteRpmRepoAndRemote()
 		if err != nil {
 			return err
@@ -160,60 +171,80 @@ func (d *DeleteRepositorySnapshots) fetchSnapshots() ([]models.Snapshot, error) 
 }
 
 func (d *DeleteRepositorySnapshots) deleteRpmDistribution(snapDistributionHref string) (*zest.TaskResponse, error) {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	deleteDistributionHref, err := d.getPulpClient().DeleteRpmDistribution(d.ctx, snapDistributionHref)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to delete rpm distribution %v: %w", snapDistributionHref, err)
 	}
 	if deleteDistributionHref == nil {
+		logger.Debug().
+			Str("distribution_href", snapDistributionHref).
+			Msg("no task href returned for distribution deletion, distribution may have already been deleted")
 		return nil, nil
 	}
 	task, err := d.getPulpClient().PollTask(d.ctx, *deleteDistributionHref)
 	if err != nil {
-		return task, err
+		return task, fmt.Errorf("error polling distribution deletion task for %v: %w", snapDistributionHref, err)
 	}
 	return task, nil
 }
 
 func (d *DeleteRepositorySnapshots) deleteRpmRepoAndRemote() (taskRepo, taskRemote *zest.TaskResponse, err error) {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
+
 	remoteResp, err := d.getPulpClient().GetRpmRemoteByName(d.ctx, d.payload.RepoConfigUUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to look up rpm remote: %w", err)
+	}
+	if remoteResp == nil {
+		logger.Debug().
+			Str("repo_config_uuid", d.payload.RepoConfigUUID).
+			Msg("no rpm remote found, skipping remote deletion")
 	}
 	if remoteResp != nil {
 		remoteHref := remoteResp.PulpHref
 		deleteRemoteHref, err := d.getPulpClient().DeleteRpmRemote(d.ctx, *remoteHref)
 		if err != nil {
-			return taskRepo, nil, err
+			return taskRepo, nil, fmt.Errorf("failed to delete rpm remote %v: %w", *remoteHref, err)
 		}
 		taskRemote, err = d.getPulpClient().PollTask(d.ctx, deleteRemoteHref)
 		if err != nil {
-			return taskRepo, taskRemote, err
+			return taskRepo, taskRemote, fmt.Errorf("error polling rpm remote deletion task for %v: %w", *remoteHref, err)
 		}
 	}
 
 	repoResp, err := d.getPulpClient().GetRpmRepositoryByName(d.ctx, d.payload.RepoConfigUUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to look up rpm repository: %w", err)
+	}
+	if repoResp == nil {
+		logger.Debug().
+			Str("repo_config_uuid", d.payload.RepoConfigUUID).
+			Msg("no rpm repository found, skipping repository deletion")
 	}
 	if repoResp != nil {
 		repoHref := repoResp.PulpHref
 		deleteRepoHref, err := d.getPulpClient().DeleteRpmRepository(d.ctx, *repoHref)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("failed to delete rpm repository %v: %w", *repoHref, err)
 		}
 		taskRepo, err = d.getPulpClient().PollTask(d.ctx, deleteRepoHref)
 		if err != nil {
-			return taskRepo, nil, err
+			return taskRepo, nil, fmt.Errorf("error polling rpm repository deletion task for %v: %w", *repoHref, err)
 		}
 	}
 	return taskRepo, taskRemote, nil
 }
 
 func (d *DeleteRepositorySnapshots) deleteSnapshot(snapUUID string) error {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	err := d.daoReg.Snapshot.Delete(d.ctx, snapUUID)
 	if err != nil {
 		var daoErr *ce.DaoError
 		if errors.As(err, &daoErr) && daoErr.NotFound {
+			logger.Warn().
+				Str("snapshot_uuid", snapUUID).
+				Msg("snapshot not found during deletion, already deleted")
 			return nil
 		}
 		return fmt.Errorf("error deleting snapshot %v: %w", snapUUID, err)
@@ -222,10 +253,14 @@ func (d *DeleteRepositorySnapshots) deleteSnapshot(snapUUID string) error {
 }
 
 func (d *DeleteRepositorySnapshots) deleteRepoConfig() error {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	err := d.daoReg.RepositoryConfig.Delete(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
 	if err != nil {
 		var daoErr *ce.DaoError
 		if errors.As(err, &daoErr) && daoErr.NotFound {
+			logger.Warn().
+				Str("repo_config_uuid", d.payload.RepoConfigUUID).
+				Msg("repo config not found during deletion, already deleted")
 			return nil
 		}
 		return fmt.Errorf("error deleting repository configuration: %w", err)
@@ -249,13 +284,15 @@ func (d *DeleteRepositorySnapshots) candlepinRHContentId(templateOrgId string, r
 }
 
 func (d *DeleteRepositorySnapshots) deleteCandlepinContent() error {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	if !config.CandlepinConfigured() {
+		logger.Debug().Msg("candlepin not configured, skipping candlepin content deletion")
 		return nil
 	}
 	if d.task.OrgId == config.RedHatOrg {
 		templates, err := d.daoReg.Template.InternalOnlyGetTemplatesForRepoConfig(d.ctx, d.payload.RepoConfigUUID, false)
 		if err != nil {
-			return fmt.Errorf("couldn't get templates for repo config")
+			return fmt.Errorf("couldn't get templates for repo config: %w", err)
 		}
 		for _, template := range templates {
 			// We have to lookup the content ID for RH content, as its based on the repo label
@@ -265,37 +302,39 @@ func (d *DeleteRepositorySnapshots) deleteCandlepinContent() error {
 			}
 			err = d.cpClient.DemoteContentFromEnvironment(d.ctx, template.UUID, []string{contentId})
 			if err != nil {
-				return fmt.Errorf("couldn't demote content from environment, %v", err)
+				return fmt.Errorf("couldn't demote content from environment for template %v: %w", template.UUID, err)
 			}
 		}
 	} else {
 		err := d.cpClient.RemoveContentFromProduct(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to remove content from candlepin product: %w", err)
 		}
 
 		err = d.cpClient.DeleteContent(d.ctx, d.task.OrgId, d.payload.RepoConfigUUID)
 		if err != nil {
-			return err
+			return fmt.Errorf("error deleting candlepin content: %w", err)
 		}
 	}
 
 	return nil
 }
 
-func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() (err error) {
+func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() error {
 	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
+	var errs []error
 
 	var templates []api.TemplateResponse
 	if d.task.OrgId == config.RedHatOrg {
+		var err error
 		templates, err = d.daoReg.Template.InternalOnlyGetTemplatesForRepoConfig(d.ctx, d.payload.RepoConfigUUID, false)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get templates for repo config: %w", err)
 		}
 	} else {
 		templateResponse, _, err := d.daoReg.Template.List(d.ctx, d.task.OrgId, true, api.PaginationData{Limit: -1}, api.TemplateFilterData{RepositoryUUIDs: []string{d.payload.RepoConfigUUID}})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get templates for repo config: %w", err)
 		}
 		templates = templateResponse.Data
 	}
@@ -303,7 +342,8 @@ func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() (err error
 	for _, template := range templates {
 		distHref, err := d.daoReg.Template.GetDistributionHref(d.ctx, template.UUID, d.payload.RepoConfigUUID)
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("failed to get distribution href for template %v: %w", template.UUID, err))
+			continue
 		}
 
 		if distHref == nil {
@@ -315,25 +355,29 @@ func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() (err error
 
 		taskHref, err := d.getPulpClient().DeleteRpmDistribution(d.ctx, *distHref)
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("failed to delete rpm distribution %v for template %v: %w", *distHref, template.UUID, err))
+			continue
 		}
 
 		if taskHref != nil {
-			_, err = d.getPulpClient().PollTask(d.ctx, *taskHref)
-			if err != nil {
-				return err
+			if _, err = d.getPulpClient().PollTask(d.ctx, *taskHref); err != nil {
+				errs = append(errs, fmt.Errorf("error polling distribution deletion task for template %v: %w", template.UUID, err))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (d *DeleteRepositorySnapshots) deleteTemplateSnapshot(snapshotUUID string) error {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	err := d.daoReg.Template.DeleteTemplateSnapshot(d.ctx, snapshotUUID)
 	if err != nil {
 		var daoErr *ce.DaoError
 		if errors.As(err, &daoErr) && daoErr.NotFound {
+			logger.Warn().
+				Str("snapshot_uuid", snapshotUUID).
+				Msg("template snapshot association not found during deletion, already deleted")
 			return nil
 		}
 		return fmt.Errorf("error deleting template snapshot %v: %w", snapshotUUID, err)

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -12,6 +12,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
@@ -79,48 +80,73 @@ func (ds *DeleteSnapshots) Run() error {
 	} else if config.PulpConfigured() && ds.pulpClient != nil {
 		err := ds.configurePulpClient()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to configure pulp client: %w", err)
 		}
 	}
 
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID)
+	var errs []error
 	for _, snapUUID := range ds.payload.SnapshotsUUIDs {
 		templateUpdateMap := make(map[string]models.Snapshot)
 		snap, err := ds.daoReg.Snapshot.FetchModel(ds.ctx, snapUUID, true)
 		if err != nil {
-			return err
+			var daoErr *ce.DaoError
+			if errors.As(err, &daoErr) && daoErr.NotFound {
+				logger.Warn().
+					Str("snapshot_uuid", snapUUID).
+					Msg("snapshot not found, skipping (already deleted)")
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to fetch snapshot %v: %w", snapUUID, err))
+			continue
 		}
 		repo, err := ds.daoReg.RepositoryConfig.Fetch(ds.ctx, ds.orgID, snap.RepositoryConfigurationUUID)
 		if err != nil {
-			return err
+			var daoErr *ce.DaoError
+			if errors.As(err, &daoErr) && daoErr.NotFound {
+				logger.Warn().
+					Str("repo_config_uuid", snap.RepositoryConfigurationUUID).
+					Str("snapshot_uuid", snapUUID).
+					Msg("repo config not found for snapshot, skipping")
+				continue
+			}
+			errs = append(errs, fmt.Errorf("couldn't fetch repo config %v for snapshot %v: %w", snap.RepositoryConfigurationUUID, snapUUID, err))
+			continue
 		}
 
-		err = ds.updateTemplatesUsingSnap(&templateUpdateMap, snap)
-		if err != nil {
-			return err
+		if err = ds.updateTemplatesUsingSnap(&templateUpdateMap, snap); err != nil {
+			errs = append(errs, fmt.Errorf("couldn't update templates for snapshot %v: %w", snapUUID, err))
+			continue
 		}
-		err = ds.daoReg.Template.DeleteTemplateSnapshot(ds.ctx, snap.UUID)
-		if err != nil {
-			return err
+		if err = ds.daoReg.Template.DeleteTemplateSnapshot(ds.ctx, snap.UUID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete template snapshot associations for snapshot %v: %w", snapUUID, err))
+			continue
 		}
 		if repo.LastSnapshotUUID == snapUUID {
-			err = ds.updateRepoConfig(repo.UUID, snapUUID)
-			if err != nil {
-				return err
+			if err = ds.updateRepoConfig(repo.UUID, snapUUID); err != nil {
+				errs = append(errs, fmt.Errorf("failed to update repo config for snapshot %v: %w", snapUUID, err))
+				continue
 			}
 		}
 
-		err = ds.deleteOrUpdatePulpContent(snap, repo, templateUpdateMap)
-		if err != nil {
-			return err
+		if err = ds.deleteOrUpdatePulpContent(snap, repo, templateUpdateMap); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete pulp content for snapshot %v: %w", snapUUID, err))
+			continue
 		}
 
-		err = ds.daoReg.Snapshot.Delete(ds.ctx, snapUUID)
-		if err != nil {
-			return err
+		if err = ds.daoReg.Snapshot.Delete(ds.ctx, snapUUID); err != nil {
+			var daoErr *ce.DaoError
+			if errors.As(err, &daoErr) && daoErr.NotFound {
+				logger.Warn().
+					Str("snapshot_uuid", snapUUID).
+					Msg("snapshot not found during deletion, already deleted")
+			} else {
+				errs = append(errs, fmt.Errorf("failed to delete snapshot %v: %w", snapUUID, err))
+			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (ds *DeleteSnapshots) getPulpClient() pulp_client.PulpClient {
@@ -157,7 +183,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 	for templateUUID, snaps := range templateUpdateMap {
 		distPath, distName, err := getDistPathAndName(repo, templateUUID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get distribution path/name for template %v: %w", templateUUID, err)
 		}
 
 		// Get the stored distribution href from DB for comparison
@@ -171,7 +197,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 
 		if storedDistHref == nil {
 			logger.Warn().Str("template_uuid", templateUUID).Msg("distribution href is null")
-			return nil
+			continue
 		}
 
 		logger.Info().
@@ -190,7 +216,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 				Err(err).
 				Str("dist_path", distPath).
 				Msg("Error finding distribution by path")
-			return err
+			return fmt.Errorf("failed to find distribution by path %v for template %v: %w", distPath, templateUUID, err)
 		}
 		if existingDist == nil {
 			logger.Warn().
@@ -207,23 +233,23 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 
 		_, _, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, snaps.PublicationHref, distName, distPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to update distribution for template %v: %w", templateUUID, err)
 		}
 	}
 
 	latestPathIdent := fmt.Sprintf("%v/%v", repo.UUID, "latest")
 	latestDistro, err := ds.getPulpClient().FindDistributionByPath(ds.ctx, latestPathIdent)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to find latest distribution by path %v: %w", latestPathIdent, err)
 	}
 	if latestDistro != nil {
 		latestSnap, err := ds.daoReg.Snapshot.FetchLatestSnapshotModel(ds.ctx, repo.UUID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to fetch latest snapshot for repo %v: %w", repo.UUID, err)
 		}
 		_, _, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, latestSnap.PublicationHref, repo.UUID, latestPathIdent)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to update latest distribution for repo %v: %w", repo.UUID, err)
 		}
 	}
 
@@ -238,12 +264,12 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 			Err(err).
 			Str("distribution_href", snap.DistributionHref).
 			Msg("Error deleting snapshot distribution")
-		return err
+		return fmt.Errorf("failed to delete snapshot distribution %v: %w", snap.DistributionHref, err)
 	}
 	if deleteDistributionHref != nil {
 		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteDistributionHref)
 		if err != nil {
-			return err
+			return fmt.Errorf("error polling snapshot distribution deletion task for %v: %w", snap.DistributionHref, err)
 		}
 	}
 
@@ -295,7 +321,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 	if err != nil {
 		distributions, listDistErr := ds.getPulpClient().ListDistributions(ds.ctx)
 		if listDistErr != nil {
-			return listDistErr
+			return fmt.Errorf("failed to list distributions after version delete failure for snapshot %v: %w", snap.UUID, listDistErr)
 		}
 		logger.Debug().Msgf("Checking distributions for publication: %v", snap.PublicationHref)
 		if distributions != nil {
@@ -312,12 +338,12 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 				}
 			}
 		}
-		return err
+		return fmt.Errorf("failed to delete repository version %v for snapshot %v: %w", snap.VersionHref, snap.UUID, err)
 	}
 	if deleteVersionHref != nil {
 		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteVersionHref)
 		if err != nil {
-			return err
+			return fmt.Errorf("error polling repository version deletion task for snapshot %v: %w", snap.UUID, err)
 		}
 	}
 

--- a/pkg/tasks/delete_templates.go
+++ b/pkg/tasks/delete_templates.go
@@ -90,7 +90,7 @@ func (d *DeleteTemplates) Run() error {
 	if config.CandlepinConfigured() {
 		err = d.cpClient.DeleteEnvironment(d.ctx, d.payload.TemplateUUID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to delete candlepin environment: %w", err)
 		}
 	}
 
@@ -104,17 +104,26 @@ func (d *DeleteTemplates) Run() error {
 // deleteDistributions deletes all the pulp distributions for the repositories in the given template
 func (d *DeleteTemplates) deleteDistributions() error {
 	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
+	var errs []error
 
 	for _, repoConfigUUID := range d.payload.RepoConfigUUIDs {
 		repo, err := d.daoReg.RepositoryConfig.Fetch(d.ctx, d.orgID, repoConfigUUID)
 		if err != nil {
 			var daoErr *ce.DaoError
 			if errors.As(err, &daoErr) && daoErr.NotFound {
+				logger.Warn().
+					Str("repo_config_uuid", repoConfigUUID).
+					Str("template_uuid", d.payload.TemplateUUID).
+					Msg("repo config not found, skipping distribution deletion")
 				continue
 			}
-			return err
+			errs = append(errs, fmt.Errorf("failed to fetch repo config %v: %w", repoConfigUUID, err))
+			continue
 		}
 		if repo.LastSnapshot == nil {
+			logger.Debug().
+				Str("repo_config_uuid", repoConfigUUID).
+				Msg("repo config has no snapshot, skipping distribution deletion")
 			continue
 		}
 
@@ -130,35 +139,44 @@ func (d *DeleteTemplates) deleteDistributions() error {
 
 		distHref, err := d.daoReg.Template.GetDistributionHref(d.ctx, d.payload.TemplateUUID, repoConfigUUID)
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("error getting distribution href for repo %v: %w", repoConfigUUID, err))
+			continue
 		}
 
 		if distHref == nil {
 			logger.Warn().
 				Str("template_uuid", d.payload.TemplateUUID).
 				Msg("distribution href is null")
-			return nil
+			continue
 		}
 
 		taskHref, err := d.pulpClient.DeleteRpmDistribution(d.ctx, *distHref)
 		if err != nil {
-			return err
+			errs = append(errs, fmt.Errorf("failed to delete rpm distribution %v for repo %v: %w", *distHref, repoConfigUUID, err))
+			continue
 		}
 
 		if taskHref != nil {
-			_, err = d.pulpClient.PollTask(d.ctx, *taskHref)
-			if err != nil {
-				return err
+			if _, err = d.pulpClient.PollTask(d.ctx, *taskHref); err != nil {
+				errs = append(errs, fmt.Errorf("error polling distribution deletion task for repo %v: %w", repoConfigUUID, err))
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (d *DeleteTemplates) deleteTemplate() error {
+	logger := LogForTask(d.task.Id.String(), d.task.Typename, d.task.RequestID)
 	err := d.daoReg.Template.Delete(d.ctx, d.task.OrgId, d.payload.TemplateUUID)
 	if err != nil {
-		return err
+		var daoErr *ce.DaoError
+		if errors.As(err, &daoErr) && daoErr.NotFound {
+			logger.Warn().
+				Str("template_uuid", d.payload.TemplateUUID).
+				Msg("template not found during deletion, already deleted")
+			return nil
+		}
+		return fmt.Errorf("failed to delete template: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Previously, if any of the 3 deletion tasks:
`delete_snapshots`
`delete_templates`
`delete_repository_snapshots`
failed to delete a resource, it was not exactly clear where and why it happened.

To make it more resilient, this was changed:
- detailed failure messages were added to identify easily which op caused a failure
- logging warnings if a resource was not found or nil
- loops now return errors at the end, so all the resources in a loop get a chance to be deleted

## Testing steps

Test manually by creating templates, repositories with snapshots and without snapshots and then deleting them.
Everything works as before, but you get much better idea what is happening if anything fails.
Automated tests pass.
