### PR TITLE
HMS-10961: support filtering packages

### DIFF
--- a/_playwright-tests/test-utils/src/client/apis/PackagesApi.ts
+++ b/_playwright-tests/test-utils/src/client/apis/PackagesApi.ts
@@ -40,6 +40,7 @@ export interface ListPackagesRequest {
     uuid: string;
     offset?: number;
     limit?: number;
+    search?: string;
 }
 
 /**
@@ -137,6 +138,10 @@ export class PackagesApi extends runtime.BaseAPI {
 
         if (requestParameters['limit'] != null) {
             queryParameters['limit'] = requestParameters['limit'];
+        }
+
+        if (requestParameters['search'] != null) {
+            queryParameters['search'] = requestParameters['search'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/api/docs.go
+++ b/api/docs.go
@@ -1798,6 +1798,12 @@ const docTemplate = `{
                         "description": "Number of items per page. Default: 100",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name.",
+                        "name": "search",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -4581,6 +4581,14 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.18
+	github.com/content-services/tang v0.0.20
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.18 h1:CFVPPYoflRRZprn81APoE/PGBDj6tRZCKG7YP8xqnC8=
-github.com/content-services/tang v0.0.18/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
+github.com/content-services/tang v0.0.20 h1:fTHblqgO8NQXAP1CFxBffAOcYiE/+iVLef/dyb6OQRc=
+github.com/content-services/tang v0.0.20/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.6.1781883872 h1:xQIDt66t/bfZfHYRMQGTpQdMxzK/XgYcYCR9TEYmb8s=

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -16,6 +16,11 @@ type PackageItem struct {
 	LatestReleases []ReleaseInfo `json:"latest_releases"`
 }
 
+type ListPackagesRequest struct {
+	UUID   string `param:"uuid" validate:"required"` // Identifier of the repository
+	Search string `query:"search"`                   // Name or group to optionally filter-on
+}
+
 // ReleaseInfo represents the latest release information for a package version
 type ReleaseInfo struct {
 	Version   string `json:"version"`

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -44,6 +44,7 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 // @Param        uuid path string true "Repository UUID"
 // @Param        offset query int false "Starting point for pagination. Default: 0"
 // @Param        limit query int false "Number of items per page. Default: 100"
+// @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name."
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.PackageResponse
@@ -52,9 +53,15 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/{uuid}/packages [get]
 func (ph *PackageHandler) listPackages(c echo.Context) error {
+	listPackagesRequest := api.ListPackagesRequest{}
+	if err := c.Bind(&listPackagesRequest); err != nil {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error binding parameters", err.Error())
+	}
+
 	uuid := c.Param("uuid")
 	// _, orgID := getAccountIdOrgId(c)
 	pageData := ParsePagination(c)
+	filterData := listPackagesRequest.Search
 	ctx := c.Request().Context()
 
 	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid) // TODO, don't hardcode lightwell org
@@ -64,9 +71,9 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 
 	switch repo.ContentType {
 	case config.ContentTypeMaven:
-		return ph.listMavenPackages(c, ctx, repo, pageData)
+		return ph.listMavenPackages(c, ctx, repo, filterData, pageData)
 	case config.ContentTypePython:
-		return ph.listPythonPackages(c, ctx, repo, pageData)
+		return ph.listPythonPackages(c, ctx, repo, filterData, pageData)
 	default:
 		return c.JSON(http.StatusOK, api.PackageResponse{
 			Results: []api.PackageItem{},
@@ -77,7 +84,7 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 	}
 }
 
-func (ph *PackageHandler) listMavenPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, pageData api.PaginationData) error {
+func (ph *PackageHandler) listMavenPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, filterData string, pageData api.PaginationData) error {
 	if repo.PublishedDistBasePath == "" {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
 	}
@@ -87,10 +94,15 @@ func (ph *PackageHandler) listMavenPackages(c echo.Context, ctx context.Context,
 		return ph.repositoryHrefErrorResponse(err)
 	}
 
-	tangResp, err := ph.TangClient.MavenPackageList(ctx, repositoryHref, tangy.PageOptions{
-		Offset: pageData.Offset,
-		Limit:  pageData.Limit,
-	})
+	tangResp, err := ph.TangClient.MavenPackageList(
+		c.Request().Context(),
+		repositoryHref,
+		tangy.MavenPackageListFilters{Search: filterData},
+		tangy.PageOptions{
+			Offset: pageData.Offset,
+			Limit:  pageData.Limit,
+		},
+	)
 	if err != nil {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving packages", err.Error())
 	}
@@ -98,7 +110,7 @@ func (ph *PackageHandler) listMavenPackages(c echo.Context, ctx context.Context,
 	return c.JSON(http.StatusOK, mapMavenPackagesToAPI(tangResp))
 }
 
-func (ph *PackageHandler) listPythonPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, pageData api.PaginationData) error {
+func (ph *PackageHandler) listPythonPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, filterData string, pageData api.PaginationData) error {
 	if repo.PublishedDistBasePath == "" {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
 	}
@@ -108,7 +120,7 @@ func (ph *PackageHandler) listPythonPackages(c echo.Context, ctx context.Context
 		return ph.repositoryHrefErrorResponse(err)
 	}
 
-	tangResp, err := ph.TangClient.PythonPackageList(ctx, repositoryHref, tangy.PageOptions{
+	tangResp, err := ph.TangClient.PythonPackageList(ctx, repositoryHref, tangy.PythonPackageListFilters{Search: filterData}, tangy.PageOptions{
 		Offset: pageData.Offset,
 		Limit:  pageData.Limit,
 	})

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -108,7 +108,7 @@ func (suite *PackagesSuite) TestListPackagesMavenSuccess() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
-	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -129,6 +129,66 @@ func (suite *PackagesSuite) TestListPackagesMavenSuccess() {
 	assert.Equal(t, 1, response.Total)
 	assert.Equal(t, 100, response.Limit)
 	assert.Equal(t, 0, response.Offset)
+}
+
+func (suite *PackagesSuite) TestListPackagesMavenWithFilter() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440007"
+	basePath := "java/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/maven/maven/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	search := "smallrye"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeMaven,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	tangResp := tangy.MavenPackageListResponse{
+		Results: []tangy.MavenPackageListItem{
+			{
+				GroupID:    "io.smallrye.reactive",
+				ArtifactID: "smallrye-mutiny-vertx-core",
+				Versions:   []string{"3.16.0"},
+				LatestReleases: []tangy.MavenReleaseInfo{
+					{
+						Version:   "3.16.0",
+						Release:   "rhlw-4000",
+						CreatedAt: "2024-02-01T14:20:00Z",
+					},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  100,
+		Offset: 0,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.MavenPackageListFilters{Search: search}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0&search=%s", api.FullRootPath(), repoUUID, search)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PackageResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response.Results))
+	assert.Equal(t, "io.smallrye.reactive", response.Results[0].Group)
+	assert.Equal(t, "smallrye-mutiny-vertx-core", response.Results[0].Name)
+	assert.Equal(t, 1, response.Total)
 }
 
 func (suite *PackagesSuite) TestListPackagesPythonSuccess() {
@@ -174,7 +234,7 @@ func (suite *PackagesSuite) TestListPackagesPythonSuccess() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
-	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -200,6 +260,66 @@ func (suite *PackagesSuite) TestListPackagesPythonSuccess() {
 	assert.Equal(t, 0, response.Offset)
 }
 
+func (suite *PackagesSuite) TestListPackagesPythonWithFilter() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440008"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f5/"
+	domainName := "test-domain"
+	search := "shelf"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	tangResp := tangy.PythonPackageListResponse{
+		Results: []tangy.PythonPackageListItem{
+			{
+				Name:           "shelf-reader",
+				NameNormalized: "shelf-reader",
+				Versions:       []string{"0.1"},
+				LatestVersions: []tangy.PythonVersionInfo{
+					{
+						Version:   "0.1",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  100,
+		Offset: 0,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PythonPackageListFilters{Search: search}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0&search=%s", api.FullRootPath(), repoUUID, search)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PackageResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response.Results))
+	assert.Empty(t, response.Results[0].Group)
+	assert.Equal(t, "shelf-reader", response.Results[0].Name)
+	assert.Equal(t, 1, len(response.Results[0].Versions))
+	assert.Equal(t, 1, response.Total)
+}
+
 func (suite *PackagesSuite) TestListPackagesPythonTangClientError() {
 	t := suite.T()
 	repoUUID := "550e8400-e29b-41d4-a716-446655440006"
@@ -220,7 +340,7 @@ func (suite *PackagesSuite) TestListPackagesPythonTangClientError() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
-	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.PythonPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
+	suite.tangClient.On("PythonPackageList", test.MockCtx(), repositoryHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.PythonPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
 
 	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -320,7 +440,7 @@ func (suite *PackagesSuite) TestListPackagesTangClientError() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
-	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.MavenPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
+	suite.tangClient.On("MavenPackageList", test.MockCtx(), repositoryHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.MavenPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
 
 	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
 	req := httptest.NewRequest(http.MethodGet, path, nil)


### PR DESCRIPTION
## Summary

Adds optional search filter to list repo packages api

## Testing steps

Could test using Ryan's [script](https://github.com/content-services/content-sources-backend/blob/main/scripts/create_maven_repo.sh) and calling the list repo packages api with a filter: `/repositories/:uuid/packages?search=fasterxml`

