### PR TITLE
HMS-10960: add python support to list packages in lightwell

### DIFF
--- a/_playwright-tests/test-utils/src/client/apis/PackagesApi.ts
+++ b/_playwright-tests/test-utils/src/client/apis/PackagesApi.ts
@@ -71,7 +71,7 @@ export class PackagesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get packages for a Maven repository grouped by group_id and artifact_id. Returns empty results for non-Maven repositories.
+     * List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.
      * List Packages
      */
     async listPackagesRaw(requestParameters: ListPackagesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ApiPackageResponse>> {
@@ -82,7 +82,7 @@ export class PackagesApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get packages for a Maven repository grouped by group_id and artifact_id. Returns empty results for non-Maven repositories.
+     * List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.
      * List Packages
      */
     async listPackages(requestParameters: ListPackagesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ApiPackageResponse> {

--- a/api/docs.go
+++ b/api/docs.go
@@ -1695,7 +1695,7 @@ const docTemplate = `{
         },
         "/repositories/{uuid}/packages": {
             "get": {
-                "description": "Get packages for a Maven repository grouped by group_id and artifact_id. Returns empty results for non-Maven repositories.",
+                "description": "List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4444,7 +4444,7 @@
         },
         "/repositories/{uuid}/packages": {
             "get": {
-                "description": "Get packages for a Maven repository grouped by group_id and artifact_id. Returns empty results for non-Maven repositories.",
+                "description": "List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.",
                 "operationId": "listPackages",
                 "parameters": [
                     {

--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -13,8 +13,9 @@ const (
 )
 
 const (
-	ContentTypeRpm   = "rpm"
-	ContentTypeMaven = "maven"
+	ContentTypeRpm    = "rpm"
+	ContentTypeMaven  = "maven"
+	ContentTypePython = "python"
 )
 
 const (

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -13,6 +15,10 @@ import (
 	"github.com/content-services/tang/pkg/tangy"
 	"github.com/labstack/echo/v4"
 )
+
+var errDistributionNotFound = errors.New("repository distribution not found")
+
+var errRepositoryNotFound = errors.New("repository not found")
 
 type PackageHandler struct {
 	DaoRegistry dao.DaoRegistry
@@ -32,7 +38,7 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 // ListPackages godoc
 // @Summary      List Packages
 // @ID           listPackages
-// @Description  Get packages for a Maven repository grouped by group_id and artifact_id. Returns empty results for non-Maven repositories.
+// @Description  List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.
 // @Tags         packages
 // @Param        uuid path string true "Repository UUID"
 // @Param        offset query int false "Starting point for pagination. Default: 0"
@@ -48,15 +54,19 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 	uuid := c.Param("uuid")
 	// _, orgID := getAccountIdOrgId(c)
 	pageData := ParsePagination(c)
+	ctx := c.Request().Context()
 
-	// Fetch repository config to get content type and distribution URL
-	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(c.Request().Context(), config.LightwellOrg, uuid) // TODO, don't hardcode lightwell org
+	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid) // TODO, don't hardcode lightwell org
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
 	}
 
-	// Return empty results for non-Maven repositories
-	if repo.ContentType != config.ContentTypeMaven {
+	switch repo.ContentType {
+	case config.ContentTypeMaven:
+		return ph.listMavenPackages(c, ctx, repo, pageData)
+	case config.ContentTypePython:
+		return ph.listPythonPackages(c, ctx, repo, pageData)
+	default:
 		return c.JSON(http.StatusOK, api.PackageResponse{
 			Results: []api.PackageItem{},
 			Total:   0,
@@ -64,27 +74,65 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 			Offset:  pageData.Offset,
 		})
 	}
+}
 
-	// Check if repository has published distribution base path
+func (ph *PackageHandler) listMavenPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, pageData api.PaginationData) error {
 	if repo.PublishedDistBasePath == "" {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
 	}
 
-	// Get domain name for the organization
-	domainName, err := ph.DaoRegistry.Domain.FetchOrCreateDomain(c.Request().Context(), config.LightwellOrg)
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
 	if err != nil {
-		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching or creating domain", err.Error())
+		return ph.repositoryHrefErrorResponse(err)
 	}
 
-	// Get repository href from distribution base path
-	pulpClient := ph.PulpClient.WithDomain(domainName)
-	dist, err := pulpClient.FindGenericDistributionByBasePath(c.Request().Context(), repo.PublishedDistBasePath)
+	tangResp, err := ph.TangClient.MavenPackageList(ctx, repositoryHref, tangy.PageOptions{
+		Offset: pageData.Offset,
+		Limit:  pageData.Limit,
+	})
 	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error finding repository distribution", err.Error())
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving packages", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, mapMavenPackagesToAPI(tangResp))
+}
+
+func (ph *PackageHandler) listPythonPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, pageData api.PaginationData) error {
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.PythonPackageList(ctx, repositoryHref, tangy.PageOptions{
+		Offset: pageData.Offset,
+		Limit:  pageData.Limit,
+	})
+	if err != nil {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving packages", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, mapPythonPackagesToAPI(tangResp))
+}
+
+func (ph *PackageHandler) resolveRepositoryHref(ctx context.Context, orgID, basePath, repoUUID string) (string, error) {
+	domainName, err := ph.DaoRegistry.Domain.FetchOrCreateDomain(ctx, orgID)
+	if err != nil {
+		return "", err
+	}
+
+	pulpClient := ph.PulpClient.WithDomain(domainName)
+	dist, err := pulpClient.FindGenericDistributionByBasePath(ctx, basePath)
+	if err != nil {
+		return "", err
 	}
 	if dist == nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution not found")
+		return "", errDistributionNotFound
 	}
+
 	repositoryHref := dist.GetRepository()
 
 	// Warning HACK, we are looking up the distribution by base path, and then trying to find the repository from it above,
@@ -93,26 +141,34 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 	//   which for lightwell it will be. Pulp is changing this to not use publications, so this will be temporary, remove after 7/10/2026
 	if repositoryHref == "" {
 		name := dist.GetName()
-		repo, err := pulpClient.FindGenericRepositoryByName(c.Request().Context(), name)
+		repo, err := pulpClient.FindGenericRepositoryByName(ctx, name)
 		if err != nil {
-			return ce.NewErrorResponse(http.StatusInternalServerError, "Error finding repository", err.Error())
+			return "", err
 		}
 		if repo == nil || repo.PulpHref == nil {
-			return ce.NewErrorResponse(http.StatusNotFound, "Repository not found", fmt.Sprintf("Repository for UUID %v", uuid))
+			return "", fmt.Errorf("%w for UUID %v", errRepositoryNotFound, repoUUID)
 		}
 		repositoryHref = *repo.PulpHref
 	}
 
-	// Call tang to get Maven packages
-	tangResp, err := ph.TangClient.MavenPackageList(c.Request().Context(), repositoryHref, tangy.PageOptions{
-		Offset: pageData.Offset,
-		Limit:  pageData.Limit,
-	})
-	if err != nil {
-		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving packages", err.Error())
-	}
+	return repositoryHref, nil
+}
 
-	// Transform tang response to API response
+func (ph *PackageHandler) repositoryHrefErrorResponse(err error) error {
+	if errors.Is(err, errDistributionNotFound) {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution not found")
+	}
+	if errors.Is(err, errRepositoryNotFound) {
+		return ce.NewErrorResponse(http.StatusNotFound, "Repository not found", err.Error())
+	}
+	var daoError *ce.DaoError
+	if errors.As(err, &daoError) {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching or creating domain", err.Error())
+	}
+	return ce.NewErrorResponse(http.StatusInternalServerError, "Error finding repository distribution", err.Error())
+}
+
+func mapMavenPackagesToAPI(tangResp tangy.MavenPackageListResponse) api.PackageResponse {
 	results := make([]api.PackageItem, len(tangResp.Results))
 	for i, item := range tangResp.Results {
 		releases := make([]api.ReleaseInfo, len(item.LatestReleases))
@@ -132,10 +188,36 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, api.PackageResponse{
+	return api.PackageResponse{
 		Results: results,
 		Total:   tangResp.Total,
 		Limit:   tangResp.Limit,
 		Offset:  tangResp.Offset,
-	})
+	}
+}
+
+func mapPythonPackagesToAPI(tangResp tangy.PythonPackageListResponse) api.PackageResponse {
+	results := make([]api.PackageItem, len(tangResp.Results))
+	for i, item := range tangResp.Results {
+		releases := make([]api.ReleaseInfo, len(item.LatestVersions))
+		for j, ver := range item.LatestVersions {
+			releases[j] = api.ReleaseInfo{
+				Version:   ver.Version,
+				CreatedAt: ver.CreatedAt,
+			}
+		}
+
+		results[i] = api.PackageItem{
+			Name:           item.NameNormalized,
+			Versions:       item.Versions,
+			LatestReleases: releases,
+		}
+	}
+
+	return api.PackageResponse{
+		Results: results,
+		Total:   tangResp.Total,
+		Limit:   tangResp.Limit,
+		Offset:  tangResp.Offset,
+	}
 }

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -104,10 +104,8 @@ func (suite *PackagesSuite) TestListPackagesMavenSuccess() {
 		Offset: 0,
 	}
 
-	orgID := config.LightwellOrg
-
-	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
-	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
 	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
@@ -133,6 +131,106 @@ func (suite *PackagesSuite) TestListPackagesMavenSuccess() {
 	assert.Equal(t, 0, response.Offset)
 }
 
+func (suite *PackagesSuite) TestListPackagesPythonSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440005"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f5/"
+	domainName := "test-domain"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	tangResp := tangy.PythonPackageListResponse{
+		Results: []tangy.PythonPackageListItem{
+			{
+				Name:           "shelf-reader",
+				NameNormalized: "shelf-reader",
+				Versions:       []string{"0.1", "0.2"},
+				LatestVersions: []tangy.PythonVersionInfo{
+					{
+						Version:   "0.1",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+					{
+						Version:   "0.2",
+						CreatedAt: "2024-02-01T14:20:00Z",
+					},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  100,
+		Offset: 0,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PackageResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response.Results))
+	assert.Empty(t, response.Results[0].Group)
+	assert.Equal(t, "shelf-reader", response.Results[0].Name)
+	assert.Equal(t, 2, len(response.Results[0].Versions))
+	assert.Equal(t, 2, len(response.Results[0].LatestReleases))
+	assert.Equal(t, "0.1", response.Results[0].LatestReleases[0].Version)
+	assert.Equal(t, "2024-01-15T10:30:00Z", response.Results[0].LatestReleases[0].CreatedAt)
+	assert.Empty(t, response.Results[0].LatestReleases[0].Release)
+	assert.Equal(t, 1, response.Total)
+	assert.Equal(t, 100, response.Limit)
+	assert.Equal(t, 0, response.Offset)
+}
+
+func (suite *PackagesSuite) TestListPackagesPythonTangClientError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440006"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f5/"
+	domainName := "test-domain"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.PythonPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
 func (suite *PackagesSuite) TestListPackagesNonMavenReturnsEmpty() {
 	t := suite.T()
 	repoUUID := "550e8400-e29b-41d4-a716-446655440001"
@@ -141,9 +239,8 @@ func (suite *PackagesSuite) TestListPackagesNonMavenReturnsEmpty() {
 		UUID:        repoUUID,
 		ContentType: "rpm", // Non-Maven content type
 	}
-	orgID := config.LightwellOrg // test_handler.MockOrgId
 
-	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -172,8 +269,7 @@ func (suite *PackagesSuite) TestListPackagesMissingDistBasePath() {
 		PublishedDistBasePath: "", // Empty distribution base path
 	}
 
-	orgId := config.LightwellOrg // test_handler.MockOrgId
-	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgId, repoUUID).Return(repo, nil)
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/packages", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -193,8 +289,7 @@ func (suite *PackagesSuite) TestListPackagesRepositoryNotFound() {
 		Message:  "Repository not found",
 	}
 
-	orgId := config.LightwellOrg // test_handler.MockOrgId
-	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgId, repoUUID).Return(api.RepositoryResponse{}, &daoError)
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(api.RepositoryResponse{}, &daoError)
 
 	path := fmt.Sprintf("%s/repositories/%s/packages", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -221,10 +316,8 @@ func (suite *PackagesSuite) TestListPackagesTangClientError() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	orgId := config.LightwellOrg // test_handler.MockOrgId
-
-	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgId, repoUUID).Return(repo, nil)
-	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgId).Return(domainName, nil)
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
 	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.MavenPackageListResponse{}, fmt.Errorf("failed to fetch packages"))

--- a/test/integration/python_packages_test.go
+++ b/test/integration/python_packages_test.go
@@ -1,0 +1,301 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/db"
+	"github.com/content-services/content-sources-backend/pkg/handler"
+	"github.com/content-services/content-sources-backend/pkg/middleware"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	test_handler "github.com/content-services/content-sources-backend/pkg/test/handler"
+	zest "github.com/content-services/zest/release/v2026"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testPythonPackageName = "shelf-reader"
+	testPythonPackageURL  = "https://pypi.org/"
+)
+
+type PythonPackagesSuite struct {
+	Suite
+	ctx      context.Context
+	server   *http.Server
+	identity identity.XRHID
+	cancel   context.CancelFunc
+}
+
+func (s *PythonPackagesSuite) SetupTest() {
+	s.Suite.SetupTest()
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	config.Get().Features.Snapshots.Enabled = true
+
+	err := db.Connect()
+	require.NoError(s.T(), err)
+
+	router := echo.New()
+	router.HTTPErrorHandler = config.CustomHTTPErrorHandler
+	router.Use(middleware.WrapMiddlewareWithSkipper(identity.EnforceIdentity, middleware.SkipMiddleware))
+
+	handler.RegisterRoutes(s.ctx, router)
+
+	s.server = &http.Server{
+		Addr:              "127.0.0.1:8102",
+		Handler:           router,
+		IdleTimeout:       1 * time.Minute,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+
+	config.Get().Clients.Pulp.StorageType = "local"
+
+	err = config.ConfigureTang()
+	require.NoError(s.T(), err)
+}
+
+func (s *PythonPackagesSuite) TearDownTest() {
+	s.cancel()
+	err := s.server.Shutdown(context.Background())
+	if err != nil {
+		log.Error().Err(err).Msg("Could not shutdown server")
+	}
+	s.Suite.TearDownTest()
+}
+
+func (s *PythonPackagesSuite) serveRouter(req *http.Request) (int, []byte, error) {
+	rr := httptest.NewRecorder()
+	s.server.Handler.ServeHTTP(rr, req)
+
+	response := rr.Result()
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(s.T(), err)
+
+	return response.StatusCode, body, err
+}
+
+func (s *PythonPackagesSuite) getZestClient() (context.Context, *zest.APIClient, error) {
+	ctx2 := context.WithValue(s.ctx, zest.ContextServerIndex, 0)
+	httpClient, err := config.GetHTTPClient(&config.PulpCertUser{}, config.Get().Clients.Pulp.Username == "")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pulpConfig := zest.NewConfiguration()
+	pulpConfig.HTTPClient = &httpClient
+	pulpConfig.Servers = zest.ServerConfigurations{zest.ServerConfiguration{
+		URL: config.Get().Clients.Pulp.Server,
+	}}
+	client := zest.NewAPIClient(pulpConfig)
+
+	if config.Get().Clients.Pulp.Username != "" {
+		ctx2 = context.WithValue(ctx2, zest.ContextBasicAuth, zest.BasicAuth{
+			UserName: config.Get().Clients.Pulp.Username,
+			Password: config.Get().Clients.Pulp.Password,
+		})
+	}
+
+	return ctx2, client, nil
+}
+
+func TestPythonPackagesSuite(t *testing.T) {
+	suite.Run(t, new(PythonPackagesSuite))
+}
+
+func (s *PythonPackagesSuite) TestPythonPackagesAPI() {
+	orgId := fmt.Sprintf("PythonPackages-%v", rand.Int())
+
+	s.identity = test_handler.MockIdentity
+	s.identity.Identity.OrgID = orgId
+
+	t := s.T()
+
+	repo := s.createPythonRepository(config.LightwellOrg)
+	packages := s.listPackages(repo.UUID)
+
+	assert.NotNil(t, packages)
+	assert.GreaterOrEqual(t, packages.Total, 1)
+	require.NotEmpty(t, packages.Results)
+
+	var shelfReader *api.PackageItem
+	for i := range packages.Results {
+		if packages.Results[i].Name == testPythonPackageName {
+			shelfReader = &packages.Results[i]
+			break
+		}
+	}
+	require.NotNil(t, shelfReader, "expected shelf-reader package in results")
+	assert.Empty(t, shelfReader.Group)
+	assert.Contains(t, shelfReader.Versions, "0.1")
+	require.NotEmpty(t, shelfReader.LatestReleases)
+
+	foundVersion := false
+	for _, release := range shelfReader.LatestReleases {
+		if release.Version == "0.1" {
+			foundVersion = true
+			assert.NotEmpty(t, release.CreatedAt)
+			assert.Empty(t, release.Release)
+		}
+	}
+	assert.True(t, foundVersion)
+}
+
+func (s *PythonPackagesSuite) createPythonRepository(orgId string) api.RepositoryResponse {
+	t := s.T()
+
+	repo := models.Repository{
+		URL:         testPythonPackageURL,
+		Public:      false,
+		Origin:      config.OriginExternal,
+		ContentType: config.ContentTypePython,
+	}
+
+	res := db.DB.Where("url = ? AND content_type = ?", repo.URL, repo.ContentType).First(&repo)
+	if res.Error != nil {
+		res = db.DB.Create(&repo)
+		require.NoError(t, res.Error)
+	}
+
+	res = db.DB.Where("repository_uuid = ?", repo.UUID).Delete(&models.RepositoryConfiguration{})
+	assert.NoError(t, res.Error)
+
+	repoConfig := models.RepositoryConfiguration{
+		Name:           fmt.Sprintf("python-repo-%v", rand.Int()),
+		OrgID:          orgId,
+		AccountID:      orgId,
+		RepositoryUUID: repo.UUID,
+		Snapshot:       false,
+	}
+	res = db.DB.Create(&repoConfig)
+	require.NoError(t, res.Error)
+
+	domainName, err := s.dao.Domain.FetchOrCreateDomain(s.ctx, orgId)
+	require.NoError(t, err)
+
+	pulpClient := pulp_client.GetPulpClientWithDomain(domainName)
+
+	_, err = pulpClient.LookupOrCreateDomain(s.ctx, domainName)
+	require.NoError(t, err)
+
+	ctx, zestClient, err := s.getZestClient()
+	require.NoError(t, err)
+
+	pythonRemote := zest.NewPythonPythonRemote(fmt.Sprintf("python-remote-%v", rand.Int()), repo.URL)
+	policy := zest.POLICY692ENUM_IMMEDIATE
+	pythonRemote.Policy = &policy
+	pythonRemote.Includes = []string{testPythonPackageName}
+
+	remoteResp, httpResp, err := zestClient.RemotesPythonAPI.RemotesPythonPythonCreate(ctx, domainName).
+		PythonPythonRemote(*pythonRemote).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.NotNil(t, remoteResp.PulpHref)
+
+	pythonRepo := zest.NewPythonPythonRepository(fmt.Sprintf("python-repo-%v", rand.Int()))
+	pythonRepo.SetRemote(*remoteResp.PulpHref)
+
+	repoResp, httpResp, err := zestClient.RepositoriesPythonAPI.RepositoriesPythonPythonCreate(ctx, domainName).
+		PythonPythonRepository(*pythonRepo).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.NotNil(t, repoResp.PulpHref)
+
+	syncURL := zest.NewRepositorySyncURL()
+	syncURL.SetRemote(*remoteResp.PulpHref)
+	mirror := true
+	syncURL.SetMirror(mirror)
+
+	// Zest prepends server URL + "/" to the href; strip leading slash to avoid "//api/pulp/..." URLs.
+	repoHref := strings.TrimPrefix(*repoResp.PulpHref, "/")
+	syncTaskResp, httpResp, err := zestClient.RepositoriesPythonAPI.RepositoriesPythonPythonSync(ctx, repoHref).
+		RepositorySyncURL(*syncURL).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.NotEmpty(t, syncTaskResp.Task)
+
+	syncTask, err := pulpClient.PollTask(s.ctx, strings.TrimPrefix(syncTaskResp.Task, "/"))
+	require.NoError(t, err)
+	require.NotNil(t, syncTask.State)
+	require.Equal(t, "completed", *syncTask.State)
+
+	distPath := fmt.Sprintf("%s/latest-%v", repo.UUID, rand.Int())
+	pythonDist := zest.NewPythonPythonDistribution(distPath, distPath)
+	pythonDist.SetRepository(*repoResp.PulpHref)
+	pythonDist.SetRemote(*remoteResp.PulpHref)
+
+	distTaskResp, httpResp, err := zestClient.DistributionsPypiAPI.DistributionsPythonPypiCreate(ctx, domainName).
+		PythonPythonDistribution(*pythonDist).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.NotEmpty(t, distTaskResp.Task)
+
+	distTask, err := pulpClient.PollTask(s.ctx, strings.TrimPrefix(distTaskResp.Task, "/"))
+	require.NoError(t, err)
+	require.NotNil(t, distTask.State)
+	require.Equal(t, "completed", *distTask.State)
+
+	baseURL, err := pulpClient.GetContentPath()
+	require.NoError(t, err)
+
+	res = db.DB.Model(&repo).Updates(map[string]any{
+		"published_distribution_base_path": distPath,
+		"published_distribution_url":       fmt.Sprintf("%s%s/%s", baseURL, domainName, distPath),
+	})
+	assert.NoError(t, res.Error)
+
+	apiRepoResp := s.dao.RepositoryConfig.InternalOnly_FetchRepoConfigsForRepoUUID(context.Background(), repo.UUID)
+	require.NotEmpty(t, apiRepoResp)
+
+	return apiRepoResp[0]
+}
+
+func (s *PythonPackagesSuite) listPackages(repoUUID string) api.PackageResponse {
+	t := s.T()
+
+	path := api.FullRootPath() + "/repositories/" + repoUUID + "/packages"
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedCustomIdentity(t, s.identity))
+	req.Header.Set("Content-Type", "application/json")
+
+	code, body, err := s.serveRouter(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code, string(body))
+
+	var resp api.PackageResponse
+	err = json.Unmarshal(body, &resp)
+	require.NoError(t, err)
+
+	return resp
+}


### PR DESCRIPTION
This PR:

- Adds Python package listing to `GET /repositories/{uuid}/packages` for Lightwell repos
- Refactors the handler to route by `content_type` (Maven, Python, or empty for others)
- Maps Python results to the existing response shape (`name`, `versions`, `latest_releases`)
- Adds unit and integration tests; regenerates OpenAPI and Playwright client