### PR TITLE
HMS-10950: Add fetch query for lightwell repos

### DIFF
--- a/pkg/api/repositories.go
+++ b/pkg/api/repositories.go
@@ -194,7 +194,7 @@ func (r *RepositoryCollectionResponse) SetMetadata(meta ResponseMetadata, links 
 }
 
 func (r *RepositoryResponse) Introspectable() bool {
-	return r.Origin != config.OriginUpload
+	return r.Origin != config.OriginUpload && r.Origin != config.OriginLightwell
 }
 
 type BulkRemoveRpmsRequest struct {

--- a/pkg/dao/helpers.go
+++ b/pkg/dao/helpers.go
@@ -101,7 +101,7 @@ func isOwnedRepository(db *gorm.DB, orgID string, repositoryConfigUUID string) (
 	var repoConfigs []models.RepositoryConfiguration
 	var count int64
 	if err := db.
-		Where("org_id IN (?, ?, ?) AND uuid = ?", orgID, config.RedHatOrg, config.CommunityOrg, UuidifyString(repositoryConfigUUID)).
+		Where("org_id IN (?, ?, ?, ?) AND uuid = ?", orgID, config.RedHatOrg, config.CommunityOrg, config.LightwellOrg, UuidifyString(repositoryConfigUUID)).
 		Find(&repoConfigs).
 		Count(&count).
 		Error; err != nil {

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -125,6 +125,10 @@ func (r repositoryConfigDaoImpl) Create(ctx context.Context, newRepoReq api.Repo
 		return api.RepositoryResponse{}, errors.New("creating of Red Hat repositories is not permitted")
 	}
 
+	if *newRepoReq.OrgID == config.LightwellOrg {
+		return api.RepositoryResponse{}, errors.New("creating of Lightwell repositories is not permitted")
+	}
+
 	if *newRepoReq.OrgID == config.CommunityOrg {
 		return api.RepositoryResponse{}, errors.New(errMsgCustomEpelRepoCreationNotPermitted)
 	}
@@ -839,7 +843,7 @@ func (r repositoryConfigDaoImpl) fetchRepoConfig(ctx context.Context, orgID stri
 	orgIdsToCheck := []string{orgID}
 
 	if includeSharedRepos {
-		orgIdsToCheck = append(orgIdsToCheck, config.RedHatOrg, config.CommunityOrg)
+		orgIdsToCheck = append(orgIdsToCheck, config.RedHatOrg, config.CommunityOrg, config.LightwellOrg)
 	}
 
 	result := r.db.WithContext(ctx).

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -254,7 +254,7 @@ func (rh *RepositoryHandler) fetch(c echo.Context) error {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}
 
-	if response.OrgID == config.RedHatOrg && !utils.AnyFeatureMatch(response.FeatureName, features) {
+	if (response.OrgID == config.RedHatOrg || response.OrgID == config.LightwellOrg) && !utils.AnyFeatureMatch(response.FeatureName, features) {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", "Account does not have access to this repository")
 	}
 
@@ -481,6 +481,9 @@ func (rh *RepositoryHandler) createSnapshot(c echo.Context) error {
 	if response.Origin == config.OriginUpload {
 		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot snapshot this repository", "Upload repositories cannot be snapshotted.  To create a new snapshot, upload more content")
 	}
+	if response.Origin == config.OriginLightwell {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot snapshot this repository", "Lightwell repositories cannot be snapshotted")
+	}
 
 	taskIDs, err := rh.DaoRegistry.TaskInfo.FetchActiveTasks(c.Request().Context(), orgID, response.RepositoryUUID, config.RepositorySnapshotTask)
 	if err != nil {
@@ -534,6 +537,9 @@ func (rh *RepositoryHandler) introspect(c echo.Context) error {
 
 	if response.Origin == config.OriginUpload {
 		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot introspect this repository", "upload repositories cannot be introspected")
+	}
+	if response.Origin == config.OriginLightwell {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Cannot introspect this repository", "lightwell repositories cannot be introspected")
 	}
 
 	repo, err := rh.DaoRegistry.Repository.FetchForUrl(c.Request().Context(), response.URL, &response.Origin)

--- a/pkg/middleware/enforce_identity.go
+++ b/pkg/middleware/enforce_identity.go
@@ -94,6 +94,10 @@ func EnforceOrgId(next echo.HandlerFunc) echo.HandlerFunc {
 			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -2")
 			c.Error(err)
 			return nil
+		} else if xRHID.Identity.Internal.OrgID == config.LightwellOrg || xRHID.Identity.OrgID == config.LightwellOrg {
+			err := ce.NewErrorResponse(http.StatusForbidden, "Invalid org ID", "Org ID cannot be -3")
+			c.Error(err)
+			return nil
 		}
 
 		return next(c)


### PR DESCRIPTION
## Summary
- Add fetch query for lightwell repos
- Also prevents them from being created, snapshotted, and introspected.

## Testing steps
1. GET `/api/content-sources/v1/repositories/<uuid-of-lightwell-repo>`
2. Should see the repo
3. POST `/api/content-sources/v1/repositories/<uuid-of-lightwell-repo>/snapshot/`
4. Should see error
