### PR TITLE
HMS-10835: Hardcode pulp content path

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -111,6 +111,7 @@ clients:
     client_key_path: compose_files/pulp/assets/certs/dev_certs/client.key
     ca_cert_path: compose_files/pulp/assets/certs/dev_certs/ca.crt
     content_origin: http://pulp.content:8081/
+    content_path_prefix: /pulp/content/
     proxy:
     database:
       host: localhost
@@ -143,7 +144,6 @@ clients:
     db: 1
     expiration:
       rbac: 1m
-      pulp_content_path: 1h
       subscription_check: 1h
       roadmap: 24h
   feature_service:

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -17,9 +17,6 @@ type Cache interface {
 	GetAccessList(ctx context.Context) (rbac.AccessList, error)
 	SetAccessList(ctx context.Context, accessList rbac.AccessList) error
 
-	GetPulpContentPath(ctx context.Context) (string, error)
-	SetPulpContentPath(ctx context.Context, pulpContentPath string) error
-
 	GetSubscriptionCheck(ctx context.Context) (*api.SubscriptionCheckResponse, error)
 	SetSubscriptionCheck(ctx context.Context, response api.SubscriptionCheckResponse) error
 

--- a/pkg/cache/cache_mock.go
+++ b/pkg/cache/cache_mock.go
@@ -163,66 +163,6 @@ func (_c *MockCache_GetFeatureStatus_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
-// GetPulpContentPath provides a mock function for the type MockCache
-func (_mock *MockCache) GetPulpContentPath(ctx context.Context) (string, error) {
-	ret := _mock.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetPulpContentPath")
-	}
-
-	var r0 string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return returnFunc(ctx)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = returnFunc(ctx)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockCache_GetPulpContentPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPulpContentPath'
-type MockCache_GetPulpContentPath_Call struct {
-	*mock.Call
-}
-
-// GetPulpContentPath is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockCache_Expecter) GetPulpContentPath(ctx interface{}) *MockCache_GetPulpContentPath_Call {
-	return &MockCache_GetPulpContentPath_Call{Call: _e.mock.On("GetPulpContentPath", ctx)}
-}
-
-func (_c *MockCache_GetPulpContentPath_Call) Run(run func(ctx context.Context)) *MockCache_GetPulpContentPath_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockCache_GetPulpContentPath_Call) Return(s string, err error) *MockCache_GetPulpContentPath_Call {
-	_c.Call.Return(s, err)
-	return _c
-}
-
-func (_c *MockCache_GetPulpContentPath_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *MockCache_GetPulpContentPath_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetRoadmapAppstreams provides a mock function for the type MockCache
 func (_mock *MockCache) GetRoadmapAppstreams(ctx context.Context) ([]byte, error) {
 	ret := _mock.Called(ctx)
@@ -519,63 +459,6 @@ func (_c *MockCache_SetFeatureStatus_Call) Return(err error) *MockCache_SetFeatu
 }
 
 func (_c *MockCache_SetFeatureStatus_Call) RunAndReturn(run func(ctx context.Context, response api.FeatureStatus) error) *MockCache_SetFeatureStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetPulpContentPath provides a mock function for the type MockCache
-func (_mock *MockCache) SetPulpContentPath(ctx context.Context, pulpContentPath string) error {
-	ret := _mock.Called(ctx, pulpContentPath)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetPulpContentPath")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, pulpContentPath)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockCache_SetPulpContentPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPulpContentPath'
-type MockCache_SetPulpContentPath_Call struct {
-	*mock.Call
-}
-
-// SetPulpContentPath is a helper method to define mock.On call
-//   - ctx context.Context
-//   - pulpContentPath string
-func (_e *MockCache_Expecter) SetPulpContentPath(ctx interface{}, pulpContentPath interface{}) *MockCache_SetPulpContentPath_Call {
-	return &MockCache_SetPulpContentPath_Call{Call: _e.mock.On("SetPulpContentPath", ctx, pulpContentPath)}
-}
-
-func (_c *MockCache_SetPulpContentPath_Call) Run(run func(ctx context.Context, pulpContentPath string)) *MockCache_SetPulpContentPath_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockCache_SetPulpContentPath_Call) Return(err error) *MockCache_SetPulpContentPath_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockCache_SetPulpContentPath_Call) RunAndReturn(run func(ctx context.Context, pulpContentPath string) error) *MockCache_SetPulpContentPath_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -26,16 +26,6 @@ func (c *noOpCache) SetAccessList(ctx context.Context, accessList rbac.AccessLis
 	return nil
 }
 
-// GetPulpContentPath a NoOp version to fetch a cached content path
-func (c *noOpCache) GetPulpContentPath(ctx context.Context) (string, error) {
-	return "", ErrNotFound
-}
-
-// SetPulpContentPath a NoOp version to store a content path
-func (c *noOpCache) SetPulpContentPath(ctx context.Context, repoConfigFile string) error {
-	return nil
-}
-
 // GetSubscriptionCheck a NoOp version to fetch a cached subscription check
 func (c *noOpCache) GetSubscriptionCheck(ctx context.Context) (*api.SubscriptionCheckResponse, error) {
 	return nil, ErrNotFound

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -13,8 +13,6 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-const PulpContentPathKey = "central-pulp-content-dir"
-
 type redisCache struct {
 	client *redis.Client
 }
@@ -39,11 +37,6 @@ func authKey(ctx context.Context) string {
 		return fmt.Sprintf("authen:%v,%v", identity.Identity.ServiceAccount.Username, identity.Identity.OrgID)
 	}
 	return fmt.Sprintf("authen:%v,%v", identity.Identity.User.Username, identity.Identity.OrgID)
-}
-
-// pulpContentPathKey returns the key for PulpContentPath caching
-func pulpContentPathKey() string {
-	return PulpContentPathKey
 }
 
 func subscriptionCheckKey(ctx context.Context) string {
@@ -98,31 +91,6 @@ func (c *redisCache) SetAccessList(ctx context.Context, accessList rbac.AccessLi
 	} else {
 		return fmt.Errorf("unable to set user in cache: %w", errors.New("user not set in identity header"))
 	}
-	return nil
-}
-
-func (c *redisCache) GetPulpContentPath(ctx context.Context) (string, error) {
-	var contentPath string
-	key := pulpContentPathKey()
-	buf, err := c.get(ctx, key)
-	if err != nil {
-		return "", fmt.Errorf("redis get error: %w", err)
-	}
-
-	err = json.Unmarshal(buf, &contentPath)
-	if err != nil {
-		return "", fmt.Errorf("redis unmarshal error: %w", err)
-	}
-	return contentPath, nil
-}
-
-func (c *redisCache) SetPulpContentPath(ctx context.Context, contentPath string) error {
-	buf, err := json.Marshal(contentPath)
-	if err != nil {
-		return fmt.Errorf("unable to marshal for Redis cache: %w", err)
-	}
-
-	c.client.Set(ctx, pulpContentPathKey(), string(buf), config.Get().Clients.Redis.Expiration.PulpContentPath)
 	return nil
 }
 

--- a/pkg/clients/pulp_client/interfaces.go
+++ b/pkg/clients/pulp_client/interfaces.go
@@ -18,7 +18,7 @@ type PulpGlobalClient interface {
 	GetTask(ctx context.Context, taskHref string) (zest.TaskResponse, error)
 	PollTask(ctx context.Context, taskHref string) (*zest.TaskResponse, error)
 	CancelTask(ctx context.Context, taskHref string) (zest.TaskResponse, error)
-	GetContentPath(ctx context.Context) (string, error)
+	GetContentPath() (string, error)
 
 	// Livez
 	Livez(ctx context.Context) error
@@ -44,7 +44,7 @@ type PulpClient interface {
 	GetTask(ctx context.Context, taskHref string) (zest.TaskResponse, error)
 	PollTask(ctx context.Context, taskHref string) (*zest.TaskResponse, error)
 	CancelTask(ctx context.Context, taskHref string) (zest.TaskResponse, error)
-	GetContentPath(ctx context.Context) (string, error)
+	GetContentPath() (string, error)
 
 	// Package
 	CreatePackage(ctx context.Context, artifactHref *string, uploadHref *string) (string, error)

--- a/pkg/clients/pulp_client/pulp_client_mock.go
+++ b/pkg/clients/pulp_client/pulp_client_mock.go
@@ -106,8 +106,8 @@ func (_c *MockPulpGlobalClient_CancelTask_Call) RunAndReturn(run func(ctx contex
 }
 
 // GetContentPath provides a mock function for the type MockPulpGlobalClient
-func (_mock *MockPulpGlobalClient) GetContentPath(ctx context.Context) (string, error) {
-	ret := _mock.Called(ctx)
+func (_mock *MockPulpGlobalClient) GetContentPath() (string, error) {
+	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetContentPath")
@@ -115,16 +115,16 @@ func (_mock *MockPulpGlobalClient) GetContentPath(ctx context.Context) (string, 
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
+		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -137,20 +137,13 @@ type MockPulpGlobalClient_GetContentPath_Call struct {
 }
 
 // GetContentPath is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockPulpGlobalClient_Expecter) GetContentPath(ctx interface{}) *MockPulpGlobalClient_GetContentPath_Call {
-	return &MockPulpGlobalClient_GetContentPath_Call{Call: _e.mock.On("GetContentPath", ctx)}
+func (_e *MockPulpGlobalClient_Expecter) GetContentPath() *MockPulpGlobalClient_GetContentPath_Call {
+	return &MockPulpGlobalClient_GetContentPath_Call{Call: _e.mock.On("GetContentPath")}
 }
 
-func (_c *MockPulpGlobalClient_GetContentPath_Call) Run(run func(ctx context.Context)) *MockPulpGlobalClient_GetContentPath_Call {
+func (_c *MockPulpGlobalClient_GetContentPath_Call) Run(run func()) *MockPulpGlobalClient_GetContentPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run()
 	})
 	return _c
 }
@@ -160,7 +153,7 @@ func (_c *MockPulpGlobalClient_GetContentPath_Call) Return(s string, err error) 
 	return _c
 }
 
-func (_c *MockPulpGlobalClient_GetContentPath_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *MockPulpGlobalClient_GetContentPath_Call {
+func (_c *MockPulpGlobalClient_GetContentPath_Call) RunAndReturn(run func() (string, error)) *MockPulpGlobalClient_GetContentPath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1916,8 +1909,8 @@ func (_c *MockPulpClient_FinishUpload_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // GetContentPath provides a mock function for the type MockPulpClient
-func (_mock *MockPulpClient) GetContentPath(ctx context.Context) (string, error) {
-	ret := _mock.Called(ctx)
+func (_mock *MockPulpClient) GetContentPath() (string, error) {
+	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetContentPath")
@@ -1925,16 +1918,16 @@ func (_mock *MockPulpClient) GetContentPath(ctx context.Context) (string, error)
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
+		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1947,20 +1940,13 @@ type MockPulpClient_GetContentPath_Call struct {
 }
 
 // GetContentPath is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockPulpClient_Expecter) GetContentPath(ctx interface{}) *MockPulpClient_GetContentPath_Call {
-	return &MockPulpClient_GetContentPath_Call{Call: _e.mock.On("GetContentPath", ctx)}
+func (_e *MockPulpClient_Expecter) GetContentPath() *MockPulpClient_GetContentPath_Call {
+	return &MockPulpClient_GetContentPath_Call{Call: _e.mock.On("GetContentPath")}
 }
 
-func (_c *MockPulpClient_GetContentPath_Call) Run(run func(ctx context.Context)) *MockPulpClient_GetContentPath_Call {
+func (_c *MockPulpClient_GetContentPath_Call) Run(run func()) *MockPulpClient_GetContentPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
+		run()
 	})
 	return _c
 }
@@ -1970,7 +1956,7 @@ func (_c *MockPulpClient_GetContentPath_Call) Return(s string, err error) *MockP
 	return _c
 }
 
-func (_c *MockPulpClient_GetContentPath_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *MockPulpClient_GetContentPath_Call {
+func (_c *MockPulpClient_GetContentPath_Call) RunAndReturn(run func() (string, error)) *MockPulpClient_GetContentPath_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/clients/pulp_client/status.go
+++ b/pkg/clients/pulp_client/status.go
@@ -28,19 +28,12 @@ func (r *pulpDaoImpl) Status(ctx context.Context) (*zest.StatusResponse, error) 
 	return status, nil
 }
 
-func (r *pulpDaoImpl) GetContentPath(ctx context.Context) (string, error) {
-	resp, err := r.Status(ctx)
+func (r *pulpDaoImpl) GetContentPath() (string, error) {
+	c := config.Get()
+	pulpContentPath, err := url.JoinPath(c.Clients.Pulp.ContentOrigin, c.Clients.Pulp.ContentPathPrefix)
 	if err != nil {
 		return "", err
 	}
-
-	contentPathPrefix := resp.ContentSettings.ContentPathPrefix
-
-	pulpContentPath, err := url.JoinPath(config.Get().Clients.Pulp.ContentOrigin, contentPathPrefix)
-	if err != nil {
-		return "", err
-	}
-
 	return pulpContentPath, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,7 +105,8 @@ type Pulp struct {
 	ClientCertPath    string       `mapstructure:"client_cert_path"`
 	ClientKeyPath     string       `mapstructure:"client_key_path"`
 	CACertPath        string       `mapstructure:"ca_cert_path"`
-	ContentOrigin     string       `mapstructure:"content_origin"` // hostname of the location of pulp content
+	ContentOrigin     string       `mapstructure:"content_origin"`      // hostname of the location of pulp content
+	ContentPathPrefix string       `mapstructure:"content_path_prefix"` // path prefix for pulp content (e.g. /api/pulp/content/)
 	Proxy             string       `mapstructure:"proxy"`
 }
 
@@ -219,7 +220,6 @@ type Redis struct {
 
 type Expiration struct {
 	Rbac              time.Duration `mapstructure:"rbac"`
-	PulpContentPath   time.Duration `mapstructure:"pulp_content_path"`
 	SubscriptionCheck time.Duration `mapstructure:"subscription_check"`
 	Roadmap           time.Duration `mapstructure:"roadmap"`
 }
@@ -361,6 +361,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.pulp.client_key_path", "")
 	v.SetDefault("clients.pulp.ca_cert_path", "")
 	v.SetDefault("clients.pulp.content_origin", "http://pulp.content:8081/")
+	v.SetDefault("clients.pulp.content_path_prefix", "/pulp/content/")
 	v.SetDefault("clients.pulp.proxy", "")
 
 	v.SetDefault("sentry.dsn", "")
@@ -378,7 +379,6 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.redis.password", "")
 	v.SetDefault("clients.redis.db", 0)
 	v.SetDefault("clients.redis.expiration.rbac", 1*time.Minute)
-	v.SetDefault("clients.redis.expiration.pulp_content_path", 1*time.Hour)
 	v.SetDefault("clients.redis.expiration.subscription_check", 1*time.Hour)
 	v.SetDefault("clients.redis.expiration.roadmap", 24*time.Hour)
 

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -593,7 +593,7 @@ func (r repositoryConfigDaoImpl) List(
 			return api.RepositoryCollectionResponse{}, totalRepos, err
 		}
 
-		contentPath, err = r.pulpClient.WithDomain(domain).GetContentPath(ctx)
+		contentPath, err = r.pulpClient.WithDomain(domain).GetContentPath()
 		if err != nil {
 			return api.RepositoryCollectionResponse{}, totalRepos, err
 		}
@@ -813,7 +813,7 @@ func (r repositoryConfigDaoImpl) Fetch(ctx context.Context, orgID string, uuid s
 		if err != nil {
 			return api.RepositoryResponse{}, err
 		}
-		contentPath, err = r.pulpClient.WithDomain(domainName).GetContentPath(ctx)
+		contentPath, err = r.pulpClient.WithDomain(domainName).GetContentPath()
 		if err != nil {
 			return api.RepositoryResponse{}, err
 		}

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -3579,7 +3579,7 @@ func (suite *RepositoryConfigSuite) TestRefreshCommunityRepo() {
 
 func (suite *RepositoryConfigSuite) mockPulpForListOrFetch(times int) {
 	if config.Get().Features.Snapshots.Enabled {
-		suite.mockPulpClient.WithDomainMock().On("GetContentPath", context.Background()).Return(testContentPath, nil).Times(times)
+		suite.mockPulpClient.WithDomainMock().On("GetContentPath").Return(testContentPath, nil).Times(times)
 	}
 }
 

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -111,7 +111,7 @@ func (sDao *snapshotDaoImpl) List(
 		return api.SnapshotCollectionResponse{Data: []api.SnapshotResponse{}}, totalSnaps, nil
 	}
 
-	pulpContentPath, err := sDao.pulpClient.GetContentPath(ctx)
+	pulpContentPath, err := sDao.pulpClient.GetContentPath()
 	if err != nil {
 		return api.SnapshotCollectionResponse{}, 0, err
 	}
@@ -130,7 +130,7 @@ func (sDao *snapshotDaoImpl) ListByTemplate(
 ) (api.SnapshotCollectionResponse, int64, error) {
 	var snaps []api.SnapshotResponse
 	var totalSnaps int64
-	pulpContentPath, err := sDao.pulpClient.GetContentPath(ctx)
+	pulpContentPath, err := sDao.pulpClient.GetContentPath()
 	if err != nil {
 		return api.SnapshotCollectionResponse{}, 0, err
 	}
@@ -256,7 +256,7 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(ctx context.Context,
 	}
 
 	pc := sDao.pulpClient
-	contentPath, err := pc.GetContentPath(ctx)
+	contentPath, err := pc.GetContentPath()
 	if err != nil {
 		return "", err
 	}
@@ -530,7 +530,7 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Conte
 		return api.ListSnapshotByDateResponse{}, err
 	}
 
-	pulpContentPath, err := sDao.pulpClient.GetContentPath(ctx)
+	pulpContentPath, err := sDao.pulpClient.GetContentPath()
 	if err != nil {
 		return api.ListSnapshotByDateResponse{}, err
 	}

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/utils"
 	"github.com/content-services/tang/pkg/tangy"
 	"github.com/content-services/yummy/pkg/yum"
-	zest "github.com/content-services/zest/release/v2026"
 	uuid2 "github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,14 +35,7 @@ func TestSnapshotsSuite(t *testing.T) {
 	suite.Run(t, &r)
 }
 
-var testPulpStatusResponse = zest.StatusResponse{
-	ContentSettings: zest.ContentSettingsResponse{
-		ContentOrigin:     *zest.NewNullableString(utils.Ptr("http://pulp-content")),
-		ContentPathPrefix: "/pulp/content",
-	},
-}
-
-var testContentPath = *testPulpStatusResponse.ContentSettings.ContentOrigin.Get() + testPulpStatusResponse.ContentSettings.ContentPathPrefix
+var testContentPath = "http://pulp-content/pulp/content"
 
 func (s *SnapshotsSuite) createSnapshotAtSpecifiedTime(rConfig models.RepositoryConfiguration, CreatedAt time.Time) models.Snapshot {
 	t := s.T()
@@ -104,9 +96,9 @@ func (s *SnapshotsSuite) TestCreateAndList() {
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient, fsClient: mockFsClient}
 
 	if config.Get().Features.Snapshots.Enabled {
-		mockPulpClient.WithDomainMock().On("GetContentPath", ctx).Return(testContentPath, nil)
+		mockPulpClient.WithDomainMock().On("GetContentPath").Return(testContentPath, nil)
 	} else {
-		mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil)
+		mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 	}
 
 	repoDaoImpl := repositoryConfigDaoImpl{db: tx, yumRepo: &yum.MockYumRepository{}, pulpClient: mockPulpClient, fsClient: mockFsClient}
@@ -154,16 +146,15 @@ func (s *SnapshotsSuite) TestCreateAndList() {
 func (s *SnapshotsSuite) TestCreateAndListRedHatRepo() {
 	t := s.T()
 	tx := s.tx
-	ctx := context.Background()
 
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	mockFsClient := feature_service_client.NewMockFeatureServiceClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient, fsClient: mockFsClient}
 
 	if config.Get().Features.Snapshots.Enabled {
-		mockPulpClient.WithDomainMock().On("GetContentPath", ctx).Return(testContentPath, nil)
+		mockPulpClient.WithDomainMock().On("GetContentPath").Return(testContentPath, nil)
 	} else {
-		mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil)
+		mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 	}
 
 	repoDao := repositoryConfigDaoImpl{db: tx, yumRepo: &yum.MockYumRepository{}, pulpClient: mockPulpClient, fsClient: mockFsClient}
@@ -258,7 +249,7 @@ func (s *SnapshotsSuite) TestListPageLimit() {
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDaoImpl := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
 
-	mockPulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 
 	rConfig := createRepository(t, tx, "", false)
 	pageData := api.PaginationData{
@@ -400,7 +391,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
-	mockPulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 
 	repoConfig := createRepository(t, tx, "", false)
 	baseTime := time.Now()
@@ -489,7 +480,7 @@ func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepositoryMulti() {
 
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
-	mockPulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 
 	repoConfig := createRepository(t, tx, "", false)
 	repoConfig2 := createRepository(t, tx, "", false)
@@ -563,7 +554,7 @@ func (s *SnapshotsSuite) TestListByTemplate() {
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
 
-	mockPulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 
 	repoConfig := createRepository(t, tx, "Last", false)
 	repoConfig2 := createRepository(t, tx, "First", false)
@@ -623,7 +614,7 @@ func (s *SnapshotsSuite) TestListByTemplateWithPagination() {
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
 
-	mockPulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
 
 	repoConfig := createRepository(t, tx, "Last", false)
 	repoConfig2 := createRepository(t, tx, "First", false)
@@ -686,7 +677,6 @@ func (s *SnapshotsSuite) TestFetchLatestSnapshotNotFound() {
 func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	t := s.T()
 	tx := s.tx
-	ctx := context.Background()
 
 	mockPulpClient := pulp_client.NewMockPulpClient(t)
 	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
@@ -711,7 +701,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	snapshot := createSnapshot(t, tx, repoConfig)
 
 	// Test happy scenario
-	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
 	repoConfigFile, err := sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID, false)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfig.Name)
@@ -720,7 +710,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	assert.Contains(t, repoConfigFile, "module_hotfixes=0")
 
 	// Test error from pulp call
-	mockPulpClient.On("GetContentPath", ctx).Return("", fmt.Errorf("some error")).Once()
+	mockPulpClient.On("GetContentPath").Return("", fmt.Errorf("some error")).Once()
 	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfig.OrgID, snapshot.UUID, false)
 	assert.Error(t, err)
 	assert.Empty(t, repoConfigFile)
@@ -738,7 +728,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 	err = tx.Updates(&snapshot).Error
 	assert.NoError(t, err)
 
-	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
 	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), repoConfigRh.OrgID, snapshot.UUID, false)
 	assert.NoError(t, err)
 	assert.Contains(t, repoConfigFile, repoConfigRh.Name)
@@ -748,7 +738,6 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFile() {
 func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	t := s.T()
 	tx := s.tx
-	ctx := context.Background()
 
 	mockPulpClient := pulp_client.MockPulpClient{}
 	mockFsClient := feature_service_client.MockFeatureServiceClient{}
@@ -757,7 +746,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	snapshot := createSnapshot(t, tx, repoConfig)
 
 	if config.Get().Features.Snapshots.Enabled {
-		mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Times(3)
+		mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Times(3)
 	}
 	mockFsClient.Mock.On("GetEntitledFeatures", context.Background()).Return([]string{}, nil)
 
@@ -774,7 +763,7 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFileNotFound() {
 	assert.Empty(t, repoConfigFile)
 
 	//  Test bad org ID
-	mockPulpClient.On("GetContentPath", ctx).Return(testContentPath, nil).Once()
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
 	repoConfigFile, err = sDao.GetRepositoryConfigurationFile(context.Background(), "bad orgID", snapshot.UUID, false)
 	assert.Error(t, err)
 	if err != nil {

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -227,7 +227,7 @@ func (t templateDaoImpl) Fetch(ctx context.Context, orgID string, uuid string, i
 	pulpContentPath := ""
 	if config.Get().Features.Snapshots.Enabled {
 		var err error
-		pulpContentPath, err = t.pulpClient.GetContentPath(ctx)
+		pulpContentPath, err = t.pulpClient.GetContentPath()
 		if err != nil {
 			return api.TemplateResponse{}, err
 		}
@@ -365,7 +365,7 @@ func (t templateDaoImpl) List(ctx context.Context, orgID string, includeSoftDel 
 	pulpContentPath := ""
 	if config.Get().Features.Snapshots.Enabled {
 		var err error
-		pulpContentPath, err = t.pulpClient.GetContentPath(ctx)
+		pulpContentPath, err = t.pulpClient.GetContentPath()
 		if err != nil {
 			return api.TemplateCollectionResponse{}, 0, err
 		}
@@ -670,7 +670,7 @@ func (t templateDaoImpl) GetRepositoryConfigurationFile(ctx context.Context, org
 	}
 
 	pc := t.pulpClient
-	contentPath, err := pc.GetContentPath(ctx)
+	contentPath, err := pc.GetContentPath()
 	if err != nil {
 		return "", err
 	}
@@ -732,7 +732,7 @@ func (t templateDaoImpl) InternalOnlyGetTemplatesForRepoConfig(ctx context.Conte
 	pulpContentPath := ""
 	if config.Get().Features.Snapshots.Enabled {
 		var err error
-		pulpContentPath, err = t.pulpClient.GetContentPath(ctx)
+		pulpContentPath, err = t.pulpClient.GetContentPath()
 		if err != nil {
 			return nil, err
 		}
@@ -759,7 +759,7 @@ func (t templateDaoImpl) InternalOnlyGetTemplatesForSnapshots(ctx context.Contex
 	pulpContentPath := ""
 	if config.Get().Features.Snapshots.Enabled {
 		var err error
-		pulpContentPath, err = t.pulpClient.GetContentPath(ctx)
+		pulpContentPath, err = t.pulpClient.GetContentPath()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -42,7 +42,7 @@ func (s *TemplateSuite) templateDao() templateDaoImpl {
 func (s *TemplateSuite) SetupTest() {
 	s.DaoSuite.SetupTest()
 	s.pulpClient = &pulp_client.MockPulpClient{}
-	s.pulpClient.On("GetContentPath", context.Background()).Return(testContentPath, nil).Maybe()
+	s.pulpClient.On("GetContentPath").Return(testContentPath, nil).Maybe()
 }
 func (s *TemplateSuite) TestCreate() {
 	templateDao := s.templateDao()

--- a/pkg/tasks/update_repository.go
+++ b/pkg/tasks/update_repository.go
@@ -113,7 +113,7 @@ func (ur *UpdateRepository) UpdateContentOverrides() error {
 		if err != nil {
 			return fmt.Errorf("could not list content for template & repo config %w", err)
 		}
-		path, err := ur.pulpClient.GetContentPath(ur.ctx)
+		path, err := ur.pulpClient.GetContentPath()
 		if err != nil {
 			return err
 		}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -362,7 +362,7 @@ func getRHRepoContentPath(rawURL string) (string, error) {
 }
 
 func (t *UpdateTemplateContent) RunEnvironmentCreate() (*caliri.EnvironmentDTO, error) {
-	rhContentPath, err := t.pulpClient.GetContentPath(t.ctx)
+	rhContentPath, err := t.pulpClient.GetContentPath()
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func (t *UpdateTemplateContent) RunCandlepin(env *caliri.EnvironmentDTO) error {
 		}
 	}
 
-	rhContentPath, err := t.pulpClient.GetContentPath(t.ctx)
+	rhContentPath, err := t.pulpClient.GetContentPath()
 	if err != nil {
 		return err
 	}

--- a/test/integration/delete_test.go
+++ b/test/integration/delete_test.go
@@ -209,7 +209,7 @@ func (s *DeleteTest) TestDeleteSnapshot() {
 	assert.NoError(t, err)
 	assert.Len(t, rpms, 7)
 
-	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath(s.ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath()
 	assert.NoError(s.T(), err)
 	rpmPath := fmt.Sprintf("%v%v/%v/latest/Packages/l", host, domain, repo.UUID)
 	err = s.getRequest(rpmPath, identity.Identity{OrgID: repo.OrgID, Internal: identity.Internal{OrgID: repo.OrgID}}, 404)
@@ -341,7 +341,7 @@ func (s *DeleteTest) TestDeleteRedHatSnapshot() {
 	tempResp, err := s.dao.Template.Create(s.ctx, reqTemplate)
 	assert.NoError(t, err)
 	s.updateTemplateContentAndWait(config.RedHatOrg, tempResp.UUID, []string{repo.UUID})
-	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath(s.ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath()
 	assert.NoError(s.T(), err)
 
 	olderSnap := repoSnaps.Data[1].UUID
@@ -481,7 +481,7 @@ func (s *DeleteTest) TestDeleteCommunitySnapshot() {
 	tempResp, err := s.dao.Template.Create(s.ctx, reqTemplate)
 	assert.NoError(t, err)
 	s.updateTemplateContentAndWait(orgID, tempResp.UUID, []string{repo.UUID})
-	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath(s.ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domain).GetContentPath()
 	assert.NoError(s.T(), err)
 
 	olderSnap := repoSnaps.Data[1].UUID

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -398,7 +398,7 @@ func (s *SnapshotSuite) createTemplate(cpClient candlepin_client.CandlepinClient
 	tempResp, err := s.dao.Template.Create(ctx, reqTemplate)
 	assert.NoError(s.T(), err)
 
-	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	distPath1 := fmt.Sprintf("%v%v/templates/%v/%v/repodata/repomd.xml", host, domainName, tempResp.UUID, repo.UUID)

--- a/test/integration/update_latest_snapshot_test.go
+++ b/test/integration/update_latest_snapshot_test.go
@@ -81,7 +81,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshot() {
 	assert.NoError(s.T(), err)
 	s.updateTemplateContentAndWait(orgID, tempResp1.UUID, []string{repo.UUID})
 
-	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	// Verify the correct snapshot content is being served by the template
@@ -149,7 +149,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshotForRedHatRepo() {
 	taskClient := client.NewTaskClient(&s.queue)
 	require.NoError(s.T(), err)
 
-	host, err := pulp_client.GetPulpClientWithDomain(config.RedHatDomainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(config.RedHatDomainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	// Create template with use latest
@@ -231,7 +231,7 @@ func (s *UpdateLatestSnapshotSuite) TestUpdateLatestSnapshotForCommunityRepo() {
 	taskClient := client.NewTaskClient(&s.queue)
 	require.NoError(s.T(), err)
 
-	host, err := pulp_client.GetPulpClientWithDomain(config.CommunityDomainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(config.CommunityDomainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	// Create template with use latest

--- a/test/integration/update_template_content_test.go
+++ b/test/integration/update_template_content_test.go
@@ -63,7 +63,7 @@ func (s *UpdateTemplateContentSuite) TestUseLatest() {
 	domainName, err := s.dao.Domain.FetchOrCreateDomain(ctx, orgID)
 	assert.NoError(s.T(), err)
 
-	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	repo := s.createAndSyncRepository(orgID, "https://content-services.github.io/fixtures/yum/comps-modules/v1/")
@@ -137,10 +137,10 @@ func (s *UpdateTemplateContentSuite) TestCreateCandlepinContent() {
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), tempResp.RHSMEnvironmentCreated)
 
-	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath(ctx)
+	host, err := pulp_client.GetPulpClientWithDomain(domainName).GetContentPath()
 	require.NoError(s.T(), err)
 
-	communityHost, err := pulp_client.GetPulpClientWithDomain(communityDomainName).GetContentPath(ctx)
+	communityHost, err := pulp_client.GetPulpClientWithDomain(communityDomainName).GetContentPath()
 	require.NoError(s.T(), err)
 
 	distPath1 := fmt.Sprintf("%v%s/templates/%v/%v", host, domainName, tempResp.UUID, repo1.UUID)


### PR DESCRIPTION
## Summary
The pulp content path should never change. This makes is configurable, but hardcodes it with the expected default.

## Testing steps
1. Integration tests are probably enough
2. You could also create a snapshot and then make sure the content URL is correct
