### PR TITLE
Build: Add snapshot detail endpoint with package diffs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1056,6 +1056,68 @@ const docTemplate = `{
             }
         },
         "/repositories/{repo_uuid}/snapshots/{snapshot_uuid}": {
+            "get": {
+                "description": "Get the details of a repository snapshot, including the package diff.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "snapshots"
+                ],
+                "summary": "Get snapshot detail",
+                "operationId": "getSnapshot",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository ID.",
+                        "name": "repo_uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Snapshot ID.",
+                        "name": "snapshot_uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SnapshotDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "description": "This enables deleting a specific snapshot.",
                 "tags": [
@@ -5089,6 +5151,76 @@ const docTemplate = `{
                 }
             }
         },
+        "api.SnapshotDetailResponse": {
+            "type": "object",
+            "properties": {
+                "added_counts": {
+                    "description": "Count of each content type",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "added_packages": {
+                    "description": "Packages added in this snapshot",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SnapshotPackageDiffItem"
+                    }
+                },
+                "content_counts": {
+                    "description": "Count of each content type",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "created_at": {
+                    "description": "Datetime the snapshot was created",
+                    "type": "string"
+                },
+                "detected_os_version": {
+                    "description": "Release version of the repository (BaseOS)",
+                    "type": "string"
+                },
+                "removed_counts": {
+                    "description": "Count of each content type",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "removed_packages": {
+                    "description": "Packages removed in this snapshot",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SnapshotPackageDiffItem"
+                    }
+                },
+                "repository_name": {
+                    "description": "Name of repository the snapshot belongs to",
+                    "type": "string"
+                },
+                "repository_path": {
+                    "description": "Path to repository snapshot contents",
+                    "type": "string"
+                },
+                "repository_uuid": {
+                    "description": "UUID of the repository the snapshot belongs to",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "URL to the snapshot's content",
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
         "api.SnapshotErrata": {
             "type": "object",
             "properties": {
@@ -5185,6 +5317,27 @@ const docTemplate = `{
                 },
                 "repository_uuid": {
                     "description": "Repository uuid for associated snapshot",
+                    "type": "string"
+                }
+            }
+        },
+        "api.SnapshotPackageDiffItem": {
+            "type": "object",
+            "properties": {
+                "arch": {
+                    "description": "RPM architecture of the changed package",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the changed package",
+                    "type": "string"
+                },
+                "release": {
+                    "description": "RPM release of the changed package",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Raw RPM version of the changed package",
                     "type": "string"
                 }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1382,6 +1382,76 @@
                 },
                 "type": "object"
             },
+            "api.SnapshotDetailResponse": {
+                "properties": {
+                    "added_counts": {
+                        "additionalProperties": {
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "description": "Count of each content type",
+                        "type": "object"
+                    },
+                    "added_packages": {
+                        "description": "Packages added in this snapshot",
+                        "items": {
+                            "$ref": "#/components/schemas/api.SnapshotPackageDiffItem"
+                        },
+                        "type": "array"
+                    },
+                    "content_counts": {
+                        "additionalProperties": {
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "description": "Count of each content type",
+                        "type": "object"
+                    },
+                    "created_at": {
+                        "description": "Datetime the snapshot was created",
+                        "type": "string"
+                    },
+                    "detected_os_version": {
+                        "description": "Release version of the repository (BaseOS)",
+                        "type": "string"
+                    },
+                    "removed_counts": {
+                        "additionalProperties": {
+                            "format": "int64",
+                            "type": "integer"
+                        },
+                        "description": "Count of each content type",
+                        "type": "object"
+                    },
+                    "removed_packages": {
+                        "description": "Packages removed in this snapshot",
+                        "items": {
+                            "$ref": "#/components/schemas/api.SnapshotPackageDiffItem"
+                        },
+                        "type": "array"
+                    },
+                    "repository_name": {
+                        "description": "Name of repository the snapshot belongs to",
+                        "type": "string"
+                    },
+                    "repository_path": {
+                        "description": "Path to repository snapshot contents",
+                        "type": "string"
+                    },
+                    "repository_uuid": {
+                        "description": "UUID of the repository the snapshot belongs to",
+                        "type": "string"
+                    },
+                    "url": {
+                        "description": "URL to the snapshot's content",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "api.SnapshotErrata": {
                 "properties": {
                     "cves": {
@@ -1477,6 +1547,27 @@
                     },
                     "repository_uuid": {
                         "description": "Repository uuid for associated snapshot",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.SnapshotPackageDiffItem": {
+                "properties": {
+                    "arch": {
+                        "description": "RPM architecture of the changed package",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the changed package",
+                        "type": "string"
+                    },
+                    "release": {
+                        "description": "RPM release of the changed package",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Raw RPM version of the changed package",
                         "type": "string"
                     }
                 },
@@ -3563,6 +3654,86 @@
                     }
                 },
                 "summary": "Delete a snapshot",
+                "tags": [
+                    "snapshots"
+                ]
+            },
+            "get": {
+                "description": "Get the details of a repository snapshot, including the package diff.",
+                "operationId": "getSnapshot",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "repo_uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Snapshot ID.",
+                        "in": "path",
+                        "name": "snapshot_uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.SnapshotDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get snapshot detail",
                 "tags": [
                     "snapshots"
                 ]

--- a/pkg/api/snapshots.go
+++ b/pkg/api/snapshots.go
@@ -18,6 +18,19 @@ type SnapshotResponse struct {
 	PublicationHref   string           `json:"-" swaggerignore:"true"` // Publication href of the snapshot in pulp
 }
 
+type SnapshotPackageDiffItem struct {
+	Name    string `json:"name"`    // Name of the changed package
+	Version string `json:"version"` // Raw RPM version of the changed package
+	Release string `json:"release"` // RPM release of the changed package
+	Arch    string `json:"arch"`    // RPM architecture of the changed package
+}
+
+type SnapshotDetailResponse struct {
+	SnapshotResponse
+	AddedPackages   []SnapshotPackageDiffItem `json:"added_packages"`   // Packages added in this snapshot
+	RemovedPackages []SnapshotPackageDiffItem `json:"removed_packages"` // Packages removed in this snapshot
+}
+
 type ListSnapshotByDateRequest struct {
 	RepositoryUUIDS []string  `json:"repository_uuids" validate:"required"` // Repository UUIDs to find snapshots for
 	Date            time.Time `json:"date" validate:"required"`             // Exact date to search by.

--- a/pkg/clients/pulp_client/interfaces.go
+++ b/pkg/clients/pulp_client/interfaces.go
@@ -50,6 +50,8 @@ type PulpClient interface {
 	CreatePackage(ctx context.Context, artifactHref *string, uploadHref *string) (string, error)
 	LookupPackage(ctx context.Context, sha256sum string) (*string, error)
 	ListVersionAllPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error)
+	ListVersionAllAddedPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error)
+	ListVersionAllRemovedPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error)
 
 	// Rpm Repository
 	CreateRpmRepository(ctx context.Context, uuid string, rpmRemotePulpRef *string) (*zest.RpmRpmRepositoryResponse, error)

--- a/pkg/clients/pulp_client/package.go
+++ b/pkg/clients/pulp_client/package.go
@@ -3,12 +3,21 @@ package pulp_client
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	zest "github.com/content-services/zest/release/v2026"
 )
 
 // specify fields to workaround https://github.com/pulp/pulp_rpm/issues/3694
 var RpmFields = []string{"pulp_href", "name", "version", "release", "arch", "epoch", "sha256", "summary"}
+
+type versionPackageQueryMode int
+
+const (
+	versionPackageQueryPresent versionPackageQueryMode = iota
+	versionPackageQueryAdded
+	versionPackageQueryRemoved
+)
 
 func (r *pulpDaoImpl) CreatePackage(ctx context.Context, artifactHref *string, uploadHref *string) (string, error) {
 	ctx, client, err := getZestClient(ctx)
@@ -68,7 +77,7 @@ func (r *pulpDaoImpl) ListVersionPackages(ctx context.Context, versionHref strin
 	if err != nil {
 		return pkgs, 0, err
 	}
-	resp, httpResp, err := client.ContentPackagesAPI.ContentRpmPackagesList(ctx, r.domainName).RepositoryVersion(versionHref).Limit(limit).Fields(RpmFields).Offset(offset).Execute()
+	resp, httpResp, err := r.listVersionPackages(ctx, client, versionHref, offset, limit, versionPackageQueryPresent)
 	if httpResp != nil {
 		defer httpResp.Body.Close()
 	}
@@ -93,5 +102,74 @@ func (r *pulpDaoImpl) ListVersionAllPackages(ctx context.Context, versionHref st
 		}
 		pkgs = append(pkgs, pkgList...)
 	}
+	return pkgs, nil
+}
+
+func (r *pulpDaoImpl) ListVersionAllAddedPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error) {
+	return r.listVersionAllPackages(ctx, versionHref, versionPackageQueryAdded)
+}
+
+func (r *pulpDaoImpl) ListVersionAllRemovedPackages(ctx context.Context, versionHref string) (pkgs []zest.RpmPackageResponse, err error) {
+	return r.listVersionAllPackages(ctx, versionHref, versionPackageQueryRemoved)
+}
+
+func (r *pulpDaoImpl) listVersionPackages(
+	ctx context.Context,
+	client *zest.APIClient,
+	versionHref string,
+	offset, limit int32,
+	mode versionPackageQueryMode,
+) (resp *zest.PaginatedrpmPackageResponseList, httpResp *http.Response, err error) {
+	req := client.ContentPackagesAPI.ContentRpmPackagesList(ctx, r.domainName).
+		Limit(limit).
+		Fields(RpmFields).
+		Offset(offset)
+
+	switch mode {
+	case versionPackageQueryAdded:
+		req = req.RepositoryVersionAdded(versionHref)
+	case versionPackageQueryRemoved:
+		req = req.RepositoryVersionRemoved(versionHref)
+	default:
+		req = req.RepositoryVersion(versionHref)
+	}
+
+	return req.Execute()
+}
+
+func (r *pulpDaoImpl) listVersionAllPackages(
+	ctx context.Context,
+	versionHref string,
+	mode versionPackageQueryMode,
+) (pkgs []zest.RpmPackageResponse, err error) {
+	ctx, client, err := getZestClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	initial := int32(0)
+	limit := int32(300)
+	resp, httpResp, err := r.listVersionPackages(ctx, client, versionHref, initial, limit, mode)
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return nil, errorWithResponseBody("error listing packages for version", httpResp, err)
+	}
+
+	pkgs = resp.Results
+	total := int(resp.Count)
+	for len(pkgs) < total {
+		initial += limit
+		pageResp, pageHTTPResp, err := r.listVersionPackages(ctx, client, versionHref, initial, limit, mode)
+		if pageHTTPResp != nil {
+			defer pageHTTPResp.Body.Close()
+		}
+		if err != nil {
+			return nil, errorWithResponseBody("error listing packages for version", pageHTTPResp, err)
+		}
+		pkgs = append(pkgs, pageResp.Results...)
+	}
+
 	return pkgs, nil
 }

--- a/pkg/clients/pulp_client/pulp_client_mock.go
+++ b/pkg/clients/pulp_client/pulp_client_mock.go
@@ -2437,6 +2437,74 @@ func (_c *MockPulpClient_ListDistributions_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// ListVersionAllAddedPackages provides a mock function for the type MockPulpClient
+func (_mock *MockPulpClient) ListVersionAllAddedPackages(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error) {
+	ret := _mock.Called(ctx, versionHref)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionAllAddedPackages")
+	}
+
+	var r0 []zest.RpmPackageResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]zest.RpmPackageResponse, error)); ok {
+		return returnFunc(ctx, versionHref)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []zest.RpmPackageResponse); ok {
+		r0 = returnFunc(ctx, versionHref)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]zest.RpmPackageResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, versionHref)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPulpClient_ListVersionAllAddedPackages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionAllAddedPackages'
+type MockPulpClient_ListVersionAllAddedPackages_Call struct {
+	*mock.Call
+}
+
+// ListVersionAllAddedPackages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - versionHref string
+func (_e *MockPulpClient_Expecter) ListVersionAllAddedPackages(ctx interface{}, versionHref interface{}) *MockPulpClient_ListVersionAllAddedPackages_Call {
+	return &MockPulpClient_ListVersionAllAddedPackages_Call{Call: _e.mock.On("ListVersionAllAddedPackages", ctx, versionHref)}
+}
+
+func (_c *MockPulpClient_ListVersionAllAddedPackages_Call) Run(run func(ctx context.Context, versionHref string)) *MockPulpClient_ListVersionAllAddedPackages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPulpClient_ListVersionAllAddedPackages_Call) Return(pkgs []zest.RpmPackageResponse, err error) *MockPulpClient_ListVersionAllAddedPackages_Call {
+	_c.Call.Return(pkgs, err)
+	return _c
+}
+
+func (_c *MockPulpClient_ListVersionAllAddedPackages_Call) RunAndReturn(run func(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error)) *MockPulpClient_ListVersionAllAddedPackages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListVersionAllPackages provides a mock function for the type MockPulpClient
 func (_mock *MockPulpClient) ListVersionAllPackages(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error) {
 	ret := _mock.Called(ctx, versionHref)
@@ -2501,6 +2569,74 @@ func (_c *MockPulpClient_ListVersionAllPackages_Call) Return(pkgs []zest.RpmPack
 }
 
 func (_c *MockPulpClient_ListVersionAllPackages_Call) RunAndReturn(run func(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error)) *MockPulpClient_ListVersionAllPackages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListVersionAllRemovedPackages provides a mock function for the type MockPulpClient
+func (_mock *MockPulpClient) ListVersionAllRemovedPackages(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error) {
+	ret := _mock.Called(ctx, versionHref)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionAllRemovedPackages")
+	}
+
+	var r0 []zest.RpmPackageResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]zest.RpmPackageResponse, error)); ok {
+		return returnFunc(ctx, versionHref)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []zest.RpmPackageResponse); ok {
+		r0 = returnFunc(ctx, versionHref)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]zest.RpmPackageResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, versionHref)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPulpClient_ListVersionAllRemovedPackages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionAllRemovedPackages'
+type MockPulpClient_ListVersionAllRemovedPackages_Call struct {
+	*mock.Call
+}
+
+// ListVersionAllRemovedPackages is a helper method to define mock.On call
+//   - ctx context.Context
+//   - versionHref string
+func (_e *MockPulpClient_Expecter) ListVersionAllRemovedPackages(ctx interface{}, versionHref interface{}) *MockPulpClient_ListVersionAllRemovedPackages_Call {
+	return &MockPulpClient_ListVersionAllRemovedPackages_Call{Call: _e.mock.On("ListVersionAllRemovedPackages", ctx, versionHref)}
+}
+
+func (_c *MockPulpClient_ListVersionAllRemovedPackages_Call) Run(run func(ctx context.Context, versionHref string)) *MockPulpClient_ListVersionAllRemovedPackages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPulpClient_ListVersionAllRemovedPackages_Call) Return(pkgs []zest.RpmPackageResponse, err error) *MockPulpClient_ListVersionAllRemovedPackages_Call {
+	_c.Call.Return(pkgs, err)
+	return _c
+}
+
+func (_c *MockPulpClient_ListVersionAllRemovedPackages_Call) RunAndReturn(run func(ctx context.Context, versionHref string) ([]zest.RpmPackageResponse, error)) *MockPulpClient_ListVersionAllRemovedPackages_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -3647,6 +3647,84 @@ func (_c *MockSnapshotDao_Fetch_Call) RunAndReturn(run func(ctx context.Context,
 	return _c
 }
 
+// FetchDetailForRepo provides a mock function for the type MockSnapshotDao
+func (_mock *MockSnapshotDao) FetchDetailForRepo(ctx context.Context, orgID string, repoConfigUUID string, snapshotUUID string) (api.SnapshotDetailResponse, error) {
+	ret := _mock.Called(ctx, orgID, repoConfigUUID, snapshotUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchDetailForRepo")
+	}
+
+	var r0 api.SnapshotDetailResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) (api.SnapshotDetailResponse, error)); ok {
+		return returnFunc(ctx, orgID, repoConfigUUID, snapshotUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) api.SnapshotDetailResponse); ok {
+		r0 = returnFunc(ctx, orgID, repoConfigUUID, snapshotUUID)
+	} else {
+		r0 = ret.Get(0).(api.SnapshotDetailResponse)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, orgID, repoConfigUUID, snapshotUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSnapshotDao_FetchDetailForRepo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FetchDetailForRepo'
+type MockSnapshotDao_FetchDetailForRepo_Call struct {
+	*mock.Call
+}
+
+// FetchDetailForRepo is a helper method to define mock.On call
+//   - ctx context.Context
+//   - orgID string
+//   - repoConfigUUID string
+//   - snapshotUUID string
+func (_e *MockSnapshotDao_Expecter) FetchDetailForRepo(ctx interface{}, orgID interface{}, repoConfigUUID interface{}, snapshotUUID interface{}) *MockSnapshotDao_FetchDetailForRepo_Call {
+	return &MockSnapshotDao_FetchDetailForRepo_Call{Call: _e.mock.On("FetchDetailForRepo", ctx, orgID, repoConfigUUID, snapshotUUID)}
+}
+
+func (_c *MockSnapshotDao_FetchDetailForRepo_Call) Run(run func(ctx context.Context, orgID string, repoConfigUUID string, snapshotUUID string)) *MockSnapshotDao_FetchDetailForRepo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchDetailForRepo_Call) Return(snapshotDetailResponse api.SnapshotDetailResponse, err error) *MockSnapshotDao_FetchDetailForRepo_Call {
+	_c.Call.Return(snapshotDetailResponse, err)
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchDetailForRepo_Call) RunAndReturn(run func(ctx context.Context, orgID string, repoConfigUUID string, snapshotUUID string) (api.SnapshotDetailResponse, error)) *MockSnapshotDao_FetchDetailForRepo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FetchForRepoConfigUUID provides a mock function for the type MockSnapshotDao
 func (_mock *MockSnapshotDao) FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string, inclSoftDel bool) ([]models.Snapshot, error) {
 	ret := _mock.Called(ctx, repoConfigUUID, inclSoftDel)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -138,6 +138,7 @@ type SnapshotDao interface {
 	Create(ctx context.Context, snap *models.Snapshot) error
 	List(ctx context.Context, orgID string, repoConfigUuid string, paginationData api.PaginationData, filterData api.FilterData) (api.SnapshotCollectionResponse, int64, error)
 	ListByTemplate(ctx context.Context, orgID string, template api.TemplateResponse, repositorySearch string, paginationData api.PaginationData) (api.SnapshotCollectionResponse, int64, error)
+	FetchDetailForRepo(ctx context.Context, orgID string, repoConfigUUID string, snapshotUUID string) (api.SnapshotDetailResponse, error)
 	FetchForRepoConfigUUID(ctx context.Context, repoConfigUUID string, inclSoftDel bool) ([]models.Snapshot, error)
 	FetchModel(ctx context.Context, uuid string, includeSoftDel bool) (models.Snapshot, error)
 	SoftDelete(ctx context.Context, snapUUID string) error

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -16,6 +16,7 @@ import (
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/utils"
+	zest "github.com/content-services/zest/release/v2026"
 	rpm_version "github.com/knqyf263/go-rpm-version"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -119,6 +120,81 @@ func (sDao *snapshotDaoImpl) List(
 	resp := snapshotConvertToResponses(snaps, pulpContentPath)
 
 	return api.SnapshotCollectionResponse{Data: resp}, totalSnaps, nil
+}
+
+func (sDao *snapshotDaoImpl) FetchDetailForRepo(
+	ctx context.Context,
+	orgID string,
+	repoConfigUUID string,
+	snapshotUUID string,
+) (api.SnapshotDetailResponse, error) {
+	var repoConfig models.RepositoryConfiguration
+	result := sDao.db.WithContext(ctx).
+		Where(
+			"repository_configurations.org_id IN (?,?,?) AND repository_configurations.uuid = ?",
+			orgID,
+			config.RedHatOrg,
+			config.CommunityOrg,
+			UuidifyString(repoConfigUUID),
+		).
+		First(&repoConfig)
+	if result.Error != nil {
+		return api.SnapshotDetailResponse{}, RepositoryDBErrorToApi(result.Error, &repoConfigUUID)
+	}
+
+	var snapshot models.Snapshot
+	result = readableSnapshots(sDao.db.WithContext(ctx), orgID).
+		Where(
+			"snapshots.repository_configuration_uuid = ? AND snapshots.uuid = ?",
+			repoConfig.UUID,
+			UuidifyString(snapshotUUID),
+		).
+		First(&snapshot)
+	if result.Error != nil {
+		return api.SnapshotDetailResponse{}, SnapshotsDBToApiError(result.Error, &snapshotUUID)
+	}
+
+	domainName, err := sDao.snapshotDomainName(ctx, snapshot)
+	if err != nil {
+		return api.SnapshotDetailResponse{}, err
+	}
+
+	pulpClient := sDao.pulpClient.WithDomain(domainName)
+	pulpContentPath, err := pulpClient.GetContentPath(ctx)
+	if err != nil {
+		return api.SnapshotDetailResponse{}, err
+	}
+
+	baseSnapshot := snapshotConvertToResponses([]models.Snapshot{snapshot}, pulpContentPath)[0]
+	addedPackages := []api.SnapshotPackageDiffItem{}
+	removedPackages := []api.SnapshotPackageDiffItem{}
+
+	version, err := pulpClient.GetRpmRepositoryVersion(ctx, snapshot.VersionHref)
+	if err != nil {
+		return api.SnapshotDetailResponse{}, err
+	}
+
+	if contentSummaryPackageCount(version.GetContentSummary().Added) > 0 {
+		pkgs, err := pulpClient.ListVersionAllAddedPackages(ctx, snapshot.VersionHref)
+		if err != nil {
+			return api.SnapshotDetailResponse{}, err
+		}
+		addedPackages = snapshotPackageDiffItemsFromPulp(pkgs)
+	}
+
+	if contentSummaryPackageCount(version.GetContentSummary().Removed) > 0 {
+		pkgs, err := pulpClient.ListVersionAllRemovedPackages(ctx, snapshot.VersionHref)
+		if err != nil {
+			return api.SnapshotDetailResponse{}, err
+		}
+		removedPackages = snapshotPackageDiffItemsFromPulp(pkgs)
+	}
+
+	return api.SnapshotDetailResponse{
+		SnapshotResponse: baseSnapshot,
+		AddedPackages:    addedPackages,
+		RemovedPackages:  removedPackages,
+	}, nil
 }
 
 func (sDao *snapshotDaoImpl) ListByTemplate(
@@ -638,4 +714,61 @@ func SnapshotModelToApi(model models.Snapshot, resp *api.SnapshotResponse) {
 // pulpContentURL combines content path and repository path to get content URL
 func pulpContentURL(pulpContentPath string, repositoryPath string) string {
 	return pulpContentPath + repositoryPath + "/"
+}
+
+func (sDao *snapshotDaoImpl) snapshotDomainName(ctx context.Context, snapshot models.Snapshot) (string, error) {
+	if snapshot.RepositoryPath != "" {
+		return strings.SplitN(snapshot.RepositoryPath, "/", 2)[0], nil
+	}
+
+	if snapshot.RepositoryConfiguration.OrgID == "" {
+		return "", nil
+	}
+
+	return domainDaoImpl{db: sDao.db}.Fetch(ctx, snapshot.RepositoryConfiguration.OrgID)
+}
+
+func contentSummaryPackageCount(contentTypeSummary map[string]map[string]interface{}) int64 {
+	rpmSummary, ok := contentTypeSummary["rpm.package"]
+	if !ok {
+		return 0
+	}
+
+	switch count := rpmSummary["count"].(type) {
+	case float64:
+		return int64(count)
+	case int64:
+		return count
+	case int:
+		return int64(count)
+	default:
+		return 0
+	}
+}
+
+func snapshotPackageDiffItemsFromPulp(pkgs []zest.RpmPackageResponse) []api.SnapshotPackageDiffItem {
+	items := make([]api.SnapshotPackageDiffItem, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		items = append(items, api.SnapshotPackageDiffItem{
+			Name:    pkg.GetName(),
+			Version: pkg.GetVersion(),
+			Release: pkg.GetRelease(),
+			Arch:    pkg.GetArch(),
+		})
+	}
+
+	slices.SortFunc(items, func(a, b api.SnapshotPackageDiffItem) int {
+		if diff := strings.Compare(a.Name, b.Name); diff != 0 {
+			return diff
+		}
+		if diff := strings.Compare(a.Version, b.Version); diff != 0 {
+			return diff
+		}
+		if diff := strings.Compare(a.Release, b.Release); diff != 0 {
+			return diff
+		}
+		return strings.Compare(a.Arch, b.Arch)
+	})
+
+	return items
 }

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -354,6 +354,151 @@ func (s *SnapshotsSuite) TestListNotFoundBadOrgId() {
 	assert.ErrorContains(t, err, "Repository with UUID "+rConfig.UUID+" not found")
 }
 
+func (s *SnapshotsSuite) TestFetchDetailForRepo() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	repoConfig := createRepository(t, tx, "", false)
+	snapshot := createSnapshotForDetail(t, &sDao, repoConfig, "detail-domain")
+
+	contentPath := "http://pulp-content/pulp/content/"
+	contentSummary := zest.ContentSummaryResponse{
+		Present: map[string]map[string]interface{}{"rpm.package": {"count": float64(4)}},
+		Added:   map[string]map[string]interface{}{"rpm.package": {"count": float64(2)}},
+		Removed: map[string]map[string]interface{}{"rpm.package": {"count": float64(1)}},
+	}
+	addedPackages := []zest.RpmPackageResponse{
+		{Name: utils.Ptr("zlib"), Version: utils.Ptr("1.2.3"), Release: utils.Ptr("7.el9"), Arch: utils.Ptr("x86_64")},
+		{Name: utils.Ptr("bash"), Version: utils.Ptr("5.2.0"), Release: utils.Ptr("3.el9"), Arch: utils.Ptr("x86_64")},
+	}
+	removedPackages := []zest.RpmPackageResponse{
+		{Name: utils.Ptr("coreutils"), Version: utils.Ptr("9.4"), Release: utils.Ptr("1.el9"), Arch: utils.Ptr("aarch64")},
+	}
+
+	mockPulpClient.On("WithDomain", "detail-domain").Return(mockPulpClient).Once()
+	mockPulpClient.On("GetContentPath", ctx).Return(contentPath, nil).Once()
+	mockPulpClient.On("GetRpmRepositoryVersion", ctx, snapshot.VersionHref).Return(&zest.RepositoryVersionResponse{ContentSummary: &contentSummary}, nil).Once()
+	mockPulpClient.On("ListVersionAllAddedPackages", ctx, snapshot.VersionHref).Return(addedPackages, nil).Once()
+	mockPulpClient.On("ListVersionAllRemovedPackages", ctx, snapshot.VersionHref).Return(removedPackages, nil).Once()
+
+	response, err := sDao.FetchDetailForRepo(ctx, repoConfig.OrgID, repoConfig.UUID, snapshot.UUID)
+	require.NoError(t, err)
+
+	assert.Equal(t, snapshot.UUID, response.UUID)
+	assert.Equal(t, repoConfig.UUID, response.RepositoryUUID)
+	assert.Equal(t, repoConfig.Name, response.RepositoryName)
+	assert.Equal(t, snapshot.DetectedOSVersion, response.DetectedOSVersion)
+	assert.Equal(t, snapshot.RepositoryPath, response.RepositoryPath)
+	assert.Equal(t, contentPath+snapshot.RepositoryPath+"/", response.URL)
+	assert.Equal(t, []api.SnapshotPackageDiffItem{
+		{Name: "bash", Version: "5.2.0", Release: "3.el9", Arch: "x86_64"},
+		{Name: "zlib", Version: "1.2.3", Release: "7.el9", Arch: "x86_64"},
+	}, response.AddedPackages)
+	assert.Equal(t, []api.SnapshotPackageDiffItem{
+		{Name: "coreutils", Version: "9.4", Release: "1.el9", Arch: "aarch64"},
+	}, response.RemovedPackages)
+}
+
+func (s *SnapshotsSuite) TestFetchDetailForRepoRepoNotFound() {
+	t := s.T()
+	tx := s.tx
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	_, err := sDao.FetchDetailForRepo(context.Background(), "someOrg", uuid2.NewString(), uuid2.NewString())
+	require.Error(t, err)
+
+	var daoError *ce.DaoError
+	require.ErrorAs(t, err, &daoError)
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchDetailForRepoSnapshotNotInRepo() {
+	t := s.T()
+	tx := s.tx
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	repoConfig := createRepository(t, tx, "", false)
+	otherRepoConfig := createRepository(t, tx, "-other", false)
+	snapshot := createSnapshotForDetail(t, &sDao, repoConfig, "detail-domain")
+
+	_, err := sDao.FetchDetailForRepo(context.Background(), repoConfig.OrgID, otherRepoConfig.UUID, snapshot.UUID)
+	require.Error(t, err)
+
+	var daoError *ce.DaoError
+	require.ErrorAs(t, err, &daoError)
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchDetailForRepoSoftDeletedSnapshot() {
+	t := s.T()
+	tx := s.tx
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	repoConfig := createRepository(t, tx, "", false)
+	snapshot := createSnapshotForDetail(t, &sDao, repoConfig, "detail-domain")
+
+	require.NoError(t, tx.Delete(&snapshot).Error)
+
+	_, err := sDao.FetchDetailForRepo(context.Background(), repoConfig.OrgID, repoConfig.UUID, snapshot.UUID)
+	require.Error(t, err)
+
+	var daoError *ce.DaoError
+	require.ErrorAs(t, err, &daoError)
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchDetailForRepoEmptyPackageDiffs() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	repoConfig := createRepository(t, tx, "", false)
+	snapshot := createSnapshotForDetail(t, &sDao, repoConfig, "detail-domain")
+
+	contentSummary := zest.ContentSummaryResponse{
+		Present: map[string]map[string]interface{}{"rpm.package": {"count": float64(4)}},
+		Added:   map[string]map[string]interface{}{},
+		Removed: map[string]map[string]interface{}{},
+	}
+
+	mockPulpClient.On("WithDomain", "detail-domain").Return(mockPulpClient).Once()
+	mockPulpClient.On("GetContentPath", ctx).Return("http://pulp-content/pulp/content/", nil).Once()
+	mockPulpClient.On("GetRpmRepositoryVersion", ctx, snapshot.VersionHref).Return(&zest.RepositoryVersionResponse{ContentSummary: &contentSummary}, nil).Once()
+
+	response, err := sDao.FetchDetailForRepo(ctx, repoConfig.OrgID, repoConfig.UUID, snapshot.UUID)
+	require.NoError(t, err)
+	assert.Empty(t, response.AddedPackages)
+	assert.Empty(t, response.RemovedPackages)
+}
+
+func (s *SnapshotsSuite) TestFetchDetailForRepoPulpError() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+	repoConfig := createRepository(t, tx, "", false)
+	snapshot := createSnapshotForDetail(t, &sDao, repoConfig, "detail-domain")
+
+	mockPulpClient.On("WithDomain", "detail-domain").Return(mockPulpClient).Once()
+	mockPulpClient.On("GetContentPath", ctx).Return("http://pulp-content/pulp/content/", nil).Once()
+	mockPulpClient.On("GetRpmRepositoryVersion", ctx, snapshot.VersionHref).Return((*zest.RepositoryVersionResponse)(nil), errors.New("pulp failed")).Once()
+
+	_, err := sDao.FetchDetailForRepo(ctx, repoConfig.OrgID, repoConfig.UUID, snapshot.UUID)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "pulp failed")
+}
+
 func (s *SnapshotsSuite) TestFetchForRepoUUID() {
 	t := s.T()
 	tx := s.tx
@@ -988,4 +1133,23 @@ func (s *SnapshotsSuite) TestSetDetectedOSVersion() {
 	err = tx.Where("uuid = ?", snap.UUID).First(&updatedSnap).Error
 	assert.NoError(t, err)
 	assert.Equal(t, "9.4", updatedSnap.DetectedOSVersion)
+}
+
+func createSnapshotForDetail(t *testing.T, sDao SnapshotDao, repoConfig models.RepositoryConfiguration, domainName string) models.Snapshot {
+	snap := models.Snapshot{
+		VersionHref:                 fmt.Sprintf("/pulp/api/v3/repositories/rpm/rpm/%s/versions/1/", uuid2.NewString()),
+		PublicationHref:             fmt.Sprintf("/pulp/api/v3/publications/rpm/rpm/%s/", uuid2.NewString()),
+		DistributionPath:            fmt.Sprintf("/path/to/%v", uuid2.NewString()),
+		RepositoryPath:              fmt.Sprintf("%s/path/to/%v", domainName, uuid2.NewString()),
+		DistributionHref:            fmt.Sprintf("/pulp/api/v3/distributions/rpm/rpm/%s/", uuid2.NewString()),
+		RepositoryConfigurationUUID: repoConfig.UUID,
+		ContentCounts:               models.ContentCountsType{"rpm.package": int64(4)},
+		AddedCounts:                 models.ContentCountsType{"rpm.package": int64(2)},
+		RemovedCounts:               models.ContentCountsType{"rpm.package": int64(1)},
+		DetectedOSVersion:           "9.4",
+	}
+
+	err := sDao.Create(context.Background(), &snap)
+	assert.NoError(t, err)
+	return snap
 }

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -47,6 +47,7 @@ func RegisterSnapshotRoutes(group *echo.Group, daoReg *dao.DaoRegistry, taskClie
 
 	addRepoRoute(group, http.MethodPost, "/snapshots/for_date/", sh.listSnapshotsByDate, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/repositories/:uuid/snapshots/", sh.listSnapshotsForRepo, rbac.RbacVerbRead)
+	addRepoRoute(group, http.MethodGet, "/repositories/:repo_uuid/snapshots/:snapshot_uuid", sh.getSnapshot, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/repositories/:uuid/config.repo", sh.getLatestRepoConfigurationFile, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/snapshots/:snapshot_uuid/config.repo", sh.getRepoConfigurationFile, rbac.RbacVerbRead)
 	addRepoRoute(group, http.MethodGet, "/templates/:uuid/snapshots/", sh.listSnapshotsForTemplate, rbac.RbacVerbRead)
@@ -120,6 +121,34 @@ func (sh *SnapshotHandler) listSnapshotsForRepo(c echo.Context) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error listing repository snapshots", err.Error())
 	}
 	return c.JSON(200, setCollectionResponseMetadata(&snapshots, c, totalSnaps))
+}
+
+// Get Snapshot godoc
+// @Summary      Get snapshot detail
+// @ID           getSnapshot
+// @Description  Get the details of a repository snapshot, including the package diff.
+// @Tags         snapshots
+// @Accept       json
+// @Produce      json
+// @Param        repo_uuid path string true "Repository ID."
+// @Param        snapshot_uuid path string true "Snapshot ID."
+// @Success      200 {object} api.SnapshotDetailResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      401 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{repo_uuid}/snapshots/{snapshot_uuid} [get]
+func (sh *SnapshotHandler) getSnapshot(c echo.Context) error {
+	repoUUID := c.Param("repo_uuid")
+	snapshotUUID := c.Param("snapshot_uuid")
+	_, orgID := getAccountIdOrgId(c)
+
+	snapshot, err := sh.DaoRegistry.Snapshot.FetchDetailForRepo(c.Request().Context(), orgID, repoUUID, snapshotUUID)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching snapshot", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, snapshot)
 }
 
 // Get Snapshots godoc

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
+	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/middleware"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/seeds"
@@ -197,6 +198,131 @@ func (suite *SnapshotSuite) TestSnapshotList() {
 	assert.Equal(t, collection.Data[0].RepositoryPath, response.Data[0].RepositoryPath)
 	assert.Equal(t, collection.Data[0].UUID, response.Data[0].UUID)
 	assert.Equal(t, collection.Data[0].URL, response.Data[0].URL)
+}
+
+func (suite *SnapshotSuite) TestGetSnapshot() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	detail := api.SnapshotDetailResponse{
+		SnapshotResponse: api.SnapshotResponse{
+			UUID:           snapshotUUID,
+			RepositoryUUID: repoUUID,
+			RepositoryPath: "detail-domain/path/to/snapshot",
+			URL:            "http://pulp-content/pulp/content/detail-domain/path/to/snapshot/",
+		},
+		AddedPackages: []api.SnapshotPackageDiffItem{
+			{Name: "bash", Version: "5.2.0", Release: "3.el9", Arch: "x86_64"},
+		},
+		RemovedPackages: []api.SnapshotPackageDiffItem{
+			{Name: "coreutils", Version: "9.4", Release: "1.el9", Arch: "aarch64"},
+		},
+	}
+
+	suite.reg.Snapshot.On("FetchDetailForRepo", test.MockCtx(), test_handler.MockOrgId, repoUUID, snapshotUUID).Return(detail, nil).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+
+	response := api.SnapshotDetailResponse{}
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, detail.UUID, response.UUID)
+	assert.Equal(t, detail.RepositoryUUID, response.RepositoryUUID)
+	assert.Equal(t, detail.AddedPackages, response.AddedPackages)
+	assert.Equal(t, detail.RemovedPackages, response.RemovedPackages)
+}
+
+func (suite *SnapshotSuite) TestGetSnapshotRepoNotFound() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	suite.reg.Snapshot.On(
+		"FetchDetailForRepo",
+		test.MockCtx(),
+		test_handler.MockOrgId,
+		repoUUID,
+		snapshotUUID,
+	).Return(api.SnapshotDetailResponse{}, &ce.DaoError{NotFound: true, Message: "Repository not found"}).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *SnapshotSuite) TestGetSnapshotNotFound() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	suite.reg.Snapshot.On(
+		"FetchDetailForRepo",
+		test.MockCtx(),
+		test_handler.MockOrgId,
+		repoUUID,
+		snapshotUUID,
+	).Return(api.SnapshotDetailResponse{}, &ce.DaoError{NotFound: true, Message: "Snapshot not found"}).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *SnapshotSuite) TestGetSnapshotNotInRepo() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	suite.reg.Snapshot.On(
+		"FetchDetailForRepo",
+		test.MockCtx(),
+		test_handler.MockOrgId,
+		repoUUID,
+		snapshotUUID,
+	).Return(api.SnapshotDetailResponse{}, &ce.DaoError{
+		NotFound: true,
+		Message:  "snapshot with this UUID does not exist for the specified repository",
+	}).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *SnapshotSuite) TestGetSnapshotDaoError() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	suite.reg.Snapshot.On("FetchDetailForRepo", test.MockCtx(), test_handler.MockOrgId, repoUUID, snapshotUUID).
+		Return(api.SnapshotDetailResponse{}, errors.New("test error")).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
 }
 
 func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {


### PR DESCRIPTION
## Summary
- add `GET /repositories/{repo_uuid}/snapshots/{snapshot_uuid}` for repo-scoped snapshot detail
- include added and removed package diffs from Pulp using the stored snapshot version href, with `name`, `version`, `release`, and `arch`
- cover the new DAO and handler paths with tests and refresh generated mocks plus OpenAPI docs

## Test plan
- [x] `go test ./pkg/dao -run TestSnapshotsSuite`
- [x] `go test ./pkg/handler -run TestSnapshotSuite`


Made with [Cursor](https://cursor.com)