### PR TITLE
Build: add update cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "Build: "
     ignore:
@@ -15,3 +17,9 @@ updates:
       go:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+    "minimumReleaseAge": "5 days",
     "extends": [
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],


### PR DESCRIPTION
## Summary
This adds cooldowns to dependabot and renovate, so they will only update packages to new version if they are at least 5 days old.
