### PR TITLE
HMS-10486: increase introspect timeout, enqueue once per job

### DIFF
--- a/cmd/external-repos/main.go
+++ b/cmd/external-repos/main.go
@@ -104,6 +104,10 @@ func main() {
 						Name:  "force",
 						Usage: "Force snapshot of the repository",
 					},
+					&cli.BoolFlag{
+						Name:  "introspect",
+						Usage: "Introspect the repository before snapshotting",
+					},
 				},
 			},
 		},

--- a/mk/repos.mk
+++ b/mk/repos.mk
@@ -22,6 +22,6 @@ repos-import-rhel10: ## Import only rhel 10 repos
 .PHONY: repos-minimal
 repos-minimal: ## Import and snapshot repos needed for a minimal setup, usefull for Playwright testing, currently: SMALL + EPEL10
 	OPTIONS_REPOSITORY_IMPORT_FILTER=small go run ./cmd/external-repos/main.go import
-	go run cmd/external-repos/main.go snapshot --url https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/ --force
+	go run cmd/external-repos/main.go snapshot --url https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/ --force --introspect
 	OPTIONS_REPOSITORY_IMPORT_FILTER=epel10 go run ./cmd/external-repos/main.go import
 	go run cmd/external-repos/main.go introspect --url https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/ --force

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -525,7 +525,7 @@ func (r *rpmDaoImpl) InsertForRepository(ctx context.Context, repoUuid string, p
 		DoNothing: true,
 	}).Create(dbPkgs)
 	if result.Error != nil {
-		return 0, fmt.Errorf("failed to PagedRpmInsert: %w", err)
+		return 0, fmt.Errorf("failed to PagedRpmInsert: %w", result.Error)
 	}
 
 	// Now fetch the uuids of all the rpms we want associated to the repository

--- a/pkg/external_repos/commands/process_repos.go
+++ b/pkg/external_repos/commands/process_repos.go
@@ -28,7 +28,7 @@ func ProcessReposAction(c *cli.Context) error {
 	}
 	if config.Get().Features.Snapshots.Enabled {
 		waitForPulp(ctx)
-		err = enqueueSnapshotRepos(ctx, nil, interval, false)
+		err = enqueueSnapshotRepos(ctx, nil, interval, false, false)
 		if err != nil {
 			log.Error().Err(err).Msg("error queueing snapshot tasks")
 		}
@@ -45,11 +45,20 @@ func enqueueIntrospectAllRepos(ctx context.Context) error {
 	c := client.NewTaskClient(&q)
 
 	repoDao := dao.GetRepositoryDao(db.DB)
+	taskInfoDao := dao.GetTaskInfoDao(db.DB)
 	repos, err := repoDao.ListForIntrospection(ctx, nil, false)
 	if err != nil {
 		return fmt.Errorf("error getting repositories: %w", err)
 	}
 	for _, repo := range repos {
+		taskIDs, err := taskInfoDao.FetchActiveTasks(ctx, "", repo.UUID, config.IntrospectTask)
+		if err != nil {
+			log.Err(err).Msgf("error checking active introspect tasks for %v", repo.URL)
+		}
+		if len(taskIDs) > 0 {
+			log.Debug().Msgf("skipping introspect for %v, task already exists", repo.URL)
+			continue
+		}
 		t := queue.Task{
 			Typename: payloads.Introspect,
 			Payload: payloads.IntrospectPayload{

--- a/pkg/external_repos/commands/snapshot.go
+++ b/pkg/external_repos/commands/snapshot.go
@@ -25,6 +25,7 @@ func SnapshotAction(c *cli.Context) error {
 	ctx := c.Context
 	urlsParam := c.StringSlice("url")
 	force := c.Bool("force")
+	shouldIntrospect := c.Bool("introspect")
 
 	var urls []string
 	for _, url := range urlsParam {
@@ -33,7 +34,7 @@ func SnapshotAction(c *cli.Context) error {
 
 	if config.Get().Features.Snapshots.Enabled {
 		waitForPulp(ctx)
-		err := enqueueSnapshotRepos(ctx, &urls, nil, force)
+		err := enqueueSnapshotRepos(ctx, &urls, nil, force, shouldIntrospect)
 		if err != nil {
 			log.Warn().Msgf("Error enqueuing snapshot tasks: %v", err)
 		}
@@ -60,7 +61,7 @@ func waitForPulp(ctx context.Context) {
 	}
 }
 
-func enqueueSnapshotRepos(ctx context.Context, urls *[]string, interval *int, force bool) error {
+func enqueueSnapshotRepos(ctx context.Context, urls *[]string, interval *int, force bool, shouldIntrospect bool) error {
 	q, err := queue.NewPgQueue(ctx, db.GetUrl())
 	if err != nil {
 		return fmt.Errorf("error getting new task queue: %w", err)
@@ -85,21 +86,40 @@ func enqueueSnapshotRepos(ctx context.Context, urls *[]string, interval *int, fo
 	}
 
 	for _, repo := range repoConfigs {
-		t := queue.Task{
-			Typename: config.IntrospectTask,
-			Payload: payloads.IntrospectPayload{
-				Url: repo.Repository.URL,
-			},
-			OrgId:      repo.OrgID,
-			AccountId:  repo.AccountID,
-			ObjectUUID: &repo.RepositoryUUID,
-			ObjectType: utils.Ptr(config.ObjectTypeRepository),
-		}
-		_, err = c.Enqueue(t)
-		if err != nil {
-			log.Err(err).Msgf("error enqueueing introspection for repository %v", repo.Name)
+		var t queue.Task
+		if shouldIntrospect {
+			taskIDs, err := dao.GetTaskInfoDao(db.DB).FetchActiveTasks(ctx, repo.OrgID, repo.RepositoryUUID, config.IntrospectTask)
+			if err != nil {
+				log.Err(err).Msgf("error checking active introspect tasks for %v", repo.Repository.URL)
+			}
+			if len(taskIDs) > 0 {
+				log.Debug().Msgf("skipping introspect for %v, task already exists", repo.Repository.URL)
+			} else {
+				t = queue.Task{
+					Typename: config.IntrospectTask,
+					Payload: payloads.IntrospectPayload{
+						Url: repo.Repository.URL,
+					},
+					OrgId:      repo.OrgID,
+					AccountId:  repo.AccountID,
+					ObjectUUID: &repo.RepositoryUUID,
+					ObjectType: utils.Ptr(config.ObjectTypeRepository),
+				}
+				_, err = c.Enqueue(t)
+				if err != nil {
+					log.Err(err).Msgf("error enqueueing introspection for repository %v", repo.Name)
+				}
+			}
 		}
 
+		taskIDs, err := dao.GetTaskInfoDao(db.DB).FetchActiveTasks(ctx, repo.OrgID, repo.RepositoryUUID, config.RepositorySnapshotTask)
+		if err != nil {
+			log.Err(err).Msgf("error checking active snapshot tasks for %v", repo.Repository.URL)
+		}
+		if len(taskIDs) > 0 {
+			log.Debug().Msgf("skipping snapshot for %v, task already exists", repo.Repository.URL)
+			continue
+		}
 		t = queue.Task{
 			Typename:   config.RepositorySnapshotTask,
 			Payload:    payloads.SnapshotPayload{},

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -26,7 +26,7 @@ import (
 const (
 	RhCdnHost                = "cdn.redhat.com"
 	cdnResponseHeaderTimeout = 180 * time.Second
-	cdnRequestTimeout        = 360 * time.Second
+	cdnRequestTimeout        = 10 * time.Minute
 )
 
 // IntrospectUrl Fetch the metadata of a url and insert RPM data

--- a/pkg/external_repos/introspect.go
+++ b/pkg/external_repos/introspect.go
@@ -62,7 +62,7 @@ func IntrospectUrl(ctx context.Context, url string, origin *string) (int64, erro
 	// Logic to handle notifications.  This should really be moved to a daily report?
 	sendIntrospectionNotifications(ctx, introspectSuccessUuids, introspectFailedUuids, dao)
 
-	return total, introspectionError, err
+	return count, introspectionError, err
 }
 
 // IsRedHat returns if the url is a 'cdn.redhat.com' url


### PR DESCRIPTION
## Summary

- Increases CDN request timeout during introspection from 6 to 10 minutes. In stage, some larger repos are getting close to hitting the 6 minute limit:
```
{"level":"debug","task_type":"introspect","task_id":"c965a698-1d90-483d-b632-e1dcfeb85b4b","request_id":"","url":"https://cdn.redhat.com/content/eus/rhel9/9.8/aarch64/baseos/os/","phase":"parse_packages","duration":331.864419797,"time":"2026-06-01T14:05:39Z","severity":"debug","message":"introspection phase parse_packages completed"}
```
-  Adjusts the `process-repos` job and snapshot command to only enqueue one introspect task per repo and prevent new introspect or snapshot tasks if any are already active for a repo
- Adds an optional `--introspect` flag to the snapshot command and updates `make repos-minimal` to use this
- Fixes a couple methods used during introspection to return proper values

## Testing steps

1. Run `make repos-import && make process-repos`. All introspect tasks should succeed and there should only be one per repo
2. Running `make process-repos` twice in a row shouldn't add multiple introspects for a repo
2. `make repos-minimal` should still introspect and snapshot the "small" repo (RHEL9 ARM codeready)