### PR TITLE
HMS-9952: Add SendTemplateUpdateEvents job

### DIFF
--- a/cmd/jobs/main.go
+++ b/cmd/jobs/main.go
@@ -27,6 +27,7 @@ func loadJobs() map[string]jobFunc {
 		"move-templates-to-shared-epel":   jobs.MigrateTemplatesToSharedEpel,
 		"remove-custom-epel-repos":        jobs.RemoveCustomEpelRepos,
 		"cancel-tasks":                    jobs.CancelTasks,
+		"send-template-update-events":     jobs.SendTemplateUpdateEvents,
 	}
 }
 

--- a/pkg/jobs/send_template_update_events.go
+++ b/pkg/jobs/send_template_update_events.go
@@ -1,0 +1,70 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/event"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/rs/zerolog/log"
+)
+
+type templateIdentity struct {
+	UUID  string
+	OrgID string
+}
+
+func SendTemplateUpdateEvents(_ []string) {
+	ctx := context.Background()
+	daoReg := dao.GetDaoRegistry(db.DB)
+
+	config.SetupTemplateEvents()
+
+	var templates []templateIdentity
+	err := db.DB.Model(&models.Template{}).
+		Where("deleted_at IS NULL").
+		Order("uuid").
+		Select("uuid", "org_id").
+		Find(&templates).Error
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to fetch templates")
+	}
+
+	log.Info().Int("template_count", len(templates)).Msg("Found templates to process")
+
+	eventsSent := 0
+	processed := 0
+
+	for _, template := range templates {
+		processed++
+
+		templateResp, err := daoReg.Template.Fetch(ctx, template.OrgID, template.UUID, false)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("template_uuid", template.UUID).
+				Str("org_id", template.OrgID).
+				Msg("failed to fetch template")
+			continue
+		}
+
+		event.SendTemplateEvent(template.OrgID, event.TemplateUpdated, []event.TemplateEvent{
+			event.MapTemplateResponse(templateResp, nil, nil),
+		})
+		eventsSent++
+
+		log.Info().
+			Str("template_uuid", template.UUID).
+			Str("org_id", template.OrgID).
+			Int("processed", processed).
+			Int("total", len(templates)).
+			Msg("Sent template-updated event")
+	}
+
+	log.Info().
+		Int("events_sent", eventsSent).
+		Int("total_templates", len(templates)).
+		Msg("Finished sending template-updated events")
+}


### PR DESCRIPTION
## Summary

[HMS-9952 add job to send update events for all templates with added advisories](https://redhat.atlassian.net/browse/HMS-9952])

## Testing steps

with backend running

snapshot a repo or two
make a template with the repos you create

In terminal 1:
```
~/content-sources-backend$ make kafka-topic-consume KAFKA_TOPIC=platform.content-sources.template
info:Using DATABASE_* defaults
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100  16101 100  16101   0      0  45918      0                              0
CONTENT_DATABASE_USER=content CONTENT_DATABASE_PASSWORD=content CONTENT_DATABASE_DATABASE_NAME=content CONTENT_DATABASE_PORT=5433 KAFKA_CONFIG_DIR=/home/<user>/content-sources-backend/compose_files/kafka/config KAFKA_DATA_DIR=/home/<user>/content-sources-backend/compose_files/kafka/data ZOOKEEPER_CLIENT_PORT=2181 KAFKA_TOPICS=platform.content-sources.introspect  podman-compose --project-name=cs -f /home/<user>/content-sources-backend/deployments/docker-compose.yml exec kafka \
  /opt/kafka/bin/kafka-console-consumer.sh \
  --property print.key=true --property print.partition=true --property print.headers=true \
  --topic platform.content-sources.template \
  --group content-sources \
  --bootstrap-server localhost:9092
Option --property is deprecated and will be removed in a future version. Use --formatter-property instead.
```
In terminal 2

```
~/content-sources-backend$ go run cmd/jobs/main.go update-template-content
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[3.243ms] [rows:1] SELECT "uuid","org_id" FROM "templates" WHERE deleted_at IS NULL AND "templates"."deleted_at" IS NULL ORDER BY uuid severity=info
7:46PM INF Found templates to process severity=info template_count=1
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[0.873ms] [rows:1] SELECT * FROM "tasks" WHERE "tasks"."id" = '020f187f-7b93-4bd1-9c6a-bb3080436ce7' severity=info
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[1.176ms] [rows:2] SELECT * FROM "repository_configurations" WHERE "repository_configurations"."uuid" IN ('8a90d784-aa2b-45c9-a241-4076ef3ae57b','d071cb05-901c-4529-b126-6d466faec790') AND "repository_configurations"."deleted_at" IS NULL severity=info
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[1.914ms] [rows:2] SELECT * FROM "snapshots" WHERE "snapshots"."uuid" IN ('3ae5f98a-ead6-49b8-9f17-338001d7cdb9','e03479d0-fbbe-4898-868a-b4b7117ba6b7') AND "snapshots"."deleted_at" IS NULL severity=info
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[2.480ms] [rows:2] SELECT * FROM "templates_repository_configurations" WHERE "templates_repository_configurations"."template_uuid" = '3defcbc9-1e6a-4579-aded-21511a86469a' AND "templates_repository_configurations"."deleted_at" IS NULL severity=info
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[4.335ms] [rows:1] SELECT * FROM "templates" WHERE (uuid = '3defcbc9-1e6a-4579-aded-21511a86469a' AND org_id = '9999') AND "templates"."deleted_at" IS NULL ORDER BY "templates"."uuid" LIMIT 1 severity=info
7:46PM WRN Creating correlation ID for pulp request 316f68ae-c30a-4db1-840e-2e31fe65cec1 severity=warn
7:46PM INF /home/<user>/content-sources-backend/pkg/db/db_logger.go:173
[0.705ms] [rows:2] SELECT * FROM "repository_configurations" WHERE uuid IN ('8a90d784-aa2b-45c9-a241-4076ef3ae57b','d071cb05-901c-4529-b126-6d466faec790')  AND "repository_configurations"."deleted_at" IS NULL severity=info
7:46PM INF Sent template-updated event org_id=9999 processed=1 severity=info template_uuid=3defcbc9-1e6a-4579-aded-21511a86469a total=1
7:46PM INF Finished sending template-updated events events_sent=1 severity=info total_templates=1
```

In terminal 1:
```

Partition:0	content-type:application/cloudevents+json	null	{"specversion":"1.0","id":"271f798f-b65b-4a7c-838e-cb58131a429a","source":"urn:redhat:source:console:app:repositories","type":"com.redhat.console.repositories.template-updated","subject":"urn:redhat:subject:console:rhel:template-updated","datacontenttype":"application/json","time":"2026-06-16T18:46:43.355319998Z","data":[{"uuid":"3defcbc9-1e6a-4579-aded-21511a86469a","name":"test-template","org_id":"9999","description":"created via curl","arch":"x86_64","version":"9","date":"0001-01-01T00:00:00Z","repository_uuids":["8a90d784-aa2b-45c9-a241-4076ef3ae57b","d071cb05-901c-4529-b126-6d466faec790"],"rhsm_environment_id":"3defcbc91e6a4579aded21511a86469a"}],"redhatorgid":"9999"}



```