### PR TITLE
HMS-10958: Workaround maven lightwell repos without repository link

### DIFF
--- a/pkg/clients/pulp_client/interfaces.go
+++ b/pkg/clients/pulp_client/interfaces.go
@@ -99,4 +99,7 @@ type PulpClient interface {
 	UploadChunk(ctx context.Context, uploadHref string, contentRange string, file *os.File, sha256 string) (*zest.UploadResponse, int, error)
 	FinishUpload(ctx context.Context, uploadHref string, sha256 string) (*zest.AsyncOperationResponse, int, error)
 	DeleteUpload(ctx context.Context, uploadHref string) (int, error)
+
+	// Generic Repository
+	FindGenericRepositoryByName(ctx context.Context, name string) (*zest.RepositoryResponse, error)
 }

--- a/pkg/clients/pulp_client/pulp_client_mock.go
+++ b/pkg/clients/pulp_client/pulp_client_mock.go
@@ -1828,6 +1828,74 @@ func (_c *MockPulpClient_FindGenericDistributionByBasePath_Call) RunAndReturn(ru
 	return _c
 }
 
+// FindGenericRepositoryByName provides a mock function for the type MockPulpClient
+func (_mock *MockPulpClient) FindGenericRepositoryByName(ctx context.Context, name string) (*zest.RepositoryResponse, error) {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindGenericRepositoryByName")
+	}
+
+	var r0 *zest.RepositoryResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*zest.RepositoryResponse, error)); ok {
+		return returnFunc(ctx, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *zest.RepositoryResponse); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*zest.RepositoryResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPulpClient_FindGenericRepositoryByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindGenericRepositoryByName'
+type MockPulpClient_FindGenericRepositoryByName_Call struct {
+	*mock.Call
+}
+
+// FindGenericRepositoryByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *MockPulpClient_Expecter) FindGenericRepositoryByName(ctx interface{}, name interface{}) *MockPulpClient_FindGenericRepositoryByName_Call {
+	return &MockPulpClient_FindGenericRepositoryByName_Call{Call: _e.mock.On("FindGenericRepositoryByName", ctx, name)}
+}
+
+func (_c *MockPulpClient_FindGenericRepositoryByName_Call) Run(run func(ctx context.Context, name string)) *MockPulpClient_FindGenericRepositoryByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPulpClient_FindGenericRepositoryByName_Call) Return(repositoryResponse *zest.RepositoryResponse, err error) *MockPulpClient_FindGenericRepositoryByName_Call {
+	_c.Call.Return(repositoryResponse, err)
+	return _c
+}
+
+func (_c *MockPulpClient_FindGenericRepositoryByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*zest.RepositoryResponse, error)) *MockPulpClient_FindGenericRepositoryByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindRpmPublicationByVersion provides a mock function for the type MockPulpClient
 func (_mock *MockPulpClient) FindRpmPublicationByVersion(ctx context.Context, versionHref string) (*zest.RpmRpmPublicationResponse, error) {
 	ret := _mock.Called(ctx, versionHref)

--- a/pkg/clients/pulp_client/repositories.go
+++ b/pkg/clients/pulp_client/repositories.go
@@ -1,0 +1,29 @@
+package pulp_client
+
+import (
+	"context"
+
+	zest "github.com/content-services/zest/release/v2026"
+)
+
+// FindGenericRepositoryByName finds a repository of any type by name
+func (r *pulpDaoImpl) FindGenericRepositoryByName(ctx context.Context, name string) (*zest.RepositoryResponse, error) {
+	ctx, client, err := getZestClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, httpResp, err := client.RepositoriesAPI.RepositoriesList(ctx, r.domainName).Name(name).Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return nil, errorWithResponseBody("error finding generic repository", httpResp, err)
+	}
+
+	results := resp.GetResults()
+	if len(results) > 0 {
+		return &results[0], nil
+	} else {
+		return nil, nil
+	}
+}

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -85,6 +86,22 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution not found")
 	}
 	repositoryHref := dist.GetRepository()
+
+	// Warning HACK, we are looking up the distribution by base path, and then trying to find the repository from it above,
+	//   but some lightwell maven repos use a publication associated with the distribution (no repo link).  However there is no
+	//   publication api to pull the publication from. So we must rely on the name of the distribution being the same as the repository,
+	//   which for lightwell it will be. Pulp is changing this to not use publications, so this will be temporary, remove after 7/10/2026
+	if repositoryHref == "" {
+		name := dist.GetName()
+		repo, err := pulpClient.FindGenericRepositoryByName(c.Request().Context(), name)
+		if err != nil {
+			return ce.NewErrorResponse(http.StatusInternalServerError, "Error finding repository", err.Error())
+		}
+		if repo == nil || repo.PulpHref == nil {
+			return ce.NewErrorResponse(http.StatusNotFound, "Repository not found", fmt.Sprintf("Repository for UUID %v", uuid))
+		}
+		repositoryHref = *repo.PulpHref
+	}
 
 	// Call tang to get Maven packages
 	tangResp, err := ph.TangClient.MavenPackageList(c.Request().Context(), repositoryHref, tangy.PageOptions{


### PR DESCRIPTION
## Summary

This workarounds a maven repository issue with lightwell stage/prod issues, where by one maven repo has a distribution without a link to the reposiotry.  Instead it links to a publication.  pulp-maven provides no publication apis so it is a dead end, however for lightwell the repo name and distro name are the same, so we can 'abuse' that to lookup the right repository.  

## Testing steps

🙏🏻 