### PR TITLE
HMS-10963: add python details endpoint + maven int tests fix

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1624,7 +1624,7 @@ const docTemplate = `{
                 "tags": [
                     "packages"
                 ],
-                "summary": "Get Package Detail",
+                "summary": "Get Maven Package Detail",
                 "operationId": "getPackageDetail",
                 "parameters": [
                     {
@@ -1660,7 +1660,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.PackageDetailResponse"
+                            "$ref": "#/definitions/api.MavenPackageDetailResponse"
                         }
                     },
                     "400": {
@@ -1811,6 +1811,71 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/api.PackageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/repositories/{uuid}/python_packages/{name}/{version}": {
+            "get": {
+                "description": "Get metadata and distributions for a specific Python package by name and version.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "packages"
+                ],
+                "summary": "Get Python Package Detail",
+                "operationId": "getPythonPackageDetail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository UUID",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Python package normalized name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Python package version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.PythonPackageDetailResponse"
                         }
                     },
                     "400": {
@@ -4162,7 +4227,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.PackageDetailResponse": {
+        "api.MavenPackageDetailResponse": {
             "type": "object",
             "properties": {
                 "builds": {
@@ -4398,6 +4463,84 @@ const docTemplate = `{
                 },
                 "url": {
                     "description": "URL of the remote yum repository",
+                    "type": "string"
+                }
+            }
+        },
+        "api.PythonDistribution": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "packagetype": {
+                    "type": "string"
+                },
+                "python_version": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.PythonPackageAuthor": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.PythonPackageDetailResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "$ref": "#/definitions/api.PythonPackageAuthor"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "distributions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.PythonDistribution"
+                    }
+                },
+                "last_updated": {
+                    "type": "string"
+                },
+                "license": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "project_url": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "upstream_versions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -254,7 +254,7 @@
                 },
                 "type": "object"
             },
-            "api.PackageDetailResponse": {
+            "api.MavenPackageDetailResponse": {
                 "properties": {
                     "builds": {
                         "items": {
@@ -489,6 +489,84 @@
                     },
                     "url": {
                         "description": "URL of the remote yum repository",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.PythonDistribution": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "packagetype": {
+                        "type": "string"
+                    },
+                    "python_version": {
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "api.PythonPackageAuthor": {
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.PythonPackageDetailResponse": {
+                "properties": {
+                    "author": {
+                        "$ref": "#/components/schemas/api.PythonPackageAuthor"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "distributions": {
+                        "items": {
+                            "$ref": "#/components/schemas/api.PythonDistribution"
+                        },
+                        "type": "array"
+                    },
+                    "last_updated": {
+                        "type": "string"
+                    },
+                    "license": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "project_url": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "upstream_versions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "version": {
                         "type": "string"
                     }
                 },
@@ -4404,7 +4482,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/api.PackageDetailResponse"
+                                    "$ref": "#/components/schemas/api.MavenPackageDetailResponse"
                                 }
                             }
                         },
@@ -4441,7 +4519,7 @@
                         "description": "Internal Server Error"
                     }
                 },
-                "summary": "Get Package Detail",
+                "summary": "Get Maven Package Detail",
                 "tags": [
                     "packages"
                 ]
@@ -4634,6 +4712,87 @@
                     }
                 },
                 "summary": "List Packages",
+                "tags": [
+                    "packages"
+                ]
+            }
+        },
+        "/repositories/{uuid}/python_packages/{name}/{version}": {
+            "get": {
+                "description": "Get metadata and distributions for a specific Python package by name and version.",
+                "operationId": "getPythonPackageDetail",
+                "parameters": [
+                    {
+                        "description": "Repository UUID",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Python package normalized name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Python package version",
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.PythonPackageDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get Python Package Detail",
                 "tags": [
                     "packages"
                 ]

--- a/go.mod
+++ b/go.mod
@@ -173,3 +173,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/content-services/tang => /Users/stepan/repos/github/TenSt/tang

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.20
+	github.com/content-services/tang v0.0.21
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect
@@ -173,5 +173,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/content-services/tang => /Users/stepan/repos/github/TenSt/tang

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.20 h1:fTHblqgO8NQXAP1CFxBffAOcYiE/+iVLef/dyb6OQRc=
-github.com/content-services/tang v0.0.20/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.6.1781883872 h1:xQIDt66t/bfZfHYRMQGTpQdMxzK/XgYcYCR9TEYmb8s=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
+github.com/content-services/tang v0.0.21 h1:ZPWWVfuApXcguKOdAu69jqZZy5Ai7eschmxpBKZO0gM=
+github.com/content-services/tang v0.0.21/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.6.1781883872 h1:xQIDt66t/bfZfHYRMQGTpQdMxzK/XgYcYCR9TEYmb8s=

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -28,10 +28,41 @@ type ReleaseInfo struct {
 	CreatedAt string `json:"created_at"`
 }
 
-// PackageDetailResponse represents the detail response for a specific Maven package
-type PackageDetailResponse struct {
+// MavenPackageDetailResponse represents the detail response for a specific Maven package.
+type MavenPackageDetailResponse struct {
 	Group   string        `json:"group"`
 	Name    string        `json:"name"`
 	Version string        `json:"version"`
 	Builds  []ReleaseInfo `json:"builds"`
+}
+
+// PythonPackageAuthor represents package authorship metadata.
+type PythonPackageAuthor struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+}
+
+// PythonDistribution represents a distribution file for a Python package version.
+type PythonDistribution struct {
+	Name          string `json:"name"`
+	Filename      string `json:"filename"`
+	PackageType   string `json:"packagetype"`
+	PythonVersion string `json:"python_version"`
+	Sha256        string `json:"sha256"`
+	Size          int64  `json:"size"`
+	CreatedAt     string `json:"created_at"`
+}
+
+// PythonPackageDetailResponse represents the detail response for a specific Python package.
+type PythonPackageDetailResponse struct {
+	Name             string               `json:"name"`
+	Version          string               `json:"version"`
+	Summary          string               `json:"summary"`
+	Description      string               `json:"description"`
+	LastUpdated      string               `json:"last_updated"`
+	License          string               `json:"license"`
+	Author           PythonPackageAuthor  `json:"author"`
+	UpstreamVersions []string             `json:"upstream_versions"`
+	ProjectURL       string               `json:"project_url"`
+	Distributions    []PythonDistribution `json:"distributions"`
 }

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -368,12 +368,12 @@ func mapPythonPackageDetailToAPI(tangDetail tangy.PythonPackageDetail) api.Pytho
 	}
 
 	return api.PythonPackageDetailResponse{
-		Name:             tangDetail.NameNormalized,
-		Version:          tangDetail.Version,
-		Summary:          tangDetail.Summary,
-		Description:      tangDetail.Description,
-		LastUpdated:      tangDetail.LastUpdated,
-		License:          tangDetail.License,
+		Name:        tangDetail.NameNormalized,
+		Version:     tangDetail.Version,
+		Summary:     tangDetail.Summary,
+		Description: tangDetail.Description,
+		LastUpdated: tangDetail.LastUpdated,
+		License:     tangDetail.License,
 		Author: api.PythonPackageAuthor{
 			Name:  tangDetail.Author,
 			Email: tangDetail.AuthorEmail,

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -33,7 +33,8 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 		PulpClient:  pulpClient,
 	}
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/packages", ph.listPackages, rbac.RbacVerbRead)
-	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/maven_packages/:group/:name/:version", ph.getPackageDetail, rbac.RbacVerbRead)
+	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/maven_packages/:group/:name/:version", ph.getMavenPackageDetail, rbac.RbacVerbRead)
+	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/python_packages/:name/:version", ph.getPythonPackageDetail, rbac.RbacVerbRead)
 }
 
 // ListPackages godoc
@@ -235,8 +236,8 @@ func mapPythonPackagesToAPI(tangResp tangy.PythonPackageListResponse) api.Packag
 	}
 }
 
-// GetPackageDetail godoc
-// @Summary      Get Package Detail
+// GetMavenPackageDetail godoc
+// @Summary      Get Maven Package Detail
 // @ID           getPackageDetail
 // @Description  Get builds for a specific Maven package by group, name, and version.
 // @Tags         packages
@@ -246,12 +247,12 @@ func mapPythonPackagesToAPI(tangResp tangy.PythonPackageListResponse) api.Packag
 // @Param        version path string true "Maven package version"
 // @Accept       json
 // @Produce      json
-// @Success      200 {object} api.PackageDetailResponse
+// @Success      200 {object} api.MavenPackageDetailResponse
 // @Failure      400 {object} ce.ErrorResponse
 // @Failure      404 {object} ce.ErrorResponse
 // @Failure      500 {object} ce.ErrorResponse
 // @Router       /repositories/{uuid}/maven_packages/{group}/{name}/{version} [get]
-func (ph *PackageHandler) getPackageDetail(c echo.Context) error {
+func (ph *PackageHandler) getMavenPackageDetail(c echo.Context) error {
 	uuid := c.Param("uuid")
 	groupID := c.Param("group")
 	name := c.Param("name")
@@ -294,10 +295,91 @@ func (ph *PackageHandler) getPackageDetail(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, api.PackageDetailResponse{
+	return c.JSON(http.StatusOK, api.MavenPackageDetailResponse{
 		Group:   groupID,
 		Name:    name,
 		Version: version,
 		Builds:  builds,
 	})
+}
+
+// GetPythonPackageDetail godoc
+// @Summary      Get Python Package Detail
+// @ID           getPythonPackageDetail
+// @Description  Get metadata and distributions for a specific Python package by name and version.
+// @Tags         packages
+// @Param        uuid path string true "Repository UUID"
+// @Param        name path string true "Python package normalized name"
+// @Param        version path string true "Python package version"
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} api.PythonPackageDetailResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{uuid}/python_packages/{name}/{version} [get]
+func (ph *PackageHandler) getPythonPackageDetail(c echo.Context) error {
+	uuid := c.Param("uuid")
+	name := c.Param("name")
+	version := c.Param("version")
+	ctx := c.Request().Context()
+
+	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
+	}
+
+	if repo.ContentType != config.ContentTypePython {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Repository is not a Python repository")
+	}
+
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.PythonPackageGet(ctx, repositoryHref, name, version)
+	if err != nil {
+		if errors.Is(err, tangy.ErrPythonPackageNotFound) {
+			return ce.NewErrorResponse(http.StatusNotFound, "Package not found", err.Error())
+		}
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package detail", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, mapPythonPackageDetailToAPI(tangResp))
+}
+
+func mapPythonPackageDetailToAPI(tangDetail tangy.PythonPackageDetail) api.PythonPackageDetailResponse {
+	distributions := make([]api.PythonDistribution, len(tangDetail.Distributions))
+	for i, dist := range tangDetail.Distributions {
+		distributions[i] = api.PythonDistribution{
+			Name:          dist.Name,
+			Filename:      dist.Filename,
+			PackageType:   dist.PackageType,
+			PythonVersion: dist.PythonVersion,
+			Sha256:        dist.Sha256,
+			Size:          dist.Size,
+			CreatedAt:     dist.CreatedAt,
+		}
+	}
+
+	return api.PythonPackageDetailResponse{
+		Name:             tangDetail.NameNormalized,
+		Version:          tangDetail.Version,
+		Summary:          tangDetail.Summary,
+		Description:      tangDetail.Description,
+		LastUpdated:      tangDetail.LastUpdated,
+		License:          tangDetail.License,
+		Author: api.PythonPackageAuthor{
+			Name:  tangDetail.Author,
+			Email: tangDetail.AuthorEmail,
+		},
+		UpstreamVersions: tangDetail.Versions,
+		ProjectURL:       tangDetail.ProjectURL,
+		Distributions:    distributions,
+	}
 }

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -22,6 +22,7 @@ import (
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -508,7 +509,7 @@ func (suite *PackagesSuite) TestGetPackageDetailSuccess() {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 
-	var response api.PackageDetailResponse
+	var response api.MavenPackageDetailResponse
 	err = json.Unmarshal(body, &response)
 	assert.Nil(t, err)
 	assert.Equal(t, groupID, response.Group)
@@ -642,11 +643,181 @@ func (suite *PackagesSuite) TestGetPackageDetailEmptyBuilds() {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 
-	var response api.PackageDetailResponse
+	var response api.MavenPackageDetailResponse
 	err = json.Unmarshal(body, &response)
 	assert.Nil(t, err)
 	assert.Equal(t, groupID, response.Group)
 	assert.Equal(t, packageName, response.Name)
 	assert.Equal(t, packageVersion, response.Version)
 	assert.Equal(t, 0, len(response.Builds))
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageDetailSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "django"
+	packageVersion := "5.0"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	tangDetail := tangy.PythonPackageDetail{
+		Name:           "Django",
+		NameNormalized: packageName,
+		Version:        packageVersion,
+		Summary:        "A high-level Python web framework",
+		Description:    "Django is a high-level Python web framework.",
+		Author:         "Django Software Foundation",
+		AuthorEmail:    "foundation@djangoproject.com",
+		License:        "BSD-3-Clause",
+		ProjectURL:     "https://www.djangoproject.com/",
+		LastUpdated:    "2024-01-01T12:00:00Z",
+		Versions:       []string{"4.2", "5.0"},
+		Distributions: []tangy.PythonDistributionListItem{
+			{
+				Name:           "Django",
+				NameNormalized: packageName,
+				Version:        packageVersion,
+				Filename:       "django-5.0-py3-none-any.whl",
+				PackageType:    "bdist_wheel",
+				PythonVersion:  "py3",
+				Sha256:         "abc123",
+				Size:           1024,
+				CreatedAt:      "2024-01-01T12:00:00Z",
+			},
+		},
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageGet", test.MockCtx(), repositoryHref, packageName, packageVersion).Return(tangDetail, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s/%s", api.FullRootPath(), repoUUID, packageName, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PythonPackageDetailResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, packageName, response.Name)
+	assert.Equal(t, packageVersion, response.Version)
+	assert.Equal(t, "A high-level Python web framework", response.Summary)
+	assert.Equal(t, "Django is a high-level Python web framework.", response.Description)
+	assert.Equal(t, "2024-01-01T12:00:00Z", response.LastUpdated)
+	assert.Equal(t, "BSD-3-Clause", response.License)
+	assert.Equal(t, "Django Software Foundation", response.Author.Name)
+	assert.Equal(t, "foundation@djangoproject.com", response.Author.Email)
+	assert.Equal(t, []string{"4.2", "5.0"}, response.UpstreamVersions)
+	assert.Equal(t, "https://www.djangoproject.com/", response.ProjectURL)
+	require.Len(t, response.Distributions, 1)
+	assert.Equal(t, "django-5.0-py3-none-any.whl", response.Distributions[0].Filename)
+	assert.Equal(t, "bdist_wheel", response.Distributions[0].PackageType)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageDetailNonPythonRepo() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440001"
+
+	repo := api.RepositoryResponse{
+		UUID:        repoUUID,
+		ContentType: config.ContentTypeMaven,
+	}
+
+	orgID := config.LightwellOrg
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s/%s", api.FullRootPath(), repoUUID, "django", "5.0")
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageDetailNotFound() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "django"
+	packageVersion := "9.9.9"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageGet", test.MockCtx(), repositoryHref, packageName, packageVersion).Return(tangy.PythonPackageDetail{}, tangy.ErrPythonPackageNotFound)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s/%s", api.FullRootPath(), repoUUID, packageName, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageDetailTangError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "django"
+	packageVersion := "5.0"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageGet", test.MockCtx(), repositoryHref, packageName, packageVersion).Return(tangy.PythonPackageDetail{}, fmt.Errorf("failed to fetch package detail"))
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s/%s", api.FullRootPath(), repoUUID, packageName, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
 }

--- a/test/integration/maven_packages_test.go
+++ b/test/integration/maven_packages_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,20 +130,20 @@ func (s *MavenPackagesSuite) TestMavenPackagesAPI() {
 	t := s.T()
 
 	// Create a Maven repository pointing to Maven Central
-	repo := s.createMavenRepository(config.LightwellOrg)
+	mavenRepo := s.createMavenRepository(config.LightwellOrg)
 
 	// Fetch some packages from the Pulp distribution to populate the repository
 	// We'll curl some random POMs from Maven Central through the Pulp distribution
-	s.fetchPackagesFromDistribution(repo, []string{
+	s.fetchPackagesFromDistribution(mavenRepo.repo, []string{
 		"/blissed/blissed/1.0-beta-3/blissed-1.0-beta-3.pom",
 		"/avalon-util/avalon-util-exception/1.0.0/avalon-util-exception-1.0.0.pom",
 	})
 
-	// Wait a bit for Pulp to process the fetched artifacts
-	time.Sleep(5 * time.Second)
+	// On-demand Maven repos cache artifacts separately; add them to the repository version.
+	s.addCachedContent(mavenRepo)
 
 	// Test the packages API endpoint
-	packages := s.listPackages(repo.UUID)
+	packages := s.listPackages(mavenRepo.repo.UUID)
 
 	// Verify we got results
 	assert.NotNil(t, packages)
@@ -158,7 +159,7 @@ func (s *MavenPackagesSuite) TestMavenPackagesAPI() {
 
 		// Test the package detail endpoint using data from the list
 		if len(firstPackage.Versions) > 0 {
-			detail := s.getPackageDetail(repo.UUID, firstPackage.Group, firstPackage.Name, firstPackage.Versions[0])
+			detail := s.getPackageDetail(mavenRepo.repo.UUID, firstPackage.Group, firstPackage.Name, firstPackage.Versions[0])
 			assert.Equal(t, firstPackage.Group, detail.Group)
 			assert.Equal(t, firstPackage.Name, detail.Name)
 			assert.Equal(t, firstPackage.Versions[0], detail.Version)
@@ -166,7 +167,13 @@ func (s *MavenPackagesSuite) TestMavenPackagesAPI() {
 	}
 }
 
-func (s *MavenPackagesSuite) createMavenRepository(orgId string) api.RepositoryResponse {
+type mavenPulpRepository struct {
+	repo           api.RepositoryResponse
+	repositoryHref string
+	remoteHref     string
+}
+
+func (s *MavenPackagesSuite) createMavenRepository(orgId string) mavenPulpRepository {
 	t := s.T()
 
 	// Create the repository directly in the database (API doesn't support Maven content type)
@@ -270,7 +277,41 @@ func (s *MavenPackagesSuite) createMavenRepository(orgId string) api.RepositoryR
 	apiRepoResp := s.dao.RepositoryConfig.InternalOnly_FetchRepoConfigsForRepoUUID(context.Background(), repo.UUID)
 	require.NotEmpty(t, apiRepoResp)
 
-	return apiRepoResp[0]
+	return mavenPulpRepository{
+		repo:           apiRepoResp[0],
+		repositoryHref: *mavenRepoResp.PulpHref,
+		remoteHref:     *remoteResp.PulpHref,
+	}
+}
+
+func (s *MavenPackagesSuite) addCachedContent(mavenRepo mavenPulpRepository) {
+	t := s.T()
+
+	domainName, err := s.dao.Domain.FetchOrCreateDomain(s.ctx, mavenRepo.repo.OrgID)
+	require.NoError(t, err)
+
+	pulpClient := pulp_client.GetPulpClientWithDomain(domainName)
+
+	ctx, zestClient, err := s.getZestClient()
+	require.NoError(t, err)
+
+	addCachedContent := zest.NewRepositoryAddCachedContent()
+	addCachedContent.SetRemote(mavenRepo.remoteHref)
+
+	repositoryHref := strings.TrimPrefix(mavenRepo.repositoryHref, "/")
+	taskResp, httpResp, err := zestClient.RepositoriesMavenAPI.RepositoriesMavenMavenAddCachedContent(ctx, repositoryHref).
+		RepositoryAddCachedContent(*addCachedContent).
+		Execute()
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	require.NoError(t, err)
+	require.NotEmpty(t, taskResp.Task)
+
+	task, err := pulpClient.PollTask(s.ctx, strings.TrimPrefix(taskResp.Task, "/"))
+	require.NoError(t, err)
+	require.NotNil(t, task.State)
+	require.Equal(t, "completed", *task.State)
 }
 
 func (s *MavenPackagesSuite) fetchPackagesFromDistribution(repo api.RepositoryResponse, paths []string) {
@@ -332,7 +373,7 @@ func (s *MavenPackagesSuite) listPackages(repoUUID string) api.PackageResponse {
 	return resp
 }
 
-func (s *MavenPackagesSuite) getPackageDetail(repoUUID, group, name, version string) api.PackageDetailResponse {
+func (s *MavenPackagesSuite) getPackageDetail(repoUUID, group, name, version string) api.MavenPackageDetailResponse {
 	t := s.T()
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s/%s", api.FullRootPath(), repoUUID, group, name, version)
@@ -344,7 +385,7 @@ func (s *MavenPackagesSuite) getPackageDetail(repoUUID, group, name, version str
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, code, string(body))
 
-	var resp api.PackageDetailResponse
+	var resp api.MavenPackageDetailResponse
 	err = json.Unmarshal(body, &resp)
 	require.NoError(t, err)
 

--- a/test/integration/python_packages_test.go
+++ b/test/integration/python_packages_test.go
@@ -160,6 +160,36 @@ func (s *PythonPackagesSuite) TestPythonPackagesAPI() {
 	assert.True(t, foundVersion)
 }
 
+func (s *PythonPackagesSuite) TestPythonPackageDetailAPI() {
+	orgId := fmt.Sprintf("PythonPackages-%v", rand.Int())
+
+	s.identity = test_handler.MockIdentity
+	s.identity.Identity.OrgID = orgId
+
+	t := s.T()
+
+	repo := s.createPythonRepository(config.LightwellOrg)
+	detail := s.getPackageDetail(repo.UUID, testPythonPackageName, "0.1")
+
+	assert.Equal(t, testPythonPackageName, detail.Name)
+	assert.Equal(t, "0.1", detail.Version)
+	assert.NotEmpty(t, detail.Summary)
+	assert.NotEmpty(t, detail.LastUpdated)
+	assert.NotEmpty(t, detail.License)
+	assert.Contains(t, detail.UpstreamVersions, "0.1")
+	require.NotEmpty(t, detail.Distributions)
+
+	for _, dist := range detail.Distributions {
+		assert.NotEmpty(t, dist.Name)
+		assert.Contains(t, dist.Filename, "0.1")
+		assert.NotEmpty(t, dist.Filename)
+		assert.NotEmpty(t, dist.PackageType)
+		assert.NotEmpty(t, dist.Sha256)
+		assert.NotZero(t, dist.Size)
+		assert.NotEmpty(t, dist.CreatedAt)
+	}
+}
+
 func (s *PythonPackagesSuite) createPythonRepository(orgId string) api.RepositoryResponse {
 	t := s.T()
 
@@ -294,6 +324,25 @@ func (s *PythonPackagesSuite) listPackages(repoUUID string) api.PackageResponse 
 	assert.Equal(t, http.StatusOK, code, string(body))
 
 	var resp api.PackageResponse
+	err = json.Unmarshal(body, &resp)
+	require.NoError(t, err)
+
+	return resp
+}
+
+func (s *PythonPackagesSuite) getPackageDetail(repoUUID, name, version string) api.PythonPackageDetailResponse {
+	t := s.T()
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s/%s", api.FullRootPath(), repoUUID, name, version)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedCustomIdentity(t, s.identity))
+	req.Header.Set("Content-Type", "application/json")
+
+	code, body, err := s.serveRouter(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code, string(body))
+
+	var resp api.PythonPackageDetailResponse
 	err = json.Unmarshal(body, &resp)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Note: it uses local version of https://github.com/content-services/tang/pull/30, so it will need to be updated once tang new tag is released

This PR:
- Adds Python package detail endpoint with `PythonPackageDetailResponse` via Tang `PythonPackageGet`
- Renames Maven detail response to `MavenPackageDetailResponse`; keeps separate handlers and routes
- Adds unit and integration tests for Python package detail; fixes Maven test with `add_cached_content`
- Regenerates OpenAPI docs for new Python endpoint and updated response schemas