### PR TITLE
HMS-9951: skip rbac for patchman on template advisory fetch

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -66,6 +66,7 @@ options:
   snapshot_retain_days_limit: 365
   feature_filter: ["RHEL-OS-x86_64"]
   entitle_all: true
+  internal_user: "internal-user"
 metrics:
   path: "/metrics"
   port: 9000

--- a/deployments/build/env-variables.yaml
+++ b/deployments/build/env-variables.yaml
@@ -195,6 +195,8 @@ env:
         optional: true
   - name: EPEL_ORG_ID_SKIP
     value: ${EPEL_ORG_ID_SKIP}
+  - name: OPTIONS_INTERNAL_USER
+    value: ${OPTIONS_INTERNAL_USER}
 
 # Only for transform-pulp-logs and hotfix-transform-pulp-logs-fix (reference floorist-bucket secret).
 env_transform_pulp_logs:
@@ -393,3 +395,5 @@ parameters:
     value: 'false'
   - name: EPEL_ORG_ID_SKIP
     description: comma separated list of org ids to skip when turning snapshotting off
+  - name: OPTIONS_INTERNAL_USER
+    value: ''

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -281,6 +281,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
             resources:
               limits:
@@ -534,6 +536,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
             resources:
               limits:
@@ -755,6 +759,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: retry-failed-tasks
           podSpec:
@@ -964,6 +970,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: process-repos
           # https://crontab.guru/
@@ -1177,6 +1185,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: cleanup
           # https://crontab.guru/
@@ -1392,6 +1402,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: pulp-orphan-cleanup
           # https://crontab.guru/
@@ -1605,6 +1617,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: transform-pulp-logs
           schedule: "0 1 * * *"
@@ -1815,6 +1829,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
               - name: CLIENTS_PULP_LOG_PARSER_S3_NAME
                 valueFrom:
                   secretKeyRef:
@@ -2048,6 +2064,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: hotfix-transform-pulp-logs-fix
           suspend: ${{SUSPEND_TRANSFORM_PULP_LOGS}}
@@ -2259,6 +2277,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
               - name: CLIENTS_PULP_LOG_PARSER_S3_NAME
                 valueFrom:
                   secretKeyRef:
@@ -2487,6 +2507,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: disable-snapshot-for-epel-repos
           podSpec:
@@ -2694,6 +2716,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: delete-invalid-redhat-repos
           podSpec:
@@ -2901,6 +2925,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: set-domain-label
           podSpec:
@@ -3108,6 +3134,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: set-detected-os-versions
           podSpec:
@@ -3315,6 +3343,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: move-templates-to-shared-epel
           podSpec:
@@ -3522,6 +3552,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
         - name: remove-custom-epel-repos
           podSpec:
@@ -3729,6 +3761,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
         - name: cancel-tasks
           podSpec:
             securityContext:
@@ -3936,6 +3970,8 @@ objects:
                     optional: true
               - name: EPEL_ORG_ID_SKIP
                 value: ${EPEL_ORG_ID_SKIP}
+              - name: OPTIONS_INTERNAL_USER
+                value: ${OPTIONS_INTERNAL_USER}
 
       database:
         name: content-sources
@@ -4179,3 +4215,5 @@ parameters:
     value: 'false'
   - name: EPEL_ORG_ID_SKIP
     description: comma separated list of org ids to skip when turning snapshotting off
+  - name: OPTIONS_INTERNAL_USER
+    value: ''

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,6 +244,7 @@ type Options struct {
 	SnapshotRetainDaysLimit int      `mapstructure:"snapshot_retain_days_limit"`
 	FeatureFilter           []string `mapstructure:"feature_filter"` // Used to control which repos are imported based on feature name
 	EntitleAll              bool     `mapstructure:"entitle_all"`    // Used in ephemeral to allow access to all layered repos
+	InternalUser            string   `mapstructure:"internal_user"`
 }
 
 type Metrics struct {
@@ -316,6 +317,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("options.feature_filter", featureFilter)
 	v.SetDefault("options.external_url", "http://pulp.content:8000")
 	v.SetDefault("options.snapshot_retain_days_limit", 365)
+	v.SetDefault("options.internal_user", "")
 	v.SetDefault("logging.level", "info")
 	v.SetDefault("logging.metrics_level", "error")
 	v.SetDefault("logging.db_level", "")

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -54,6 +54,12 @@ func SkipRbac(c echo.Context, p string) bool {
 	if utils.Contains(skipped, p) && xrhid.Identity.Type == "System" {
 		return true
 	}
+	if p == "/templates/:uuid/advisories/ids" &&
+		xrhid.Identity.User != nil &&
+		xrhid.Identity.User.Username == config.Get().Options.InternalUser &&
+		c.Request().Method == http.MethodGet {
+		return true
+	}
 	return false
 }
 

--- a/pkg/middleware/enforce_identity_test.go
+++ b/pkg/middleware/enforce_identity_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -202,4 +203,57 @@ func TestEnforceOrgId(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "\"It worked\"\n", string(body))
 	assert.Equal(t, http.StatusOK, res.Code)
+}
+
+func TestSkipRbacForInternalUser(t *testing.T) {
+	templateAdvisoriesPath := "/templates/:uuid/advisories/ids"
+	internalUsername := config.Get().Options.InternalUser
+
+	tests := []struct {
+		name     string
+		path     string
+		method   string
+		username string
+		expected bool
+	}{
+		{
+			name:     fmt.Sprintf("%s skips RBAC on %s", internalUsername, templateAdvisoriesPath),
+			path:     templateAdvisoriesPath,
+			method:   http.MethodGet,
+			username: internalUsername,
+			expected: true,
+		},
+		{
+			name:     fmt.Sprintf("other user does not skip RBAC on %s", templateAdvisoriesPath),
+			path:     templateAdvisoriesPath,
+			method:   http.MethodGet,
+			username: "test-user",
+			expected: false,
+		},
+		{
+			name:     fmt.Sprintf("%s does not skip RBAC on /templates/", internalUsername),
+			path:     "/templates/",
+			method:   http.MethodGet,
+			username: internalUsername,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/", nil)
+			xrhid := identity.XRHID{
+				Identity: identity.Identity{
+					OrgID:    "12345",
+					Type:     "User",
+					User:     &identity.User{Username: tt.username},
+					Internal: identity.Internal{OrgID: "12345"},
+				},
+			}
+			req = req.WithContext(identity.WithIdentity(req.Context(), xrhid))
+
+			c := echo.New().NewContext(req, httptest.NewRecorder())
+			assert.Equal(t, tt.expected, SkipRbac(c, tt.path))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds an RBAC skip condition for when an identity header with the internal username requests to fetch template advisory IDs. 

## Testing steps

1. Set a username in the config.yaml at `options.internal_user`
2. Enable the [mock rbac](https://github.com/content-services/content-sources-backend#start--stop-mock-for-rbac)
3. Create a template with your own user
4. Build an identity header with the username you set and the org ID of the template (you can use this [script](https://github.com/content-services/content-sources-backend/blob/main/scripts/header.sh))
5. Make a request to `/templates/:uuid/advisories/ids`. You should see the template's advisories. 
6. Change the username in the config.yaml or use a different username in the identity header and make another request. You should see 401 Unauthorized.