### PR TITLE
HMS-10965: add new endpoint to get details of all package's versions

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1834,6 +1834,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/{uuid}/python_packages/{name}": {
+            "get": {
+                "description": "Get metadata and distributions for all versions of a Python package by name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "packages"
+                ],
+                "summary": "Get Python Package Versions",
+                "operationId": "getPythonPackageVersions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository UUID",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Python package normalized name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.PythonPackageVersionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}/python_packages/{name}/{version}": {
             "get": {
                 "description": "Get metadata and distributions for a specific Python package by name and version.",
@@ -4542,6 +4600,20 @@ const docTemplate = `{
                 },
                 "version": {
                     "type": "string"
+                }
+            }
+        },
+        "api.PythonPackageVersionsResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.PythonPackageDetailResponse"
+                    }
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -572,6 +572,20 @@
                 },
                 "type": "object"
             },
+            "api.PythonPackageVersionsResponse": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "versions": {
+                        "items": {
+                            "$ref": "#/components/schemas/api.PythonPackageDetailResponse"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
             "api.ReleaseInfo": {
                 "properties": {
                     "created_at": {
@@ -4712,6 +4726,78 @@
                     }
                 },
                 "summary": "List Packages",
+                "tags": [
+                    "packages"
+                ]
+            }
+        },
+        "/repositories/{uuid}/python_packages/{name}": {
+            "get": {
+                "description": "Get metadata and distributions for all versions of a Python package by name.",
+                "operationId": "getPythonPackageVersions",
+                "parameters": [
+                    {
+                        "description": "Repository UUID",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Python package normalized name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.PythonPackageVersionsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get Python Package Versions",
                 "tags": [
                     "packages"
                 ]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.21
+	github.com/content-services/tang v0.0.22
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.21 h1:ZPWWVfuApXcguKOdAu69jqZZy5Ai7eschmxpBKZO0gM=
-github.com/content-services/tang v0.0.21/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
+github.com/content-services/tang v0.0.22 h1:L1k7iIZo/pfp4GBkTO29+Nk/ZgobLE+qJ0fTR9jfdIA=
+github.com/content-services/tang v0.0.22/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.6.1781883872 h1:xQIDt66t/bfZfHYRMQGTpQdMxzK/XgYcYCR9TEYmb8s=

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -53,6 +53,12 @@ type PythonDistribution struct {
 	CreatedAt     string `json:"created_at"`
 }
 
+// PythonPackageVersionsResponse represents details for all versions of a Python package.
+type PythonPackageVersionsResponse struct {
+	Name     string                        `json:"name"`
+	Versions []PythonPackageDetailResponse `json:"versions"`
+}
+
 // PythonPackageDetailResponse represents the detail response for a specific Python package.
 type PythonPackageDetailResponse struct {
 	Name             string               `json:"name"`

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -35,6 +35,7 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/packages", ph.listPackages, rbac.RbacVerbRead)
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/maven_packages/:group/:name/:version", ph.getMavenPackageDetail, rbac.RbacVerbRead)
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/python_packages/:name/:version", ph.getPythonPackageDetail, rbac.RbacVerbRead)
+	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/python_packages/:name", ph.getPythonPackageVersions, rbac.RbacVerbRead)
 }
 
 // ListPackages godoc
@@ -300,6 +301,62 @@ func (ph *PackageHandler) getMavenPackageDetail(c echo.Context) error {
 		Name:    name,
 		Version: version,
 		Builds:  builds,
+	})
+}
+
+// GetPythonPackageVersions godoc
+// @Summary      Get Python Package Versions
+// @ID           getPythonPackageVersions
+// @Description  Get metadata and distributions for all versions of a Python package by name.
+// @Tags         packages
+// @Param        uuid path string true "Repository UUID"
+// @Param        name path string true "Python package normalized name"
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} api.PythonPackageVersionsResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{uuid}/python_packages/{name} [get]
+func (ph *PackageHandler) getPythonPackageVersions(c echo.Context) error {
+	uuid := c.Param("uuid")
+	name := c.Param("name")
+	ctx := c.Request().Context()
+
+	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
+	}
+
+	if repo.ContentType != config.ContentTypePython {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Repository is not a Python repository")
+	}
+
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.PythonPackageVersionsGet(ctx, repositoryHref, name)
+	if err != nil {
+		if errors.Is(err, tangy.ErrPythonPackageNotFound) {
+			return ce.NewErrorResponse(http.StatusNotFound, "Package not found", err.Error())
+		}
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package versions", err.Error())
+	}
+
+	versions := make([]api.PythonPackageDetailResponse, len(tangResp))
+	for i, detail := range tangResp {
+		versions[i] = mapPythonPackageDetailToAPI(detail)
+	}
+
+	return c.JSON(http.StatusOK, api.PythonPackageVersionsResponse{
+		Name:     name,
+		Versions: versions,
 	})
 }
 

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -652,6 +652,168 @@ func (suite *PackagesSuite) TestGetPackageDetailEmptyBuilds() {
 	assert.Equal(t, 0, len(response.Builds))
 }
 
+func (suite *PackagesSuite) TestGetPythonPackageVersionsSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "django"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	tangDetails := []tangy.PythonPackageDetail{
+		{
+			Name:           "Django",
+			NameNormalized: packageName,
+			Version:        "4.2",
+			Summary:        "A high-level Python web framework",
+			LastUpdated:    "2024-01-01T12:00:00Z",
+			Versions:       []string{"4.2", "5.0"},
+			Distributions: []tangy.PythonDistributionListItem{
+				{
+					Filename:    "django-4.2-py3-none-any.whl",
+					PackageType: "bdist_wheel",
+				},
+			},
+		},
+		{
+			Name:           "Django",
+			NameNormalized: packageName,
+			Version:        "5.0",
+			Summary:        "A high-level Python web framework",
+			LastUpdated:    "2024-02-01T12:00:00Z",
+			Versions:       []string{"4.2", "5.0"},
+			Distributions: []tangy.PythonDistributionListItem{
+				{
+					Filename:    "django-5.0-py3-none-any.whl",
+					PackageType: "bdist_wheel",
+				},
+			},
+		},
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageVersionsGet", test.MockCtx(), repositoryHref, packageName).Return(tangDetails, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s", api.FullRootPath(), repoUUID, packageName)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PythonPackageVersionsResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, packageName, response.Name)
+	require.Len(t, response.Versions, 2)
+	assert.Equal(t, "4.2", response.Versions[0].Version)
+	assert.Equal(t, "5.0", response.Versions[1].Version)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageVersionsNonPythonRepo() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440001"
+
+	repo := api.RepositoryResponse{
+		UUID:        repoUUID,
+		ContentType: config.ContentTypeMaven,
+	}
+
+	orgID := config.LightwellOrg
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s", api.FullRootPath(), repoUUID, "django")
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageVersionsNotFound() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "nonexistent"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageVersionsGet", test.MockCtx(), repositoryHref, packageName).Return([]tangy.PythonPackageDetail{}, tangy.ErrPythonPackageNotFound)
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s", api.FullRootPath(), repoUUID, packageName)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *PackagesSuite) TestGetPythonPackageVersionsTangError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440002"
+	basePath := "python/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/python/python/018c1c95-4281-76eb-b277-842cbad524f4/"
+	domainName := "test-domain"
+	packageName := "django"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypePython,
+		PublishedDistBasePath: basePath,
+	}
+
+	dist := zest.DistributionResponse{}
+	dist.SetRepository(repositoryHref)
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("FindGenericDistributionByBasePath", test.MockCtx(), basePath).Return(&dist, nil)
+	suite.tangClient.On("PythonPackageVersionsGet", test.MockCtx(), repositoryHref, packageName).Return([]tangy.PythonPackageDetail{}, fmt.Errorf("failed to fetch package versions"))
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s", api.FullRootPath(), repoUUID, packageName)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
 func (suite *PackagesSuite) TestGetPythonPackageDetailSuccess() {
 	t := suite.T()
 	repoUUID := "550e8400-e29b-41d4-a716-446655440002"

--- a/test/integration/python_packages_test.go
+++ b/test/integration/python_packages_test.go
@@ -160,6 +160,37 @@ func (s *PythonPackagesSuite) TestPythonPackagesAPI() {
 	assert.True(t, foundVersion)
 }
 
+func (s *PythonPackagesSuite) TestPythonPackageVersionsAPI() {
+	orgId := fmt.Sprintf("PythonPackages-%v", rand.Int())
+
+	s.identity = test_handler.MockIdentity
+	s.identity.Identity.OrgID = orgId
+
+	t := s.T()
+
+	repo := s.createPythonRepository(config.LightwellOrg)
+	versions := s.getPackageVersions(repo.UUID, testPythonPackageName)
+
+	assert.Equal(t, testPythonPackageName, versions.Name)
+	require.NotEmpty(t, versions.Versions)
+
+	for _, detail := range versions.Versions {
+		assert.Equal(t, testPythonPackageName, detail.Name)
+		assert.NotEmpty(t, detail.Version)
+		assert.NotEmpty(t, detail.LastUpdated)
+		require.NotEmpty(t, detail.Distributions)
+
+		for _, dist := range detail.Distributions {
+			assert.NotEmpty(t, dist.Filename)
+			assert.Contains(t, dist.Filename, detail.Version)
+			assert.NotEmpty(t, dist.PackageType)
+			assert.NotEmpty(t, dist.Sha256)
+			assert.NotZero(t, dist.Size)
+			assert.NotEmpty(t, dist.CreatedAt)
+		}
+	}
+}
+
 func (s *PythonPackagesSuite) TestPythonPackageDetailAPI() {
 	orgId := fmt.Sprintf("PythonPackages-%v", rand.Int())
 
@@ -324,6 +355,25 @@ func (s *PythonPackagesSuite) listPackages(repoUUID string) api.PackageResponse 
 	assert.Equal(t, http.StatusOK, code, string(body))
 
 	var resp api.PackageResponse
+	err = json.Unmarshal(body, &resp)
+	require.NoError(t, err)
+
+	return resp
+}
+
+func (s *PythonPackagesSuite) getPackageVersions(repoUUID, name string) api.PythonPackageVersionsResponse {
+	t := s.T()
+
+	path := fmt.Sprintf("%s/repositories/%s/python_packages/%s", api.FullRootPath(), repoUUID, name)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedCustomIdentity(t, s.identity))
+	req.Header.Set("Content-Type", "application/json")
+
+	code, body, err := s.serveRouter(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code, string(body))
+
+	var resp api.PythonPackageVersionsResponse
 	err = json.Unmarshal(body, &resp)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR:
- Adds GET `/repositories/{uuid}/python_packages/{name}` for all versions of a Python package
- Adds `PythonPackageVersionsResponse` and OpenAPI docs for the new endpoint
- Adds unit and integration tests for the new handler
