### PR TITLE
Build: group dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       go:
         patterns:
           - "*"
+      npm:
+        patterns:
+          - '*'
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
Groups npm package updates so that dependabot opens one PR with many updates instead of many PRs with one update

## Testing steps

