### PR TITLE
HMS-10722: modify template msg structure

### DIFF
--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -124,7 +124,7 @@ func (t templateDaoImpl) create(ctx context.Context, tx *gorm.DB, reqTemplate ap
 	templatesModelToApi(modelTemplate, &respTemplate)
 	respTemplate.RepositoryUUIDS = reqTemplate.RepositoryUUIDS
 
-	event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []api.TemplateResponse{respTemplate})
+	event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []event.TemplateEvent{event.MapTemplateResponse(respTemplate, nil, nil)})
 
 	return respTemplate, nil
 }
@@ -272,7 +272,7 @@ func (t templateDaoImpl) Update(ctx context.Context, orgID string, uuid string, 
 		return resp, err
 	}
 
-	event.SendTemplateEvent(orgID, event.TemplateUpdated, []api.TemplateResponse{resp})
+	event.SendTemplateEvent(orgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
 
 	return resp, err
 }
@@ -460,7 +460,7 @@ func (t templateDaoImpl) SoftDelete(ctx context.Context, orgID string, uuid stri
 
 	var resp api.TemplateResponse
 	templatesModelToApi(modelTemplate, &resp)
-	event.SendTemplateEvent(orgID, event.TemplateDeleted, []api.TemplateResponse{resp})
+	event.SendTemplateEvent(orgID, event.TemplateDeleted, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
 
 	return nil
 }

--- a/pkg/event/client.go
+++ b/pkg/event/client.go
@@ -79,7 +79,7 @@ func SetEmptyToNil(value string) *string {
 }
 
 // SendTemplateEvent - Sends an event about a template to the patch service
-func SendTemplateEvent(orgID string, eventName EventName, templates []api.TemplateResponse) {
+func SendTemplateEvent(orgID string, eventName EventName, templates []TemplateEvent) {
 	if config.Get().TemplateEventClient != nil && len(templates) > 0 {
 		eventNameStr := eventName.String()
 		newUUID, _ := uuid.NewRandom()

--- a/pkg/event/template_event.go
+++ b/pkg/event/template_event.go
@@ -1,0 +1,37 @@
+package event
+
+import (
+	"time"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+)
+
+type TemplateEvent struct {
+	UUID              string    `json:"uuid" readonly:"true"`
+	Name              string    `json:"name"`                         // Name of the template
+	OrgID             string    `json:"org_id"`                       // Organization ID of the owner
+	Description       *string   `json:"description"`                  // Description of the template
+	Arch              string    `json:"arch"`                         // Architecture of the template
+	Version           string    `json:"version"`                      // Version of the template
+	Date              time.Time `json:"date"`                         // Latest date to include snapshots for
+	RepositoryUUIDS   []string  `json:"repository_uuids"`             // Repositories added to the template
+	RHSMEnvironmentID string    `json:"rhsm_environment_id"`          // Environment ID used by subscription-manager & candlepin
+	AddedAdvisories   []string  `json:"added_advisories,omitempty"`   // List of added advisory IDs
+	RemovedAdvisories []string  `json:"removed_advisories,omitempty"` // List of removed advisory IDs
+}
+
+func MapTemplateResponse(t api.TemplateResponse, addedAdvisories, removedAdvisories []string) TemplateEvent {
+	return TemplateEvent{
+		UUID:              t.UUID,
+		Name:              t.Name,
+		OrgID:             t.OrgID,
+		Description:       &t.Description,
+		Arch:              t.Arch,
+		Version:           t.Version,
+		Date:              t.Date,
+		RepositoryUUIDS:   t.RepositoryUUIDS,
+		RHSMEnvironmentID: t.RHSMEnvironmentID,
+		AddedAdvisories:   addedAdvisories,
+		RemovedAdvisories: removedAdvisories,
+	}
+}


### PR DESCRIPTION
## Summary

Updates the structure of template events to include added and removed advisories. These fields are kept empty for now.

## Testing steps

1. Create the template topic and start the Kafka consumer:

```
export KAFKA_TOPICS=platform.content-sources.template
make kafka-topics-create
make kafka-topic-consume KAFKA_TOPIC=platform.content-sources.template
```
2. Create, update, and delete a template. You should see the template data in the consumer output after each request. `added_advisories` and `removed_advisories` should be omitted