### PR TITLE
HMS-10984: updates ContentCountsForType to use new metrics methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.24
+	github.com/content-services/tang v0.0.25
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,12 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.23 h1:mGyvoTpA/ql5edLmGAMYqFclG88LoFAbDgK49BjFzoI=
-github.com/content-services/tang v0.0.23/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
-github.com/content-services/tang v0.0.22 h1:L1k7iIZo/pfp4GBkTO29+Nk/ZgobLE+qJ0fTR9jfdIA=
-github.com/content-services/tang v0.0.22/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
-github.com/content-services/tang v0.0.24 h1:gcPyIxKGc+QXmGR2uBfzE/kl4dqrldVKyI0RPKj45Gc=
-github.com/content-services/tang v0.0.24/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
+github.com/content-services/tang v0.0.25 h1:RYvH9NHkYYqkORxLNLFkvT7N5/g23YLU8fhKkOvASHY=
+github.com/content-services/tang v0.0.25/go.mod h1:Kny+gBiKxmn4YNzDP3zaRG/QrD8CzkKs+9Xk+Ivqogs=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.6.1782694749 h1:ViOrtIQANAjf/BcDduJa2i/Um/BUYJrjN2P4df/+QGQ=

--- a/pkg/external_repos/content_counts.go
+++ b/pkg/external_repos/content_counts.go
@@ -91,25 +91,11 @@ func GetContentCountsWithCache(ctx context.Context, pulpClient pulp_client.PulpC
 func ContentCountsForType(ctx context.Context, tang tangy.Tangy, repoHref string, contentType string) (int, int, error) {
 	switch contentType {
 	case config.ContentTypePython:
-		pkgResp, err := tang.PythonPackageList(ctx, repoHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Limit: 1})
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to get Python package list: %w", err)
-		}
-		fullPython, err := tang.PythonPackageVersionsGet(ctx, repoHref, "")
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to get Python package versions: %w", err)
-		}
-		return pkgResp.Total, len(fullPython), nil
+		m, err := tang.PythonRepositoryMetrics(ctx, repoHref)
+		return m.PackageCount, m.BuildCount, err
 	case config.ContentTypeMaven:
-		pkgResp, err := tang.MavenPackageList(ctx, repoHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1})
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to fetch Maven package list: %w", err)
-		}
-		buildResp, err := tang.MavenBuildList(ctx, repoHref, "", "", "", tangy.PageOptions{Limit: 1})
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to fetch build list for repo %s: %w", repoHref, err)
-		}
-		return pkgResp.Total, buildResp.Total, nil
+		m, err := tang.MavenRepositoryMetrics(ctx, repoHref)
+		return m.PackageCount, m.BuildCount, err
 	default:
 		return 0, 0, fmt.Errorf("unknown content type: %s", contentType)
 	}

--- a/pkg/external_repos/content_counts_test.go
+++ b/pkg/external_repos/content_counts_test.go
@@ -72,10 +72,8 @@ func (s *ContentCountsSuite) TestUpdateContentCountsWithCache_Success() {
 	// First repo - cache miss, fetch from pulp
 	s.mockCache.On("GetContentCounts", s.ctx, domainName, repoUUID1).Return(nil, cache.ErrNotFound)
 	s.mockPulpClient.On("ResolveRepositoryFromBasePath", s.ctx, "/base/path/1").Return(&repoHref1, nil)
-	s.mockTangy.On("MavenPackageList", s.ctx, repoHref1, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenPackageListResponse{Total: 10}, nil)
-	s.mockTangy.On("MavenBuildList", s.ctx, repoHref1, "", "", "", tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenBuildListResponse{Total: 8}, nil)
+	s.mockTangy.On("MavenRepositoryMetrics", s.ctx, repoHref1).
+		Return(tangy.MavenRepositoryMetrics{PackageCount: 10, BuildCount: 8}, nil)
 	s.mockCache.On("SetContentCounts", s.ctx, domainName, repoUUID1, cache.RepoContentCount{
 		Packages: 10,
 		Builds:   8,
@@ -144,10 +142,8 @@ func (s *ContentCountsSuite) TestGetContentCountsWithCache_CacheMiss() {
 
 	s.mockCache.On("GetContentCounts", s.ctx, domainName, repoUUID).Return(nil, cache.ErrNotFound)
 	s.mockPulpClient.On("ResolveRepositoryFromBasePath", s.ctx, "/base/path").Return(&repoHref, nil)
-	s.mockTangy.On("MavenPackageList", s.ctx, repoHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenPackageListResponse{Total: 25}, nil)
-	s.mockTangy.On("MavenBuildList", s.ctx, repoHref, "", "", "", tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenBuildListResponse{Total: 15}, nil)
+	s.mockTangy.On("MavenRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.MavenRepositoryMetrics{PackageCount: 25, BuildCount: 15}, nil)
 	s.mockCache.On("SetContentCounts", s.ctx, domainName, repoUUID, cache.RepoContentCount{
 		Packages: 25,
 		Builds:   15,
@@ -209,10 +205,8 @@ func (s *ContentCountsSuite) TestContentCountsForType_Maven() {
 	t := s.T()
 	repoHref := "test-repo-href"
 
-	s.mockTangy.On("MavenPackageList", s.ctx, repoHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenPackageListResponse{Total: 30}, nil)
-	s.mockTangy.On("MavenBuildList", s.ctx, repoHref, "", "", "", tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenBuildListResponse{Total: 20}, nil)
+	s.mockTangy.On("MavenRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.MavenRepositoryMetrics{PackageCount: 30, BuildCount: 20}, nil)
 
 	pkgCount, buildCount, err := ContentCountsForType(s.ctx, s.mockTangy, repoHref, config.ContentTypeMaven)
 	assert.NoError(t, err)
@@ -224,9 +218,8 @@ func (s *ContentCountsSuite) TestContentCountsForType_Python() {
 	t := s.T()
 	repoHref := "test-repo-href"
 
-	s.mockTangy.On("PythonPackageList", s.ctx, repoHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.PythonPackageListResponse{Total: 42}, nil)
-	s.mockTangy.On("PythonPackageVersionsGet", s.ctx, repoHref, "").Return([]tangy.PythonPackageDetail{{}, {}}, nil)
+	s.mockTangy.On("PythonRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.PythonRepositoryMetrics{PackageCount: 42, BuildCount: 2}, nil)
 
 	pkgCount, buildCount, err := ContentCountsForType(s.ctx, s.mockTangy, repoHref, config.ContentTypePython)
 	assert.NoError(t, err)
@@ -245,46 +238,28 @@ func (s *ContentCountsSuite) TestContentCountsForType_UnknownType() {
 	assert.Equal(t, 0, buildCount)
 }
 
-func (s *ContentCountsSuite) TestContentCountsForType_MavenPackageListError() {
+func (s *ContentCountsSuite) TestContentCountsForType_MavenRepositoryMetricsError() {
 	t := s.T()
 	repoHref := "test-repo-href"
 
-	s.mockTangy.On("MavenPackageList", s.ctx, repoHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenPackageListResponse{}, errors.New("package list error"))
+	s.mockTangy.On("MavenRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.MavenRepositoryMetrics{}, errors.New("repository metrics error"))
 
 	pkgCount, buildCount, err := ContentCountsForType(s.ctx, s.mockTangy, repoHref, config.ContentTypeMaven)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to fetch Maven package list")
 	assert.Equal(t, 0, pkgCount)
 	assert.Equal(t, 0, buildCount)
 }
 
-func (s *ContentCountsSuite) TestContentCountsForType_MavenBuildListError() {
+func (s *ContentCountsSuite) TestContentCountsForType_PythonRepositoryMetricsError() {
 	t := s.T()
 	repoHref := "test-repo-href"
 
-	s.mockTangy.On("MavenPackageList", s.ctx, repoHref, tangy.MavenPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenPackageListResponse{Total: 30}, nil)
-	s.mockTangy.On("MavenBuildList", s.ctx, repoHref, "", "", "", tangy.PageOptions{Limit: 1}).
-		Return(tangy.MavenBuildListResponse{}, errors.New("build list error"))
-
-	pkgCount, buildCount, err := ContentCountsForType(s.ctx, s.mockTangy, repoHref, config.ContentTypeMaven)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to fetch build list")
-	assert.Equal(t, 0, pkgCount)
-	assert.Equal(t, 0, buildCount)
-}
-
-func (s *ContentCountsSuite) TestContentCountsForType_PythonPackageListError() {
-	t := s.T()
-	repoHref := "test-repo-href"
-
-	s.mockTangy.On("PythonPackageList", s.ctx, repoHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.PythonPackageListResponse{}, errors.New("python package list error"))
+	s.mockTangy.On("PythonRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.PythonRepositoryMetrics{}, errors.New("repository metrics error"))
 
 	pkgCount, buildCount, err := ContentCountsForType(s.ctx, s.mockTangy, repoHref, config.ContentTypePython)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get Python package list")
 	assert.Equal(t, 0, pkgCount)
 	assert.Equal(t, 0, buildCount)
 }
@@ -354,9 +329,8 @@ func (s *ContentCountsSuite) TestUpdateContentCountsWithCache_ContinuesOnError()
 	// Second repo - succeeds
 	s.mockPulpClient.On("ResolveRepositoryFromBasePath", s.ctx, "/base/path/2").Return(&repoHref2, nil)
 	s.mockCache.On("GetContentCounts", s.ctx, domainName, repoUUID2).Return(nil, cache.ErrNotFound)
-	s.mockTangy.On("PythonPackageList", s.ctx, repoHref2, tangy.PythonPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.PythonPackageListResponse{Total: 10}, nil)
-	s.mockTangy.On("PythonPackageVersionsGet", s.ctx, repoHref2, "").Return([]tangy.PythonPackageDetail{{}, {}}, nil)
+	s.mockTangy.On("PythonRepositoryMetrics", s.ctx, repoHref2).
+		Return(tangy.PythonRepositoryMetrics{PackageCount: 10, BuildCount: 2}, nil)
 
 	s.mockCache.On("SetContentCounts", s.ctx, domainName, repoUUID2, cache.RepoContentCount{
 		Packages: 10,
@@ -383,9 +357,8 @@ func (s *ContentCountsSuite) TestGetContentCountsWithCache_CacheReadError() {
 
 	s.mockCache.On("GetContentCounts", s.ctx, domainName, repoUUID).Return(nil, errors.New("cache read error"))
 	s.mockPulpClient.On("ResolveRepositoryFromBasePath", s.ctx, "/base/path").Return(&repoHref, nil)
-	s.mockTangy.On("PythonPackageList", s.ctx, repoHref, tangy.PythonPackageListFilters{}, tangy.PageOptions{Limit: 1}).
-		Return(tangy.PythonPackageListResponse{Total: 5}, nil)
-	s.mockTangy.On("PythonPackageVersionsGet", s.ctx, repoHref, "").Return([]tangy.PythonPackageDetail{{}, {}}, nil)
+	s.mockTangy.On("PythonRepositoryMetrics", s.ctx, repoHref).
+		Return(tangy.PythonRepositoryMetrics{PackageCount: 5, BuildCount: 2}, nil)
 	s.mockCache.On("SetContentCounts", s.ctx, domainName, repoUUID, mock.Anything).Return(nil)
 
 	pkgCount, buildCount, updated, err := GetContentCountsWithCache(s.ctx, s.mockPulpClient, s.mockTangy, s.mockCache, domainName, repo)

--- a/test/integration/maven_packages_test.go
+++ b/test/integration/maven_packages_test.go
@@ -434,8 +434,6 @@ func (s *MavenPackagesSuite) TestContentCountsForMavenRepository() {
 		"/avalon-util/avalon-util-exception/1.0.0/avalon-util-exception-1.0.0.pom",
 	})
 
-	time.Sleep(5 * time.Second)
-
 	s.addCachedContent(mavenRepo)
 
 	// Get domain and pulp client

--- a/test/integration/python_packages_test.go
+++ b/test/integration/python_packages_test.go
@@ -430,6 +430,6 @@ func (s *PythonPackagesSuite) TestContentCountsForPythonRepository() {
 	// Verify the repository was updated in the database
 	updatedRepo, err := s.dao.RepositoryConfig.Fetch(s.ctx, repo.OrgID, repo.UUID)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, updatedRepo.PackageCount, 1, "Package count should be updated in database")
-	assert.GreaterOrEqual(t, updatedRepo.BuildCount, 1, "Build count should be updated in database")
+	assert.Equal(t, 1, updatedRepo.PackageCount, "Package count should be updated in database")
+	assert.Equal(t, 1, updatedRepo.BuildCount, "Build count should be updated in database")
 }


### PR DESCRIPTION
This PR:
- Switches `ContentCountsForType` to `PythonRepositoryMetrics` and `MavenRepositoryMetrics`
- Bumps `tang` to `v0.0.25`
- Updates Python/Maven integration tests for exact content count assertions