### PR TITLE
HMS-10951: add python/validated repository

### DIFF
--- a/pkg/external_repos/lightwell_repos.json
+++ b/pkg/external_repos/lightwell_repos.json
@@ -10,5 +10,11 @@
     "type": "maven",
     "base_path": "java/validated",
     "feature_name": "lightwell-network"
+  },
+  {
+    "name": "lightwell/python/validated",
+    "type": "python",
+    "base_path": "python/validated",
+    "feature_name": "lightwell-network"
   }
 ]


### PR DESCRIPTION
## Summary
Adds the python/validated repository import

## Testing steps
1. Run `go run cmd/external-repos/main.go import`
2. List `/repostories?search=python`. You should see it.
