### PR TITLE
HMS-10723: add endpoint to return template advisory IDs

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3457,6 +3457,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/templates/{uuid}/advisories/ids": {
+            "get": {
+                "description": "This operation enables users to retrieve a template's advisory IDs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "templates"
+                ],
+                "summary": "Fetch template Advisory IDs",
+                "operationId": "fetchTemplateAdvisoryIDs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.TemplateAdvisoryIDsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/templates/{uuid}/errata": {
             "get": {
                 "description": "List errata in a content template.",
@@ -5456,6 +5510,17 @@ const docTemplate = `{
                 "uuid": {
                     "description": "UUID of the object",
                     "type": "string"
+                }
+            }
+        },
+        "api.TemplateAdvisoryIDsResponse": {
+            "type": "object",
+            "properties": {
+                "advisory_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1752,6 +1752,17 @@
                 },
                 "type": "object"
             },
+            "api.TemplateAdvisoryIDsResponse": {
+                "properties": {
+                    "advisory_ids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
             "api.TemplateCollectionResponse": {
                 "properties": {
                     "data": {
@@ -6619,6 +6630,79 @@
                     }
                 },
                 "summary": "Fully update all attributes of a Template",
+                "tags": [
+                    "templates"
+                ]
+            }
+        },
+        "/templates/{uuid}/advisories/ids": {
+            "get": {
+                "description": "This operation enables users to retrieve a template's advisory IDs.",
+                "operationId": "fetchTemplateAdvisoryIDs",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TemplateAdvisoryIDsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Fetch template Advisory IDs",
                 "tags": [
                     "templates"
                 ]

--- a/pkg/api/templates.go
+++ b/pkg/api/templates.go
@@ -146,3 +146,7 @@ func (d *EmptiableDate) UnmarshalJSON(b []byte) error {
 	*d = EmptiableDate(t.UTC())
 	return nil
 }
+
+type TemplateAdvisoryIDsResponse struct {
+	AdvisoryIDs []string `json:"advisory_ids"`
+}

--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -2101,6 +2101,80 @@ func (_c *MockRpmDao_FetchForRepository_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// FetchTemplateErrataIDs provides a mock function for the type MockRpmDao
+func (_mock *MockRpmDao) FetchTemplateErrataIDs(ctx context.Context, orgId string, templateUUID string) ([]string, error) {
+	ret := _mock.Called(ctx, orgId, templateUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchTemplateErrataIDs")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]string, error)); ok {
+		return returnFunc(ctx, orgId, templateUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []string); ok {
+		r0 = returnFunc(ctx, orgId, templateUUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, orgId, templateUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRpmDao_FetchTemplateErrataIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FetchTemplateErrataIDs'
+type MockRpmDao_FetchTemplateErrataIDs_Call struct {
+	*mock.Call
+}
+
+// FetchTemplateErrataIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - orgId string
+//   - templateUUID string
+func (_e *MockRpmDao_Expecter) FetchTemplateErrataIDs(ctx interface{}, orgId interface{}, templateUUID interface{}) *MockRpmDao_FetchTemplateErrataIDs_Call {
+	return &MockRpmDao_FetchTemplateErrataIDs_Call{Call: _e.mock.On("FetchTemplateErrataIDs", ctx, orgId, templateUUID)}
+}
+
+func (_c *MockRpmDao_FetchTemplateErrataIDs_Call) Run(run func(ctx context.Context, orgId string, templateUUID string)) *MockRpmDao_FetchTemplateErrataIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRpmDao_FetchTemplateErrataIDs_Call) Return(strings []string, err error) *MockRpmDao_FetchTemplateErrataIDs_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockRpmDao_FetchTemplateErrataIDs_Call) RunAndReturn(run func(ctx context.Context, orgId string, templateUUID string) ([]string, error)) *MockRpmDao_FetchTemplateErrataIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InsertForRepository provides a mock function for the type MockRpmDao
 func (_mock *MockRpmDao) InsertForRepository(ctx context.Context, repoUuid string, pkgs []yum.Package) (int64, error) {
 	ret := _mock.Called(ctx, repoUuid, pkgs)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -122,6 +122,7 @@ type RpmDao interface {
 	ListTemplateRpms(ctx context.Context, orgId string, templateUUID string, search string, pageOpts api.PaginationData) ([]api.SnapshotRpm, int, error)
 	ListTemplateErrata(ctx context.Context, orgId string, templateUUID string, filters tangy.ErrataListFilters, pageOpts api.PaginationData) ([]api.SnapshotErrata, int, error)
 	FetchForRepository(ctx context.Context, orgID string, repositoryConfigUUID string, rpmUUIDs []string) ([]models.Rpm, error)
+	FetchTemplateErrataIDs(ctx context.Context, orgId string, templateUUID string) ([]string, error)
 }
 
 type RepositoryDao interface {

--- a/pkg/dao/rpms.go
+++ b/pkg/dao/rpms.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,8 @@ import (
 )
 
 var DbInClauseLimit = 60000
+
+const TemplateErrataIDsPageLimit = 10000
 
 type rpmDaoImpl struct {
 	db            *gorm.DB
@@ -1034,4 +1037,35 @@ func (r *rpmDaoImpl) FetchForRepository(ctx context.Context, orgID string, repos
 	}
 
 	return rpms, nil
+}
+
+// FetchTemplateErrataIDs returns deduplicated and sorted errata IDs for the given template
+func (r *rpmDaoImpl) FetchTemplateErrataIDs(ctx context.Context, orgID string, templateUUID string) ([]string, error) {
+	limit := TemplateErrataIDsPageLimit
+	var offset int
+	seen := make(map[string]struct{})
+	var errataIDs []string
+
+	// paginate through ListTemplateErrata until all errata are fetched
+	for {
+		page, total, err := r.ListTemplateErrata(ctx, orgID, templateUUID, tangy.ErrataListFilters{}, api.PaginationData{
+			Limit: limit, Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, errata := range page {
+			if _, ok := seen[errata.ErrataId]; !ok {
+				seen[errata.ErrataId] = struct{}{}
+				errataIDs = append(errataIDs, errata.ErrataId)
+			}
+		}
+		offset += len(page)
+		if offset >= total || len(page) == 0 {
+			break
+		}
+	}
+
+	slices.Sort(errataIDs)
+	return errataIDs, nil
 }

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -2,6 +2,8 @@ package dao
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1588,4 +1590,70 @@ func (s *RpmSuite) TestListErrataForTemplates() {
 		Summary:  expectedErrataItem[0].Summary,
 		CVEs:     expectedErrataItem[0].CVEs,
 	}}, resp)
+}
+
+func (s *RpmSuite) TestFetchTemplateErrataIDs() {
+	mTangy, origTangy := mockTangy(s.T())
+	defer func() { config.Tang = origTangy }()
+	ctx := context.Background()
+	dao := GetRpmDao(s.tx, s.mockRoadmapClient)
+	orgId := seeds.RandomOrgId()
+	hrefs := []string{"some_pulp_version_href"}
+
+	_, err := seeds.SeedRepositoryConfigurations(s.tx, 1, seeds.SeedOptions{
+		OrgID: orgId,
+	})
+	require.NoError(s.T(), err)
+	repoConfig := models.RepositoryConfiguration{}
+	res := s.tx.Where("org_id = ?", orgId).First(&repoConfig)
+	require.NoError(s.T(), res.Error)
+
+	snaps, err := seeds.SeedSnapshots(s.tx, repoConfig.UUID, 1)
+	require.NoError(s.T(), err)
+	res = s.tx.Model(&models.Snapshot{}).Where("repository_configuration_uuid = ?", repoConfig.UUID).Update("version_href", hrefs[0])
+	require.NoError(s.T(), res.Error)
+
+	templates, err := seeds.SeedTemplates(s.tx, 1, seeds.TemplateSeedOptions{OrgID: orgId, RepositoryConfigUUIDs: []string{repoConfig.UUID}, Snapshots: []models.Snapshot{snaps[0]}})
+	require.NoError(s.T(), err)
+	template := templates[0]
+
+	pageLimit := TemplateErrataIDsPageLimit
+	page1 := makeErrataListItems(pageLimit) // adv-1 ... adv-10000
+	// add duplicates plus a new unique one
+	page2 := []tangy.ErrataListItem{
+		{
+			Id:       page1[0].Id,
+			ErrataId: page1[0].ErrataId,
+		},
+		{
+			Id:       page1[1].Id,
+			ErrataId: page1[1].ErrataId,
+		},
+		{
+			Id:       fmt.Sprintf("%d", pageLimit+1),
+			ErrataId: fmt.Sprintf("adv-%d", pageLimit+1),
+		},
+	}
+	total := pageLimit + 1
+
+	mTangy.On("RpmRepositoryVersionErrataList", ctx, hrefs, tangy.ErrataListFilters{},
+		tangy.PageOptions{Offset: 0, Limit: pageLimit}).Return(page1, total, nil)
+	mTangy.On("RpmRepositoryVersionErrataList", ctx, hrefs, tangy.ErrataListFilters{},
+		tangy.PageOptions{Offset: pageLimit, Limit: pageLimit}).Return(page2, total, nil)
+
+	ids, err := dao.FetchTemplateErrataIDs(ctx, orgId, template.UUID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), pageLimit+1, len(ids)) // 501 unique, duplicates removed
+	assert.True(s.T(), slices.IsSorted(ids))
+}
+
+func makeErrataListItems(count int) []tangy.ErrataListItem {
+	items := make([]tangy.ErrataListItem, count)
+	for i := range items {
+		items[i] = tangy.ErrataListItem{
+			Id:       fmt.Sprintf("%d", i+1),
+			ErrataId: fmt.Sprintf("adv-%d", i+1),
+		}
+	}
+	return items
 }

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -124,7 +124,7 @@ func (t templateDaoImpl) create(ctx context.Context, tx *gorm.DB, reqTemplate ap
 	templatesModelToApi(modelTemplate, &respTemplate)
 	respTemplate.RepositoryUUIDS = reqTemplate.RepositoryUUIDS
 
-	event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []event.TemplateEvent{event.MapTemplateResponse(respTemplate, nil, nil)})
+	event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []event.TemplateEvent{event.MapTemplateResponse(respTemplate)})
 
 	return respTemplate, nil
 }
@@ -272,7 +272,7 @@ func (t templateDaoImpl) Update(ctx context.Context, orgID string, uuid string, 
 		return resp, err
 	}
 
-	event.SendTemplateEvent(orgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
+	event.SendTemplateEvent(orgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(resp)})
 
 	return resp, err
 }
@@ -460,7 +460,7 @@ func (t templateDaoImpl) SoftDelete(ctx context.Context, orgID string, uuid stri
 
 	var resp api.TemplateResponse
 	templatesModelToApi(modelTemplate, &resp)
-	event.SendTemplateEvent(orgID, event.TemplateDeleted, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
+	event.SendTemplateEvent(orgID, event.TemplateDeleted, []event.TemplateEvent{event.MapTemplateResponse(resp)})
 
 	return nil
 }

--- a/pkg/event/template_event.go
+++ b/pkg/event/template_event.go
@@ -8,19 +8,17 @@ import (
 
 type TemplateEvent struct {
 	UUID              string    `json:"uuid" readonly:"true"`
-	Name              string    `json:"name"`                         // Name of the template
-	OrgID             string    `json:"org_id"`                       // Organization ID of the owner
-	Description       *string   `json:"description"`                  // Description of the template
-	Arch              string    `json:"arch"`                         // Architecture of the template
-	Version           string    `json:"version"`                      // Version of the template
-	Date              time.Time `json:"date"`                         // Latest date to include snapshots for
-	RepositoryUUIDS   []string  `json:"repository_uuids"`             // Repositories added to the template
-	RHSMEnvironmentID string    `json:"rhsm_environment_id"`          // Environment ID used by subscription-manager & candlepin
-	AddedAdvisories   []string  `json:"added_advisories,omitempty"`   // List of added advisory IDs
-	RemovedAdvisories []string  `json:"removed_advisories,omitempty"` // List of removed advisory IDs
+	Name              string    `json:"name"`                // Name of the template
+	OrgID             string    `json:"org_id"`              // Organization ID of the owner
+	Description       *string   `json:"description"`         // Description of the template
+	Arch              string    `json:"arch"`                // Architecture of the template
+	Version           string    `json:"version"`             // Version of the template
+	Date              time.Time `json:"date"`                // Latest date to include snapshots for
+	RepositoryUUIDS   []string  `json:"repository_uuids"`    // Repositories added to the template
+	RHSMEnvironmentID string    `json:"rhsm_environment_id"` // Environment ID used by subscription-manager & candlepin
 }
 
-func MapTemplateResponse(t api.TemplateResponse, addedAdvisories, removedAdvisories []string) TemplateEvent {
+func MapTemplateResponse(t api.TemplateResponse) TemplateEvent {
 	return TemplateEvent{
 		UUID:              t.UUID,
 		Name:              t.Name,
@@ -31,7 +29,5 @@ func MapTemplateResponse(t api.TemplateResponse, addedAdvisories, removedAdvisor
 		Date:              t.Date,
 		RepositoryUUIDS:   t.RepositoryUUIDS,
 		RHSMEnvironmentID: t.RHSMEnvironmentID,
-		AddedAdvisories:   addedAdvisories,
-		RemovedAdvisories: removedAdvisories,
 	}
 }

--- a/pkg/handler/templates.go
+++ b/pkg/handler/templates.go
@@ -49,6 +49,7 @@ func RegisterTemplateRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, taskCli
 	addTemplateRoute(engine, http.MethodPut, "/templates/:uuid", h.fullUpdate, rbac.RbacVerbWrite)
 	addTemplateRoute(engine, http.MethodPatch, "/templates/:uuid", h.partialUpdate, rbac.RbacVerbWrite)
 	addTemplateRoute(engine, http.MethodGet, "/templates/:template_uuid/config.repo", h.getTemplateRepoConfigurationFile, rbac.RbacVerbRead)
+	addTemplateRoute(engine, http.MethodGet, "/templates/:uuid/advisories/ids", h.fetchTemplateAdvisoryIDs, rbac.RbacVerbRead)
 }
 
 // CreateRepository godoc
@@ -326,6 +327,32 @@ func (th *TemplateHandler) getTemplateRepoConfigurationFile(c echo.Context) erro
 	}
 
 	return c.String(http.StatusOK, templateRepoConfigFiles)
+}
+
+// FetchTemplateAdvisoryIDs godoc
+// @Summary      Fetch template Advisory IDs
+// @ID           fetchTemplateAdvisoryIDs
+// @Description  This operation enables users to retrieve a template's advisory IDs.
+// @Tags         templates
+// @Produce      json
+// @Param        uuid  path  string    true  "Template ID"
+// @Success      200 {object} api.TemplateAdvisoryIDsResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      401 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /templates/{uuid}/advisories/ids [get]
+func (th *TemplateHandler) fetchTemplateAdvisoryIDs(c echo.Context) error {
+	_, orgID := getAccountIdOrgId(c)
+	templateUUID := c.Param("uuid")
+
+	advisoryIDs, err := th.DaoRegistry.Rpm.FetchTemplateErrataIDs(c.Request().Context(), orgID, templateUUID)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching template advisory IDs", err.Error())
+	}
+	return c.JSON(http.StatusOK, api.TemplateAdvisoryIDsResponse{
+		AdvisoryIDs: advisoryIDs,
+	})
 }
 
 func (th *TemplateHandler) enqueueTemplateDeleteEvent(c echo.Context, orgID string, template api.TemplateResponse) error {

--- a/pkg/jobs/send_template_update_events.go
+++ b/pkg/jobs/send_template_update_events.go
@@ -50,9 +50,7 @@ func SendTemplateUpdateEvents(_ []string) {
 			continue
 		}
 
-		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{
-			event.MapTemplateResponse(templateResp, nil, nil),
-		})
+		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(templateResp)})
 		eventsSent++
 
 		log.Info().

--- a/pkg/tasks/delete_repository_snapshots.go
+++ b/pkg/tasks/delete_repository_snapshots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
+	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	zest "github.com/content-services/zest/release/v2026"
@@ -364,6 +365,8 @@ func (d *DeleteRepositorySnapshots) deleteTemplateRepoDistributions() error {
 				errs = append(errs, fmt.Errorf("error polling distribution deletion task for template %v: %w", template.UUID, err))
 			}
 		}
+
+		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(template)})
 	}
 
 	return errors.Join(errs...)

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
+	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
@@ -433,6 +434,8 @@ func (ds *DeleteSnapshots) updateTemplatesUsingSnap(templateUpdateMap *map[strin
 		}
 
 		(*templateUpdateMap)[template.UUID] = snaps[0]
+
+		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(template)})
 	}
 
 	return nil

--- a/pkg/tasks/update_latest_snapshot.go
+++ b/pkg/tasks/update_latest_snapshot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
@@ -119,6 +120,8 @@ func (t *UpdateLatestSnapshot) Run() error {
 			}
 			return err
 		}
+
+		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(template)})
 	}
 	return nil
 }

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -17,6 +17,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	"github.com/content-services/content-sources-backend/pkg/dao"
 	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
@@ -109,7 +110,15 @@ func UpdateTemplateContentHandler(ctx context.Context, task *models.TaskInfo, qu
 	if err != nil {
 		return err
 	}
-	return t.RunCandlepin(env)
+
+	err = t.RunCandlepin(env)
+	if err != nil {
+		return err
+	}
+
+	event.SendTemplateEvent(t.orgId, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(t.template)})
+
+	return nil
 }
 
 type UpdateTemplateContent struct {


### PR DESCRIPTION
## Summary

- Adds an endpoint that returns a template's advisory IDs with no pagination
- Sends template update events whenever a template is updated

## Testing steps

1. Create a template with snapshots that have advisories.
2. Send a GET request to  `/templates/:uuid/advisories/ids`. This should return all the advisory IDs in the template.
3. Run `make kafka-topic-consume KAFKA_TOPIC=platform.content-sources.template`
4. Update the template. There should be 2 messages in the consumer output, one when the update request is sent and one during the `update-template-content` task.
5. Add a custom repo to a template that's using the latest snapshots. Triggering a new snapshot for that repo should enqueue the `update-latest-snapshot` task, and a message should be sent in the consumer output during that task.
6. Change the template to a date before the latest custom repo snapshot. Delete the custom repo snapshot used by the template, this should enqueue a `delete-snapshots` task and a message should be sent in the consumer output.
7. Delete the custom repository used by the template. This should enqueue a `delete-repository-snapshots` task and a message should be sent during this task too.

