### PR TITLE
HMS-10544: Add lookup for orphaned distributions

### DIFF
--- a/pkg/external_repos/commands/cleanup.go
+++ b/pkg/external_repos/commands/cleanup.go
@@ -25,6 +25,8 @@ import (
 
 var allTypes = []string{"repository", "task", "snapshot", "upload", "pulp-orphan"}
 
+const maxSnapshotsPerDeleteTask = 100
+
 func CleanupUsage() string {
 	return fmt.Sprintf("Run the cleanup tasks [%v]", strings.Join(allTypes, ", "))
 }
@@ -156,6 +158,13 @@ func enqueueSnapshotCleanupForRepoConfig(ctx context.Context, taskClient client.
 		if snap.CreatedAt.Before(cutoffTime) {
 			toBeDeletedSnapUUIDs = append(toBeDeletedSnapUUIDs, snap.UUID)
 		}
+	}
+	if len(toBeDeletedSnapUUIDs) > maxSnapshotsPerDeleteTask {
+		log.Info().Msgf(
+			"Limiting delete snapshots task to %d snapshots for repository %v (%d outdated snapshots found)",
+			maxSnapshotsPerDeleteTask, repo.Name, len(toBeDeletedSnapUUIDs),
+		)
+		toBeDeletedSnapUUIDs = toBeDeletedSnapUUIDs[:maxSnapshotsPerDeleteTask]
 	}
 	if len(toBeDeletedSnapUUIDs) == 0 {
 		return fmt.Errorf("no outdated snapshot found for repository %v", repo.Name)

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -274,78 +275,205 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 		}
 	}
 
-	// Before deleting the version, list all distributions to see if any still reference this publication
-	logger.Info().
-		Str("snapshot_uuid", snap.UUID).
-		Str("publication_href", snap.PublicationHref).
-		Msg("Checking for distributions still using publication before deleting version")
+	if err = ds.deleteRepositoryVersion(snap, repo); err != nil {
+		return err
+	}
 
-	allDistributions, listErr := ds.getPulpClient().ListDistributions(ds.ctx)
-	if listErr != nil {
-		logger.Warn().
-			Err(listErr).
-			Msg("Could not list distributions before version delete")
-	} else if allDistributions != nil {
-		blockingDistributions := []string{}
-		for _, dist := range *allDistributions {
-			if dist.Publication.IsSet() {
-				pub := dist.Publication.Get()
-				if pub != nil && *pub == snap.PublicationHref {
-					blockingDistributions = append(blockingDistributions, fmt.Sprintf("%s (path: %s)", dist.Name, dist.BasePath))
-					logger.Warn().
-						Str("dist_name", dist.Name).
-						Str("dist_base_path", dist.BasePath).
-						Str("dist_href", *dist.PulpHref).
-						Str("publication", *pub).
-						Msg("Found distribution still using publication about to be deleted")
-				}
-			}
-		}
-		if len(blockingDistributions) > 0 {
-			logger.Warn().
-				Str("snapshot_uuid", snap.UUID).
-				Str("publication_href", snap.PublicationHref).
-				Msg("Distributions still using publication - version delete will likely fail")
-		} else {
-			logger.Info().
-				Str("snapshot_uuid", snap.UUID).
-				Msg("No distributions found using publication - safe to delete version")
-		}
+	return nil
+}
+
+func isRepositoryVersionBlockedByDistribution(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "currently being used to distribute content") ||
+		strings.Contains(msg, "update the necessary distributions first")
+}
+
+func (ds *DeleteSnapshots) deleteDistributionAtPath(distPath string) error {
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID)
+
+	dist, err := ds.getPulpClient().FindDistributionByPath(ds.ctx, distPath)
+	if err != nil {
+		return fmt.Errorf("failed to find distribution at base path %v: %w", distPath, err)
+	}
+	if dist == nil || dist.PulpHref == nil {
+		logger.Debug().
+			Str("base_path", distPath).
+			Bool("distribution_found", dist != nil).
+			Msg("no distribution found at path")
+		return nil
 	}
 
 	logger.Info().
+		Str("dist_href", *dist.PulpHref).
+		Str("base_path", dist.BasePath).
+		Msg("Deleting distribution at path")
+
+	deleteDistributionHref, err := ds.getPulpClient().DeleteRpmDistribution(ds.ctx, *dist.PulpHref)
+	if err != nil {
+		return fmt.Errorf("failed to delete distribution %v at path %v: %w", *dist.PulpHref, distPath, err)
+	}
+	if deleteDistributionHref != nil {
+		if _, err = ds.getPulpClient().PollTask(ds.ctx, *deleteDistributionHref); err != nil {
+			return fmt.Errorf("error polling distribution deletion task for %v: %w", *dist.PulpHref, err)
+		}
+	}
+
+	return nil
+}
+
+// deleteDistributionIfBlockingPublication deletes the distribution at distPath when it
+// references publicationHref (or has no publication set). Returns whether a delete ran.
+func (ds *DeleteSnapshots) deleteDistributionIfBlockingPublication(distPath, publicationHref, snapshotUUID string) (bool, error) {
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID)
+
+	dist, err := ds.getPulpClient().FindDistributionByPath(ds.ctx, distPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to find distribution at base path %v: %w", distPath, err)
+	}
+	if dist == nil || dist.PulpHref == nil {
+		logger.Debug().
+			Str("base_path", distPath).
+			Str("publication", publicationHref).
+			Bool("distribution_found", dist != nil).
+			Msg("no distribution found at path while looking for blocking distribution")
+		return false, nil
+	}
+	if !dist.Publication.IsSet() {
+		if err := ds.deleteDistributionAtPath(distPath); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	pub := dist.Publication.Get()
+	if pub == nil || *pub != publicationHref {
+		foundPub := ""
+		if pub != nil {
+			foundPub = *pub
+		}
+		logger.Debug().
+			Str("base_path", distPath).
+			Str("expected_publication", publicationHref).
+			Str("found_publication", foundPub).
+			Msg("distribution at path does not reference the publication blocking repository version deletion")
+		return false, nil
+	}
+
+	logger.Info().
+		Str("snapshot_uuid", snapshotUUID).
+		Str("dist_href", *dist.PulpHref).
+		Str("base_path", dist.BasePath).
+		Str("publication", publicationHref).
+		Msg("Deleting untracked distribution blocking repository version deletion")
+
+	if err := ds.deleteDistributionAtPath(distPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (ds *DeleteSnapshots) deleteDistributionsBlockingPublication(snap models.Snapshot, repo api.RepositoryResponse, publicationHref string) error {
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID)
+
+	distPaths := []string{snap.DistributionPath}
+
+	templates, err := ds.daoReg.Template.InternalOnlyGetTemplatesForRepoConfig(ds.ctx, snap.RepositoryConfigurationUUID, false)
+	if err != nil {
+		return fmt.Errorf("failed to list templates for repo %v: %w", snap.RepositoryConfigurationUUID, err)
+	}
+	for _, template := range templates {
+		distPath, _, pathErr := getDistPathAndName(repo, template.UUID)
+		if pathErr != nil {
+			return fmt.Errorf("failed to get distribution path for template %v: %w", template.UUID, pathErr)
+		}
+		distPaths = append(distPaths, distPath)
+	}
+
+	deletedAny := false
+	for _, distPath := range distPaths {
+		deleted, deleteErr := ds.deleteDistributionIfBlockingPublication(distPath, publicationHref, snap.UUID)
+		if deleteErr != nil {
+			return deleteErr
+		}
+		if deleted {
+			deletedAny = true
+		}
+	}
+
+	if !deletedAny {
+		logger.Warn().
+			Str("snapshot_uuid", snap.UUID).
+			Str("base_path", snap.DistributionPath).
+			Str("publication", publicationHref).
+			Int("paths_checked", len(distPaths)).
+			Msg("expected distribution blocking repository version deletion, but none found referencing publication")
+	}
+
+	return nil
+}
+
+func (ds *DeleteSnapshots) deleteRepositoryVersion(snap models.Snapshot, repo api.RepositoryResponse) error {
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID).With().
 		Str("snapshot_uuid", snap.UUID).
 		Str("version_href", snap.VersionHref).
-		Msg("Deleting repository version")
+		Logger()
+
+	logger.Info().Msg("Deleting repository version")
+
+	if err := ds.attemptDeleteRepositoryVersion(snap, repo); err != nil {
+		if !isRepositoryVersionBlockedByDistribution(err) {
+			return err
+		}
+		if cleanupErr := ds.deleteDistributionsBlockingPublication(snap, repo, snap.PublicationHref); cleanupErr != nil {
+			return fmt.Errorf("%w (also failed to clean up blocking distributions: %v)", err, cleanupErr)
+		}
+		if err := ds.attemptDeleteRepositoryVersion(snap, repo); err != nil {
+			return fmt.Errorf("failed to delete repository version after cleanup: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (ds *DeleteSnapshots) attemptDeleteRepositoryVersion(snap models.Snapshot, repo api.RepositoryResponse) error {
+	logger := LogForTask(ds.task.Id.String(), ds.task.Typename, ds.task.RequestID).With().
+		Str("snapshot_uuid", snap.UUID).
+		Str("version_href", snap.VersionHref).
+		Logger()
 
 	deleteVersionHref, err := ds.getPulpClient().DeleteRpmRepositoryVersion(ds.ctx, snap.VersionHref)
 	if err != nil {
-		distributions, listDistErr := ds.getPulpClient().ListDistributions(ds.ctx)
-		if listDistErr != nil {
-			return fmt.Errorf("failed to list distributions after version delete failure for snapshot %v: %w", snap.UUID, listDistErr)
-		}
-		logger.Debug().Msgf("Checking distributions for publication: %v", snap.PublicationHref)
-		if distributions != nil {
-			for _, dist := range *distributions {
-				if dist.Publication.IsSet() {
-					pub := dist.Publication.Get()
-					if dist.PulpHref != nil && pub != nil && *pub == snap.PublicationHref {
-						logger.Debug().
-							Str("href", *dist.PulpHref).
-							Str("base_path", dist.BasePath).
-							Str("publication", *pub).
-							Msg("Found distribution using deleted publication")
-					}
-				}
-			}
-		}
-		return fmt.Errorf("failed to delete repository version %v for snapshot %v: %w", snap.VersionHref, snap.UUID, err)
+		return fmt.Errorf("failed to delete repository version: %w", err)
 	}
+
 	if deleteVersionHref != nil {
 		_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteVersionHref)
 		if err != nil {
-			return fmt.Errorf("error polling repository version deletion task for snapshot %v: %w", snap.UUID, err)
+			if !isRepositoryVersionBlockedByDistribution(err) {
+				return fmt.Errorf("error polling repository version deletion task: %w", err)
+			}
+			if cleanupErr := ds.deleteDistributionsBlockingPublication(snap, repo, snap.PublicationHref); cleanupErr != nil {
+				return fmt.Errorf(
+					"error polling repository version deletion task: %w (also failed to clean up blocking distributions: %v)",
+					err, cleanupErr,
+				)
+			}
+			deleteVersionHref, err = ds.getPulpClient().DeleteRpmRepositoryVersion(ds.ctx, snap.VersionHref)
+			if err != nil {
+				return fmt.Errorf("failed to delete repository version after cleanup: %w", err)
+			}
+			if deleteVersionHref != nil {
+				_, err = ds.getPulpClient().PollTask(ds.ctx, *deleteVersionHref)
+				if err != nil {
+					return fmt.Errorf("error polling repository version deletion task after cleanup: %w", err)
+				}
+			}
 		}
+	} else if _, verifyErr := ds.getPulpClient().GetRpmRepositoryVersion(ds.ctx, snap.VersionHref); verifyErr == nil {
+		logger.Warn().Msg("repository version still exists after delete returned no task")
+		return fmt.Errorf("repository version still exists after delete returned no task")
 	}
 
 	return nil

--- a/pkg/tasks/delete_snapshots_test.go
+++ b/pkg/tasks/delete_snapshots_test.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -113,7 +115,6 @@ func (s *DeleteSnapshotsSuite) TestDeleteSnapshots() {
 	s.mockPulpClient.On("CreateRpmDistribution", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uuid.NewString(), nil)
 	s.mockPulpClient.On("UpdateRpmDistribution", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(uuid.NewString(), nil)
 	s.mockPulpClient.On("DeleteRpmDistribution", ctx, snap.DistributionHref).Return(&deleteDistributionHref, nil)
-	s.mockPulpClient.On("ListDistributions", ctx).Return(&[]zest.RpmRpmDistributionResponse{}, nil)
 	s.mockPulpClient.On("PollTask", ctx, mock.Anything).Return(nil, nil)
 	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, snap.VersionHref).Return(utils.Ptr("taskHref"), nil)
 
@@ -138,4 +139,239 @@ func (s *DeleteSnapshotsSuite) TestDeleteSnapshots() {
 
 	taskErr := deleteSnapshotsTask.Run()
 	assert.NoError(t, taskErr)
+}
+
+func (s *DeleteSnapshotsSuite) TestDeleteRepositoryVersionCleansUntrackedBlockingDistributions() {
+	t := s.T()
+	ctx := context.Background()
+
+	repoUUID := uuid.NewString()
+	snapIdent := uuid.NewString()
+	publicationHref := uuid.NewString()
+	versionHref := uuid.NewString()
+	blockingDistHref := uuid.NewString()
+	deleteDistTaskHref := uuid.NewString()
+	versionDeleteTaskHref := uuid.NewString()
+	distributionPath := fmt.Sprintf("%s/%s", repoUUID, snapIdent)
+
+	nullablePubHref := zest.NullableString{}
+	nullablePubHref.Set(&publicationHref)
+
+	blockingPollErr := errors.New("domain cs-test had Pulp Task error 'description: The repository version cannot be deleted because it (or its publications) are currently being used to distribute content. Please update the necessary distributions first.'")
+
+	repo := api.RepositoryResponse{
+		UUID:  repoUUID,
+		OrgID: test_handler.MockOrgId,
+	}
+	snap := models.Snapshot{
+		Base: models.Base{
+			UUID: uuid.NewString(),
+		},
+		DistributionPath:            distributionPath,
+		PublicationHref:             publicationHref,
+		VersionHref:                 versionHref,
+		RepositoryConfigurationUUID: repoUUID,
+	}
+
+	s.mockDaoRegistry.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, false).Return([]api.TemplateResponse{}, nil).Once()
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(&versionDeleteTaskHref, nil).Twice()
+	s.mockPulpClient.On("PollTask", ctx, versionDeleteTaskHref).Return(nil, blockingPollErr).Once()
+	s.mockPulpClient.On("FindDistributionByPath", ctx, distributionPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:    &blockingDistHref,
+		BasePath:    distributionPath,
+		Publication: nullablePubHref,
+	}, nil).Twice()
+	s.mockPulpClient.On("DeleteRpmDistribution", ctx, blockingDistHref).Return(&deleteDistTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, deleteDistTaskHref).Return(nil, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, versionDeleteTaskHref).Return(nil, nil).Once()
+
+	pulpClient := s.pulpClient()
+	task := models.TaskInfo{
+		Id:        uuid.UUID{},
+		RequestID: uuid.NewString(),
+		Typename:  config.DeleteSnapshotsTask,
+	}
+	deleteSnapshotsTask := DeleteSnapshots{
+		ctx:        ctx,
+		task:       &task,
+		daoReg:     s.mockDaoRegistry.ToDaoRegistry(),
+		pulpClient: &pulpClient,
+	}
+
+	err := deleteSnapshotsTask.deleteRepositoryVersion(snap, repo)
+	assert.NoError(t, err)
+}
+
+func (s *DeleteSnapshotsSuite) TestDeleteRepositoryVersionCleansUntrackedBlockingDistributionsOnDeleteError() {
+	t := s.T()
+	ctx := context.Background()
+
+	repoUUID := uuid.NewString()
+	snapIdent := uuid.NewString()
+	publicationHref := uuid.NewString()
+	versionHref := uuid.NewString()
+	blockingDistHref := uuid.NewString()
+	deleteDistTaskHref := uuid.NewString()
+	versionDeleteTaskHref := uuid.NewString()
+	distributionPath := fmt.Sprintf("%s/%s", repoUUID, snapIdent)
+
+	nullablePubHref := zest.NullableString{}
+	nullablePubHref.Set(&publicationHref)
+
+	blockingDeleteErr := errors.New(`error deleting rpm repository versions: 400 Bad Request: ["The repository version cannot be deleted because it (or its publications) are currently being used to distribute content. Please update the necessary distributions first."]`)
+
+	repo := api.RepositoryResponse{
+		UUID:  repoUUID,
+		OrgID: test_handler.MockOrgId,
+	}
+	snap := models.Snapshot{
+		Base: models.Base{
+			UUID: uuid.NewString(),
+		},
+		DistributionPath:            distributionPath,
+		PublicationHref:             publicationHref,
+		VersionHref:                 versionHref,
+		RepositoryConfigurationUUID: repoUUID,
+	}
+
+	s.mockDaoRegistry.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, false).Return([]api.TemplateResponse{}, nil).Once()
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(nil, blockingDeleteErr).Once()
+	s.mockPulpClient.On("FindDistributionByPath", ctx, distributionPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:    &blockingDistHref,
+		BasePath:    distributionPath,
+		Publication: nullablePubHref,
+	}, nil).Twice()
+	s.mockPulpClient.On("DeleteRpmDistribution", ctx, blockingDistHref).Return(&deleteDistTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, deleteDistTaskHref).Return(nil, nil).Once()
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(&versionDeleteTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, versionDeleteTaskHref).Return(nil, nil).Once()
+
+	pulpClient := s.pulpClient()
+	task := models.TaskInfo{
+		Id:        uuid.UUID{},
+		RequestID: uuid.NewString(),
+		Typename:  config.DeleteSnapshotsTask,
+	}
+	deleteSnapshotsTask := DeleteSnapshots{
+		ctx:        ctx,
+		task:       &task,
+		daoReg:     s.mockDaoRegistry.ToDaoRegistry(),
+		pulpClient: &pulpClient,
+	}
+
+	err := deleteSnapshotsTask.deleteRepositoryVersion(snap, repo)
+	assert.NoError(t, err)
+}
+
+func (s *DeleteSnapshotsSuite) TestDeleteRepositoryVersionCleansUntrackedTemplateBlockingDistributions() {
+	t := s.T()
+	ctx := context.Background()
+
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	snapIdent := uuid.NewString()
+	publicationHref := uuid.NewString()
+	otherPublicationHref := uuid.NewString()
+	versionHref := uuid.NewString()
+	blockingDistHref := uuid.NewString()
+	deleteDistTaskHref := uuid.NewString()
+	versionDeleteTaskHref := uuid.NewString()
+	distributionPath := fmt.Sprintf("%s/%s", repoUUID, snapIdent)
+	templateDistPath := fmt.Sprintf("templates/%s/%s", templateUUID, repoUUID)
+
+	snapPubHref := zest.NullableString{}
+	snapPubHref.Set(&otherPublicationHref)
+	templatePubHref := zest.NullableString{}
+	templatePubHref.Set(&publicationHref)
+
+	blockingDeleteErr := errors.New(`error deleting rpm repository versions: 400 Bad Request: ["The repository version cannot be deleted because it (or its publications) are currently being used to distribute content. Please update the necessary distributions first."]`)
+
+	repo := api.RepositoryResponse{
+		UUID:  repoUUID,
+		OrgID: test_handler.MockOrgId,
+	}
+	snap := models.Snapshot{
+		Base: models.Base{
+			UUID: uuid.NewString(),
+		},
+		DistributionPath:            distributionPath,
+		PublicationHref:             publicationHref,
+		VersionHref:                 versionHref,
+		RepositoryConfigurationUUID: repoUUID,
+	}
+	template := api.TemplateResponse{UUID: templateUUID}
+
+	s.mockDaoRegistry.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, false).
+		Return([]api.TemplateResponse{template}, nil).Once()
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(nil, blockingDeleteErr).Once()
+	// Snapshot path distribution points at a different publication — should be left alone.
+	s.mockPulpClient.On("FindDistributionByPath", ctx, distributionPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:    utils.Ptr(uuid.NewString()),
+		BasePath:    distributionPath,
+		Publication: snapPubHref,
+	}, nil).Once()
+	// Template path distribution blocks deletion.
+	s.mockPulpClient.On("FindDistributionByPath", ctx, templateDistPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:    &blockingDistHref,
+		BasePath:    templateDistPath,
+		Publication: templatePubHref,
+	}, nil).Twice()
+	s.mockPulpClient.On("DeleteRpmDistribution", ctx, blockingDistHref).Return(&deleteDistTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, deleteDistTaskHref).Return(nil, nil).Once()
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(&versionDeleteTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, versionDeleteTaskHref).Return(nil, nil).Once()
+
+	pulpClient := s.pulpClient()
+	task := models.TaskInfo{
+		Id:        uuid.UUID{},
+		RequestID: uuid.NewString(),
+		Typename:  config.DeleteSnapshotsTask,
+	}
+	deleteSnapshotsTask := DeleteSnapshots{
+		ctx:        ctx,
+		task:       &task,
+		daoReg:     s.mockDaoRegistry.ToDaoRegistry(),
+		pulpClient: &pulpClient,
+	}
+
+	err := deleteSnapshotsTask.deleteRepositoryVersion(snap, repo)
+	assert.NoError(t, err)
+}
+
+func (s *DeleteSnapshotsSuite) TestDeleteRepositoryVersionDoesNotCleanupOnUnrelatedPollFailure() {
+	t := s.T()
+	ctx := context.Background()
+
+	versionHref := uuid.NewString()
+	versionDeleteTaskHref := uuid.NewString()
+
+	repo := api.RepositoryResponse{
+		UUID:  uuid.NewString(),
+		OrgID: test_handler.MockOrgId,
+	}
+	snap := models.Snapshot{
+		Base: models.Base{
+			UUID: uuid.NewString(),
+		},
+		VersionHref: versionHref,
+	}
+
+	s.mockPulpClient.On("DeleteRpmRepositoryVersion", ctx, versionHref).Return(&versionDeleteTaskHref, nil).Once()
+	s.mockPulpClient.On("PollTask", ctx, versionDeleteTaskHref).Return(nil, errors.New("unexpected pulp failure")).Once()
+
+	pulpClient := s.pulpClient()
+	task := models.TaskInfo{
+		Id:        uuid.UUID{},
+		RequestID: uuid.NewString(),
+		Typename:  config.DeleteSnapshotsTask,
+	}
+	deleteSnapshotsTask := DeleteSnapshots{
+		ctx:        ctx,
+		task:       &task,
+		pulpClient: &pulpClient,
+	}
+
+	err := deleteSnapshotsTask.deleteRepositoryVersion(snap, repo)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected pulp failure")
 }

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +26,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/utils"
 	uuid2 "github.com/google/uuid"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -40,6 +41,7 @@ type DeleteTest struct {
 }
 
 func (s *DeleteTest) SetupTest() {
+	s.configurePulpClientCertPaths()
 	s.Suite.SetupTest()
 	s.ctx = context.Background()
 	s.cpClient = candlepin_client.NewCandlepinClient()
@@ -49,6 +51,37 @@ func (s *DeleteTest) SetupTest() {
 	// Force content guard setup
 	config.Get().Clients.Pulp.RepoContentGuards = true
 	config.Get().Clients.Pulp.GuardSubjectDn = "warlin.door"
+}
+
+func (s *DeleteTest) configurePulpClientCertPaths() {
+	cfg := config.Get()
+	root := findProjectRoot(s.T())
+
+	if cfg.Clients.Pulp.ClientCertPath != "" && !filepath.IsAbs(cfg.Clients.Pulp.ClientCertPath) {
+		cfg.Clients.Pulp.ClientCertPath = filepath.Join(root, cfg.Clients.Pulp.ClientCertPath)
+	}
+	if cfg.Clients.Pulp.ClientKeyPath != "" && !filepath.IsAbs(cfg.Clients.Pulp.ClientKeyPath) {
+		cfg.Clients.Pulp.ClientKeyPath = filepath.Join(root, cfg.Clients.Pulp.ClientKeyPath)
+	}
+	if cfg.Clients.Pulp.CACertPath != "" && !filepath.IsAbs(cfg.Clients.Pulp.CACertPath) {
+		cfg.Clients.Pulp.CACertPath = filepath.Join(root, cfg.Clients.Pulp.CACertPath)
+	}
+}
+
+func findProjectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find project root")
+		}
+		dir = parent
+	}
 }
 
 func TestDeleteTest(t *testing.T) {
@@ -422,6 +455,159 @@ func (s *DeleteTest) TestDeleteRedHatSnapshot() {
 	assert.NoError(s.T(), err)
 }
 
+func (s *DeleteTest) TestDeleteSnapshotCleansUntrackedBlockingDistribution() {
+	t := s.T()
+
+	config.Get().Features.Snapshots.Enabled = true
+	err := config.ConfigureTang()
+	require.NoError(t, err)
+	require.NotNil(t, config.Tang)
+	orgID := uuid2.NewString()
+	taskClient := client.NewTaskClient(&s.queue)
+	domain, err := s.dao.Domain.FetchOrCreateDomain(s.ctx, orgID)
+	require.NoError(t, err)
+	s.pulpClient = pulp_client.GetPulpClientWithDomain(domain)
+	require.NotNil(t, s.pulpClient)
+
+	repo, err := s.dao.RepositoryConfig.Create(s.ctx, api.RepositoryRequest{
+		Name:      utils.Ptr(uuid2.NewString()),
+		URL:       utils.Ptr("https://fedorapeople.org/groups/katello/fakerepos/zoo/"),
+		AccountID: utils.Ptr(orgID),
+		OrgID:     utils.Ptr(orgID),
+	})
+	require.NoError(t, err)
+	repoUuid, err := uuid2.Parse(repo.RepositoryUUID)
+	require.NoError(t, err)
+	s.snapshotAndWait(taskClient, repo, repoUuid, false)
+
+	_, err = s.dao.RepositoryConfig.Update(s.ctx, orgID, repo.UUID, api.RepositoryUpdateRequest{
+		URL: utils.Ptr("https://content-services.github.io/fixtures/yum/comps-modules/v1/"),
+	})
+	require.NoError(t, err)
+	repo, err = s.dao.RepositoryConfig.Fetch(s.ctx, orgID, repo.UUID)
+	require.NoError(t, err)
+	s.snapshotAndWait(taskClient, repo, dao.UuidifyString(repo.RepositoryUUID), false)
+
+	repoSnaps, _, err := s.dao.Snapshot.List(s.ctx, orgID, repo.UUID, api.PaginationData{
+		Limit:  -1,
+		SortBy: "created_at desc",
+	}, api.FilterData{})
+	require.NoError(t, err)
+	require.Len(t, repoSnaps.Data, 2)
+
+	olderSnapUUID, newerSnapUUID := snapshotUUIDsByAge(t, repoSnaps.Data)
+	olderSnap, err := s.dao.Snapshot.FetchModel(s.ctx, olderSnapUUID, true)
+	require.NoError(t, err)
+
+	s.recreateUntrackedBlockingDistribution(olderSnap)
+
+	err = s.dao.Snapshot.SoftDelete(s.ctx, olderSnapUUID)
+	require.NoError(t, err)
+
+	requestID := uuid2.NewString()
+	taskUUID, err := taskClient.Enqueue(queue.Task{
+		Typename: config.DeleteSnapshotsTask,
+		Payload: utils.Ptr(payloads.DeleteSnapshotsPayload{
+			RepoUUID:       repo.UUID,
+			SnapshotsUUIDs: []string{olderSnapUUID},
+		}),
+		OrgId:      orgID,
+		AccountId:  orgID,
+		ObjectUUID: utils.Ptr(repo.UUID),
+		ObjectType: utils.Ptr(config.ObjectTypeRepository),
+		RequestID:  requestID,
+	})
+	require.NoError(t, err)
+	s.WaitOnTask(taskUUID)
+
+	repoSnaps, _, err = s.dao.Snapshot.List(s.ctx, orgID, repo.UUID, api.PaginationData{
+		Limit:  -1,
+		SortBy: "created_at desc",
+	}, api.FilterData{})
+	require.NoError(t, err)
+	require.Len(t, repoSnaps.Data, 1)
+	require.Equal(t, newerSnapUUID, repoSnaps.Data[0].UUID)
+	deletedSnap, err := s.dao.Snapshot.FetchModel(s.ctx, olderSnapUUID, true)
+	require.Error(t, err)
+	require.Equal(t, models.Snapshot{}, deletedSnap)
+
+	resp, err := s.pulpClient.FindDistributionByPath(s.ctx, olderSnap.DistributionPath)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	_, err = s.pulpClient.FindRpmPublicationByVersion(s.ctx, olderSnap.VersionHref)
+	require.Error(t, err)
+	_, err = s.pulpClient.GetRpmRepositoryVersion(s.ctx, olderSnap.VersionHref)
+	require.Error(t, err)
+}
+
+func (s *DeleteTest) recreateUntrackedBlockingDistribution(snap models.Snapshot) {
+	t := s.T()
+
+	dist, err := s.pulpClient.FindDistributionByPath(s.ctx, snap.DistributionPath)
+	require.NoError(t, err)
+	require.NotNil(t, dist)
+	require.NotNil(t, dist.PulpHref)
+	require.Equal(t, snap.DistributionHref, *dist.PulpHref)
+
+	var contentGuardHref *string
+	if dist.ContentGuard.IsSet() {
+		contentGuardHref = dist.ContentGuard.Get()
+	}
+
+	deleteTaskHref, err := s.pulpClient.DeleteRpmDistribution(s.ctx, snap.DistributionHref)
+	require.NoError(t, err)
+	if deleteTaskHref != nil {
+		_, err = s.pulpClient.PollTask(s.ctx, *deleteTaskHref)
+		require.NoError(t, err)
+	}
+
+	gone, err := s.pulpClient.FindDistributionByPath(s.ctx, snap.DistributionPath)
+	require.NoError(t, err)
+	require.Nil(t, gone)
+
+	createTaskHref, err := s.pulpClient.CreateRpmDistribution(
+		s.ctx, snap.PublicationHref, dist.Name, snap.DistributionPath, contentGuardHref,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, createTaskHref)
+	_, err = s.pulpClient.PollTask(s.ctx, *createTaskHref)
+	require.NoError(t, err)
+
+	newDist, err := s.pulpClient.FindDistributionByPath(s.ctx, snap.DistributionPath)
+	require.NoError(t, err)
+	require.NotNil(t, newDist)
+	require.NotNil(t, newDist.PulpHref)
+	assert.NotEqual(t, snap.DistributionHref, *newDist.PulpHref)
+	require.True(t, newDist.Publication.IsSet())
+	pub := newDist.Publication.Get()
+	require.NotNil(t, pub)
+	assert.Equal(t, snap.PublicationHref, *pub)
+}
+
+func snapshotUUIDsByAge(t *testing.T, snaps []api.SnapshotResponse) (olderUUID, newerUUID string) {
+	t.Helper()
+	require.NotEmpty(t, snaps)
+
+	olderUUID = snaps[0].UUID
+	newerUUID = snaps[0].UUID
+	olderCreated := snaps[0].CreatedAt
+	newerCreated := snaps[0].CreatedAt
+
+	for _, snap := range snaps[1:] {
+		if snap.CreatedAt.Before(olderCreated) {
+			olderUUID = snap.UUID
+			olderCreated = snap.CreatedAt
+		}
+		if snap.CreatedAt.After(newerCreated) {
+			newerUUID = snap.UUID
+			newerCreated = snap.CreatedAt
+		}
+	}
+
+	return olderUUID, newerUUID
+}
+
 func (s *DeleteTest) TestDeleteCommunitySnapshot() {
 	t := s.T()
 
@@ -559,25 +745,4 @@ func (s *DeleteTest) TestDeleteCommunitySnapshot() {
 	rpmPath = fmt.Sprintf("%v%v/%v/latest/Packages/f", host, domain, repo.UUID)
 	err = s.getRequest(rpmPath, identity.Identity{OrgID: orgID, Internal: identity.Internal{OrgID: orgID}}, 200)
 	assert.NoError(s.T(), err)
-}
-
-func (s *DeleteTest) WaitOnTask(taskUuid uuid2.UUID) {
-	// Poll until the task is complete
-	taskInfo, err := s.queue.Status(taskUuid)
-	assert.NoError(s.T(), err)
-	for {
-		if taskInfo.Status == config.TaskStatusRunning || taskInfo.Status == config.TaskStatusPending {
-			log.Logger.Error().Msg("SLEEPING")
-			time.Sleep(1 * time.Second)
-		} else {
-			break
-		}
-		taskInfo, err = s.queue.Status(taskUuid)
-		assert.NoError(s.T(), err)
-	}
-	if taskInfo.Error != nil {
-		assert.Nil(s.T(), *taskInfo.Error)
-	}
-
-	assert.Equal(s.T(), config.TaskStatusCompleted, taskInfo.Status)
 }


### PR DESCRIPTION


## Summary
Add lookup for orphaned distributions
To work with delete-snapshots task
## Testing steps

start new clean backend without any repos, i.e. `make compose-clean`

Automated
```
go test ./pkg/tasks/ -run TestDeleteRepositoryVersionCleansUntrackedBlockingDistributions -v
go test ./test/integration/ -run TestDeleteSnapshotCleansUntrackedBlockingDistribution -v (with local compose stack)
```

Manual (local)

Setup

make compose-up and make run
`Org header: HDR="$(./scripts/header.sh $ORG_ID snapUser)"`

Repo with snapshotting enabled using https://fixtures.pulpproject.org/rpm-unsigned/
Simulate untracked Pulp distribution

Enable a temporary failure before GetRpmRepositoryVersion in snapshot_helper.go 

I added this to `pkg/tasks/snapshot_helper.go`:
```
	 if os.Getenv("SIMULATE_GET_RPM_REPOSITORY_VERSION_TIMEOUT") == "1" {
	 	return fmt.Errorf("simulated timeout fetching repository version: %w", context.DeadlineExceeded)
	 }
```
and then reran the backend with `SIMULATE_GET_RPM_REPOSITORY_VERSION_TIMEOUT=1` 

Create the repo and let the first snapshot task fail after creating Pulp resources but before writing the snapshot row.
Disable the simulation (temporary failure code) and restart the backend.
Change the repo URL (e.g. to rpm-with-sha-512) and trigger a second snapshot so a valid snapshot exists in the DB.

Exercise delete-snapshots cleanup

Confirm two snapshots exist:
`curl -s ".../repositories/$REPO_CONFIG_UUID/snapshots/" -H "$HDR" | jq '.meta.count'`
On the older snapshot, set a bogus distribution_href so delete skips the real Pulp distribution:
```
UPDATE snapshots
SET distribution_href = 'bogus-untracked-distribution-href'
WHERE uuid = '<older_snapshot_uuid>';
Delete the older snapshot via API (no trailing slash after $REPO_CONFIG_UUID):
curl -s -X DELETE \
  ".../repositories/$REPO_CONFIG_UUID/snapshots/<older_snapshot_uuid>" \
  -H "$HDR"
```
Expected results

DELETE returns 204
delete-snapshots task status is completed with no error
Snapshot count drops from 2 to 1
Worker logs include: Deleting untracked distribution blocking repository version deletion
Pulp distribution at the snapshot’s distribution_path and its repository version are removed despite the bogus DB distribution_href

Look for a line like this in the terminal where backend is running:
`1:19PM INF Deleting untracked distribution blocking repository version deletion base_path=`
