### PR TITLE
Test: run post-test cleanup sequentially

### DIFF
--- a/_playwright-tests/test-utils/src/fixtures/cleanup.ts
+++ b/_playwright-tests/test-utils/src/fixtures/cleanup.ts
@@ -63,7 +63,9 @@ export const cleanupTest = oldTest.extend<WithCleanup>({
     await cleanupTest.step(
       'Post-test cleanup',
       async () => {
-        await Promise.all(Array.from(cleanupFns).map(([, fn]) => fn()));
+        for (const [, fn] of cleanupFns) {
+          await fn();
+        }
       },
       { box: true },
     );


### PR DESCRIPTION


## Summary
Run post-test cleanup sequentially
Parallel Promise.all teardown caused race conditions when template deletes and RHSM container disconnect ran at the same time.

## Testing steps

Integration template tests pass