### PR TITLE
Build: disable sast coverity check

### DIFF
--- a/.tekton/content-sources-backend-pull-request.yaml
+++ b/.tekton/content-sources-backend-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: path-context
     value: .
   - name: skip-sast-coverity-check
-    value: "false"
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/content-sources-backend-push.yaml
+++ b/.tekton/content-sources-backend-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: path-context
     value: .
   - name: skip-sast-coverity-check
-    value: "false"
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:


### PR DESCRIPTION
This PR disables sast coverity check as it takes about 28m to run.
We will need to investigate how to configure it later to run faster and not block the pipeline.