### PR TITLE
HMS-10967: update maven package versions lists metadata

### DIFF
--- a/_playwright-tests/test-utils/src/client/models/ApiMavenPackageVersionsResponse.ts
+++ b/_playwright-tests/test-utils/src/client/models/ApiMavenPackageVersionsResponse.ts
@@ -13,13 +13,13 @@
  */
 
 import { mapValues } from '../runtime';
-import type { ApiReleaseInfo } from './ApiReleaseInfo';
+import type { ApiMavenPackageDetailResponse } from './ApiMavenPackageDetailResponse';
 import {
-    ApiReleaseInfoFromJSON,
-    ApiReleaseInfoFromJSONTyped,
-    ApiReleaseInfoToJSON,
-    ApiReleaseInfoToJSONTyped,
-} from './ApiReleaseInfo';
+    ApiMavenPackageDetailResponseFromJSON,
+    ApiMavenPackageDetailResponseFromJSONTyped,
+    ApiMavenPackageDetailResponseToJSON,
+    ApiMavenPackageDetailResponseToJSONTyped,
+} from './ApiMavenPackageDetailResponse';
 
 /**
  * 
@@ -41,10 +41,10 @@ export interface ApiMavenPackageVersionsResponse {
     name?: string;
     /**
      * 
-     * @type {Array<ApiReleaseInfo>}
+     * @type {Array<ApiMavenPackageDetailResponse>}
      * @memberof ApiMavenPackageVersionsResponse
      */
-    versions?: Array<ApiReleaseInfo>;
+    versions?: Array<ApiMavenPackageDetailResponse>;
 }
 
 /**
@@ -66,7 +66,7 @@ export function ApiMavenPackageVersionsResponseFromJSONTyped(json: any, ignoreDi
         
         'group': json['group'] == null ? undefined : json['group'],
         'name': json['name'] == null ? undefined : json['name'],
-        'versions': json['versions'] == null ? undefined : ((json['versions'] as Array<any>).map(ApiReleaseInfoFromJSON)),
+        'versions': json['versions'] == null ? undefined : ((json['versions'] as Array<any>).map(ApiMavenPackageDetailResponseFromJSON)),
     };
 }
 
@@ -83,7 +83,7 @@ export function ApiMavenPackageVersionsResponseToJSONTyped(value?: ApiMavenPacka
         
         'group': value['group'],
         'name': value['name'],
-        'versions': value['versions'] == null ? undefined : ((value['versions'] as Array<any>).map(ApiReleaseInfoToJSON)),
+        'versions': value['versions'] == null ? undefined : ((value['versions'] as Array<any>).map(ApiMavenPackageDetailResponseToJSON)),
     };
 }
 

--- a/api/docs.go
+++ b/api/docs.go
@@ -4394,7 +4394,7 @@ const docTemplate = `{
                 "versions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/api.ReleaseInfo"
+                        "$ref": "#/definitions/api.MavenPackageDetailResponse"
                     }
                 }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -296,7 +296,7 @@
                     },
                     "versions": {
                         "items": {
-                            "$ref": "#/components/schemas/api.ReleaseInfo"
+                            "$ref": "#/components/schemas/api.MavenPackageDetailResponse"
                         },
                         "type": "array"
                     }

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -30,9 +30,9 @@ type ReleaseInfo struct {
 
 // MavenPackageVersionsResponse represents the response for listing all versions of a Maven package.
 type MavenPackageVersionsResponse struct {
-	Group    string        `json:"group"`
-	Name     string        `json:"name"`
-	Versions []ReleaseInfo `json:"versions"`
+	Group    string                       `json:"group"`
+	Name     string                       `json:"name"`
+	Versions []MavenPackageDetailResponse `json:"versions"`
 }
 
 // MavenPackageDetailResponse represents the detail response for a specific Maven package.

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -266,12 +266,32 @@ func (ph *PackageHandler) listMavenPackageVersions(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package versions", err.Error())
 	}
 
-	versions := make([]api.ReleaseInfo, len(tangResp.Results))
+	versions := make([]api.MavenPackageDetailResponse, len(tangResp.Results))
 	for i, item := range tangResp.Results {
-		versions[i] = api.ReleaseInfo{
-			Version:   item.Version,
-			Release:   item.Release,
-			CreatedAt: item.CreatedAt,
+		versions[i] = api.MavenPackageDetailResponse{
+			Group:   groupID,
+			Name:    name,
+			Version: item.Version,
+			Builds: []api.ReleaseInfo{
+				{
+					Version:   item.Version,
+					Release:   item.Release,
+					CreatedAt: item.CreatedAt,
+				},
+			},
+		}
+	}
+
+	if len(tangResp.Results) > 0 {
+		summary, license, projectURL, author, err := ph.mavenPackageMetadata(ctx, groupID, name, tangResp.Results[0].Version)
+		if err != nil {
+			return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package metadata from maven", err.Error())
+		}
+		for i := range versions {
+			versions[i].Summary = summary
+			versions[i].License = license
+			versions[i].ProjectURL = projectURL
+			versions[i].Author = author
 		}
 	}
 

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -242,6 +242,13 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsSuccess() {
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
 	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(buildListResp, nil)
+	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), packageName).Return(&models.MavenPackage{
+		Name:       packageName,
+		Summary:    utils.Ptr("A reactive library."),
+		License:    utils.Ptr("Apache-2.0"),
+		ProjectURL: utils.Ptr("https://smallrye.io/smallrye-mutiny/"),
+		Author:     utils.Ptr("SmallRye"),
+	}, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s", api.FullRootPath(), repoUUID, groupID, packageName)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -258,9 +265,14 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsSuccess() {
 	assert.Equal(t, packageName, response.Name)
 	assert.Equal(t, 2, len(response.Versions))
 	assert.Equal(t, "3.16.0", response.Versions[0].Version)
-	assert.Equal(t, "rhlw-4000", response.Versions[0].Release)
+	assert.Equal(t, "rhlw-4000", response.Versions[0].Builds[0].Release)
+	require.NotNil(t, response.Versions[0].Summary)
+	assert.Equal(t, "A reactive library.", *response.Versions[0].Summary)
+	assert.Equal(t, "Apache-2.0", *response.Versions[0].License)
 	assert.Equal(t, "3.15.0", response.Versions[1].Version)
-	assert.Equal(t, "rhlw-3001", response.Versions[1].Release)
+	assert.Equal(t, "rhlw-3001", response.Versions[1].Builds[0].Release)
+	require.NotNil(t, response.Versions[1].Summary)
+	assert.Equal(t, "A reactive library.", *response.Versions[1].Summary)
 }
 
 func (suite *PackagesSuite) TestListMavenPackageVersionsNonMavenRepo() {

--- a/test/integration/maven_packages_test.go
+++ b/test/integration/maven_packages_test.go
@@ -158,7 +158,8 @@ func (s *MavenPackagesSuite) TestMavenPackagesAPI() {
 	require.NotEmpty(t, versions.Versions)
 	for _, v := range versions.Versions {
 		assert.NotEmpty(t, v.Version)
-		assert.NotEmpty(t, v.CreatedAt)
+		require.NotEmpty(t, v.Builds)
+		assert.NotEmpty(t, v.Builds[0].CreatedAt)
 	}
 
 	// Test the package detail endpoint using data from the list


### PR DESCRIPTION
## Summary
Adds the new maven central metadata fields to the MavenPackageVersionsList

## Testing steps
1. Create a maven repository `./scripts/create_maven_repo.sh`
2. GET `/repositories/:uuid/org.apache.httpcomponents/httpclient` to see the new fields