### PR TITLE
Build: fix group npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,13 @@ updates:
       go:
         patterns:
           - "*"
-      npm:
-        patterns:
-          - '*'
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 5
+    groups:
+      npm:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
the dependabot npm grouping was accidentally put under the go ecosystem configuration

## Testing steps

