### PR TITLE
Test: Apply kafka backoff and retry to sarama

### DIFF
--- a/pkg/config/event.go
+++ b/pkg/config/event.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/RedHatInsights/insights-operator-utils/tls"
@@ -170,5 +171,23 @@ func GetSaramaConfig() (*sarama.Config, error) {
 			}
 		}
 	}
+
+	saramaConfig.Producer.Retry.Max = LoadedConfig.Kafka.Message.Send.Max.Retries
+	saramaConfig.Producer.Retry.Backoff = time.Duration(LoadedConfig.Kafka.Retry.Backoff.Ms) * time.Millisecond
+	saramaConfig.Producer.RequiredAcks = producerRequiredAcks(LoadedConfig.Kafka.Request.Required.Acks)
+
 	return saramaConfig, nil
+}
+
+func producerRequiredAcks(acks int) sarama.RequiredAcks {
+	switch acks {
+	case int(sarama.NoResponse):
+		return sarama.NoResponse
+	case int(sarama.WaitForLocal):
+		return sarama.WaitForLocal
+	case int(sarama.WaitForAll):
+		return sarama.WaitForAll
+	default:
+		return sarama.WaitForAll
+	}
 }

--- a/pkg/config/event_test.go
+++ b/pkg/config/event_test.go
@@ -3,8 +3,12 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/IBM/sarama"
+	"github.com/content-services/content-sources-backend/pkg/kafka"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadEnv(t *testing.T) {
@@ -46,4 +50,25 @@ func TestReadEnv(t *testing.T) {
 		result := readEnv(testCase.Given.Key, testCase.Given.DefaultValue)
 		assert.Equal(t, string(testCase.Expected), result)
 	}
+}
+
+func TestGetSaramaConfigProducerSettings(t *testing.T) {
+	LoadedConfig.Kafka = kafka.KafkaConfig{}
+	LoadedConfig.Kafka.Message.Send.Max.Retries = 15
+	LoadedConfig.Kafka.Retry.Backoff.Ms = 100
+	LoadedConfig.Kafka.Request.Required.Acks = -1
+
+	saramaConfig, err := GetSaramaConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, 15, saramaConfig.Producer.Retry.Max)
+	assert.Equal(t, 100*time.Millisecond, saramaConfig.Producer.Retry.Backoff)
+	assert.Equal(t, sarama.WaitForAll, saramaConfig.Producer.RequiredAcks)
+}
+
+func TestProducerRequiredAcks(t *testing.T) {
+	assert.Equal(t, sarama.NoResponse, producerRequiredAcks(0))
+	assert.Equal(t, sarama.WaitForLocal, producerRequiredAcks(1))
+	assert.Equal(t, sarama.WaitForAll, producerRequiredAcks(-1))
+	assert.Equal(t, sarama.WaitForAll, producerRequiredAcks(99))
 }

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -19,6 +19,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -124,7 +125,9 @@ func (t templateDaoImpl) create(ctx context.Context, tx *gorm.DB, reqTemplate ap
 	templatesModelToApi(modelTemplate, &respTemplate)
 	respTemplate.RepositoryUUIDS = reqTemplate.RepositoryUUIDS
 
-	event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []event.TemplateEvent{event.MapTemplateResponse(respTemplate, nil, nil)})
+	if sendErr := event.SendTemplateEvent(*reqTemplate.OrgID, event.TemplateCreated, []event.TemplateEvent{event.MapTemplateResponse(respTemplate, nil, nil)}); sendErr != nil {
+		log.Error().Err(sendErr).Str("template_uuid", respTemplate.UUID).Msg("failed to send template created event")
+	}
 
 	return respTemplate, nil
 }
@@ -272,7 +275,9 @@ func (t templateDaoImpl) Update(ctx context.Context, orgID string, uuid string, 
 		return resp, err
 	}
 
-	event.SendTemplateEvent(orgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
+	if sendErr := event.SendTemplateEvent(orgID, event.TemplateUpdated, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)}); sendErr != nil {
+		log.Error().Err(sendErr).Str("template_uuid", resp.UUID).Msg("failed to send template updated event")
+	}
 
 	return resp, err
 }
@@ -460,7 +465,9 @@ func (t templateDaoImpl) SoftDelete(ctx context.Context, orgID string, uuid stri
 
 	var resp api.TemplateResponse
 	templatesModelToApi(modelTemplate, &resp)
-	event.SendTemplateEvent(orgID, event.TemplateDeleted, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)})
+	if sendErr := event.SendTemplateEvent(orgID, event.TemplateDeleted, []event.TemplateEvent{event.MapTemplateResponse(resp, nil, nil)}); sendErr != nil {
+		log.Error().Err(sendErr).Str("template_uuid", resp.UUID).Msg("failed to send template deleted event")
+	}
 
 	return nil
 }

--- a/pkg/event/client.go
+++ b/pkg/event/client.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/RedHatInsights/event-schemas-go/apps/repositories/v1"
@@ -78,33 +79,37 @@ func SetEmptyToNil(value string) *string {
 	return &value
 }
 
-// SendTemplateEvent - Sends an event about a template to the patch service
-func SendTemplateEvent(orgID string, eventName EventName, templates []TemplateEvent) {
-	if config.Get().TemplateEventClient != nil && len(templates) > 0 {
-		eventNameStr := eventName.String()
-		newUUID, _ := uuid.NewRandom()
-		e := cloudevents.NewEvent()
-		e.SetSource("urn:redhat:source:console:app:repositories")
-		e.SetID(newUUID.String())
-		e.SetType("com.redhat.console.repositories." + eventNameStr)
-		e.SetSubject("urn:redhat:subject:console:rhel:" + eventNameStr)
-		e.SetTime(time.Now())
-		e.SetExtension("redhatorgid", orgID)
-
-		data := templates
-		err := e.SetData(cloudevents.ApplicationJSON, data)
-
-		if err != nil {
-			log.Error().Err(err).Msg("failed to create cloudevents client")
-			return
-		}
-
-		ctx := cloudevents.WithEncodingStructured(context.Background())
-		// Send the event
-		if result := config.Get().TemplateEventClient.Send(ctx, e); cloudevents.IsUndelivered(result) {
-			log.Error().Msgf("Notification message failed to send: %v", result)
-			return
-		}
-		ctx.Done()
+// SendTemplateEvent sends an event about a template to the patch service.
+func SendTemplateEvent(orgID string, eventName EventName, templates []TemplateEvent) error {
+	if len(templates) == 0 {
+		return nil
 	}
+	if config.Get().TemplateEventClient == nil {
+		return fmt.Errorf("template event client is not configured")
+	}
+
+	eventNameStr := eventName.String()
+	newUUID, _ := uuid.NewRandom()
+	e := cloudevents.NewEvent()
+	e.SetSource("urn:redhat:source:console:app:repositories")
+	e.SetID(newUUID.String())
+	e.SetType("com.redhat.console.repositories." + eventNameStr)
+	e.SetSubject("urn:redhat:subject:console:rhel:" + eventNameStr)
+	e.SetTime(time.Now())
+	e.SetExtension("redhatorgid", orgID)
+
+	data := templates
+	err := e.SetData(cloudevents.ApplicationJSON, data)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create template cloudevent")
+		return fmt.Errorf("failed to create template cloudevent: %w", err)
+	}
+
+	ctx := cloudevents.WithEncodingStructured(context.Background())
+	if result := config.Get().TemplateEventClient.Send(ctx, e); cloudevents.IsUndelivered(result) {
+		log.Error().Msgf("template message failed to send: %v", result)
+		return fmt.Errorf("template message failed to send: %v", result)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
 Apply kafka backoff and retry to sarama

Kafka retry, backoff, and required-acks from config were defined but never applied in GetSaramaConfig(). This applies them so template and notification producers retry transient broker failures.

SendTemplateEvent now returns an error on send failure so callers can detect and report failed events instead of silently continuing.

## Testing steps

tests pass

