### PR TITLE
HMS-10971: add npm packages support for lightwell

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1749,6 +1749,143 @@ const docTemplate = `{
                 }
             }
         },
+        "/repositories/{uuid}/npm_packages/{scope}/{name}": {
+            "get": {
+                "description": "Get tarball info for all versions of an npm package by scope and name. Use \"-\" as the scope for unscoped packages.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "packages"
+                ],
+                "summary": "Get NPM Package Versions",
+                "operationId": "getNpmPackageVersions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository UUID",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "NPM package scope (e.g. @types). Use - for unscoped packages.",
+                        "name": "scope",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "NPM package name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.NpmPackageVersionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/repositories/{uuid}/npm_packages/{scope}/{name}/{version}": {
+            "get": {
+                "description": "Get tarball info for a specific npm package by scope, name, and version. Use \"-\" as the scope for unscoped packages.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "packages"
+                ],
+                "summary": "Get NPM Package Detail",
+                "operationId": "getNpmPackageDetail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Repository UUID",
+                        "name": "uuid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "NPM package scope (e.g. @types). Use - for unscoped packages.",
+                        "name": "scope",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "NPM package name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "NPM package version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.NpmPackageDetailResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/repositories/{uuid}/package_groups": {
             "get": {
                 "description": "List package groups in a repository.",
@@ -1832,7 +1969,7 @@ const docTemplate = `{
         },
         "/repositories/{uuid}/packages": {
             "get": {
-                "description": "List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.",
+                "description": "List packages for Maven (group and name), Python (name), or npm (scope and name) repositories. Returns empty results for other content types.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1866,7 +2003,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name.",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python and npm, search term can include name (including scoped names like @types/).",
                         "name": "search",
                         "in": "query"
                     }
@@ -4396,6 +4533,72 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/api.MavenPackageDetailResponse"
                     }
+                }
+            }
+        },
+        "api.NpmPackageDetailResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "latest_versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.ReleaseInfo"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "tarball": {
+                    "$ref": "#/definitions/api.NpmTarball"
+                },
+                "upstream_versions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.NpmPackageVersionsResponse": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.NpmPackageDetailResponse"
+                    }
+                }
+            }
+        },
+        "api.NpmTarball": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string"
+                },
+                "relative_path": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -303,6 +303,72 @@
                 },
                 "type": "object"
             },
+            "api.NpmPackageDetailResponse": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "latest_versions": {
+                        "items": {
+                            "$ref": "#/components/schemas/api.ReleaseInfo"
+                        },
+                        "type": "array"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "scope": {
+                        "type": "string"
+                    },
+                    "tarball": {
+                        "$ref": "#/components/schemas/api.NpmTarball"
+                    },
+                    "upstream_versions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "version": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.NpmPackageVersionsResponse": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "scope": {
+                        "type": "string"
+                    },
+                    "versions": {
+                        "items": {
+                            "$ref": "#/components/schemas/api.NpmPackageDetailResponse"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "api.NpmTarball": {
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "relative_path": {
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
             "api.PackageItem": {
                 "properties": {
                     "group": {
@@ -4665,6 +4731,177 @@
                 ]
             }
         },
+        "/repositories/{uuid}/npm_packages/{scope}/{name}": {
+            "get": {
+                "description": "Get tarball info for all versions of an npm package by scope and name. Use \"-\" as the scope for unscoped packages.",
+                "operationId": "getNpmPackageVersions",
+                "parameters": [
+                    {
+                        "description": "Repository UUID",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "NPM package scope (e.g. @types). Use - for unscoped packages.",
+                        "in": "path",
+                        "name": "scope",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "NPM package name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.NpmPackageVersionsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get NPM Package Versions",
+                "tags": [
+                    "packages"
+                ]
+            }
+        },
+        "/repositories/{uuid}/npm_packages/{scope}/{name}/{version}": {
+            "get": {
+                "description": "Get tarball info for a specific npm package by scope, name, and version. Use \"-\" as the scope for unscoped packages.",
+                "operationId": "getNpmPackageDetail",
+                "parameters": [
+                    {
+                        "description": "Repository UUID",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "NPM package scope (e.g. @types). Use - for unscoped packages.",
+                        "in": "path",
+                        "name": "scope",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "NPM package name",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "NPM package version",
+                        "in": "path",
+                        "name": "version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.NpmPackageDetailResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get NPM Package Detail",
+                "tags": [
+                    "packages"
+                ]
+            }
+        },
         "/repositories/{uuid}/package_groups": {
             "get": {
                 "description": "List package groups in a repository.",
@@ -4772,7 +5009,7 @@
         },
         "/repositories/{uuid}/packages": {
             "get": {
-                "description": "List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.",
+                "description": "List packages for Maven (group and name), Python (name), or npm (scope and name) repositories. Returns empty results for other content types.",
                 "operationId": "listPackages",
                 "parameters": [
                     {
@@ -4801,7 +5038,7 @@
                         }
                     },
                     {
-                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name.",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python and npm, search term can include name (including scoped names like @types/).",
                         "in": "query",
                         "name": "search",
                         "schema": {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.27
+	github.com/content-services/tang v0.0.29
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.27 h1:qxNbJAz3Gh5FnRh/LfKh9zEDjIJJklNkDXUc05iowNg=
-github.com/content-services/tang v0.0.27/go.mod h1:Z969TdEJaoRHxhpZ89Gi25RFVj1dBjEiFzhsGppyz8g=
+github.com/content-services/tang v0.0.29 h1:+RpzxOFlIbAgts7Ii0rIiNMI0Lnj9FePfmuoUS37lt8=
+github.com/content-services/tang v0.0.29/go.mod h1:Z969TdEJaoRHxhpZ89Gi25RFVj1dBjEiFzhsGppyz8g=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.7.1783082453 h1:mZ8LExJlcMcoIUCv7eW+qQwZ9in18byKtuA99WWG0+M=

--- a/pkg/api/packages.go
+++ b/pkg/api/packages.go
@@ -83,3 +83,29 @@ type PythonPackageDetailResponse struct {
 	ProjectURL       string               `json:"project_url"`
 	Distributions    []PythonDistribution `json:"distributions"`
 }
+
+// NpmTarball represents tarball metadata for an npm package version.
+type NpmTarball struct {
+	RelativePath string `json:"relative_path"`
+	Filename     string `json:"filename"`
+	Sha256       string `json:"sha256"`
+	Size         int64  `json:"size"`
+}
+
+// NpmPackageVersionsResponse represents details for all versions of an npm package.
+type NpmPackageVersionsResponse struct {
+	Scope    string                     `json:"scope"`
+	Name     string                     `json:"name"`
+	Versions []NpmPackageDetailResponse `json:"versions"`
+}
+
+// NpmPackageDetailResponse represents the detail response for a specific npm package.
+type NpmPackageDetailResponse struct {
+	Scope            string        `json:"scope"`
+	Name             string        `json:"name"`
+	Version          string        `json:"version"`
+	CreatedAt        string        `json:"created_at"`
+	Tarball          NpmTarball    `json:"tarball"`
+	UpstreamVersions []string      `json:"upstream_versions"`
+	LatestVersions   []ReleaseInfo `json:"latest_versions"`
+}

--- a/pkg/config/value_constraints.go
+++ b/pkg/config/value_constraints.go
@@ -16,6 +16,7 @@ const (
 	ContentTypeRpm    = "rpm"
 	ContentTypeMaven  = "maven"
 	ContentTypePython = "python"
+	ContentTypeNpm    = "npm"
 )
 
 const (

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
@@ -39,17 +40,19 @@ func RegisterPackageRoutes(engine *echo.Group, daoReg *dao.DaoRegistry, tangClie
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/maven_packages/:group/:name/:version", ph.getMavenPackageDetail, rbac.RbacVerbRead)
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/python_packages/:name/:version", ph.getPythonPackageDetail, rbac.RbacVerbRead)
 	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/python_packages/:name", ph.getPythonPackageVersions, rbac.RbacVerbRead)
+	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/npm_packages/:scope/:name", ph.getNpmPackageVersions, rbac.RbacVerbRead)
+	addRepoRoute(engine, http.MethodGet, "/repositories/:uuid/npm_packages/:scope/:name/:version", ph.getNpmPackageDetail, rbac.RbacVerbRead)
 }
 
 // ListPackages godoc
 // @Summary      List Packages
 // @ID           listPackages
-// @Description  List packages for Maven (group and name) or Python (name) repositories. Returns empty results for other content types.
+// @Description  List packages for Maven (group and name), Python (name), or npm (scope and name) repositories. Returns empty results for other content types.
 // @Tags         packages
 // @Param        uuid path string true "Repository UUID"
 // @Param        offset query int false "Starting point for pagination. Default: 0"
 // @Param        limit query int false "Number of items per page. Default: 100"
-// @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python, search term can include name."
+// @Param        search query string false "Term to filter and retrieve items that match the specified search criteria. For Maven, search term can include name or group. For Python and npm, search term can include name (including scoped names like @types/)."
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.PackageResponse
@@ -79,6 +82,8 @@ func (ph *PackageHandler) listPackages(c echo.Context) error {
 		return ph.listMavenPackages(c, ctx, repo, filterData, pageData)
 	case config.ContentTypePython:
 		return ph.listPythonPackages(c, ctx, repo, filterData, pageData)
+	case config.ContentTypeNpm:
+		return ph.listNpmPackages(c, ctx, repo, filterData, pageData)
 	default:
 		return c.JSON(http.StatusOK, api.PackageResponse{
 			Results: []api.PackageItem{},
@@ -556,5 +561,209 @@ func mapPythonPackageDetailToAPI(tangDetail tangy.PythonPackageDetail) api.Pytho
 		UpstreamVersions: tangDetail.Versions,
 		ProjectURL:       tangDetail.ProjectURL,
 		Distributions:    distributions,
+	}
+}
+
+func npmPackageName(scope, name string) string {
+	if scope == "" || scope == "-" {
+		return name
+	}
+	return scope + "/" + name
+}
+
+func parseNpmPackageName(fullName string) (scope, name string) {
+	if strings.HasPrefix(fullName, "@") {
+		parts := strings.SplitN(fullName, "/", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1]
+		}
+	}
+	return "-", fullName
+}
+
+func (ph *PackageHandler) listNpmPackages(c echo.Context, ctx context.Context, repo api.RepositoryResponse, filterData string, pageData api.PaginationData) error {
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.NpmPackageList(ctx, repositoryHref, tangy.NpmPackageListFilters{Search: filterData}, tangy.PageOptions{
+		Offset: pageData.Offset,
+		Limit:  pageData.Limit,
+	})
+	if err != nil {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving packages", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, mapNpmPackagesToAPI(tangResp))
+}
+
+func mapNpmPackagesToAPI(tangResp tangy.NpmPackageListResponse) api.PackageResponse {
+	results := make([]api.PackageItem, len(tangResp.Results))
+	for i, item := range tangResp.Results {
+		scope, name := parseNpmPackageName(item.Name)
+		releases := make([]api.ReleaseInfo, len(item.LatestVersions))
+		for j, ver := range item.LatestVersions {
+			releases[j] = api.ReleaseInfo{
+				Version:   ver.Version,
+				CreatedAt: ver.CreatedAt,
+			}
+		}
+
+		results[i] = api.PackageItem{
+			Group:          scope,
+			Name:           name,
+			Versions:       item.Versions,
+			LatestReleases: releases,
+		}
+	}
+
+	return api.PackageResponse{
+		Results: results,
+		Total:   tangResp.Total,
+		Limit:   tangResp.Limit,
+		Offset:  tangResp.Offset,
+	}
+}
+
+// GetNpmPackageVersions godoc
+// @Summary      Get NPM Package Versions
+// @ID           getNpmPackageVersions
+// @Description  Get tarball info for all versions of an npm package by scope and name. Use "-" as the scope for unscoped packages.
+// @Tags         packages
+// @Param        uuid path string true "Repository UUID"
+// @Param        scope path string true "NPM package scope (e.g. @types). Use - for unscoped packages."
+// @Param        name path string true "NPM package name"
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} api.NpmPackageVersionsResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{uuid}/npm_packages/{scope}/{name} [get]
+func (ph *PackageHandler) getNpmPackageVersions(c echo.Context) error {
+	uuid := c.Param("uuid")
+	scope := c.Param("scope")
+	name := c.Param("name")
+	packageName := npmPackageName(scope, name)
+	ctx := c.Request().Context()
+
+	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
+	}
+
+	if repo.ContentType != config.ContentTypeNpm {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Repository is not an npm repository")
+	}
+
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.NpmPackageVersionsGet(ctx, repositoryHref, packageName)
+	if err != nil {
+		if errors.Is(err, tangy.ErrNpmPackageNotFound) {
+			return ce.NewErrorResponse(http.StatusNotFound, "Package not found", err.Error())
+		}
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package versions", err.Error())
+	}
+
+	versions := make([]api.NpmPackageDetailResponse, len(tangResp))
+	for i, detail := range tangResp {
+		versions[i] = mapNpmPackageDetailToAPI(detail, scope, name)
+	}
+
+	return c.JSON(http.StatusOK, api.NpmPackageVersionsResponse{
+		Scope:    scope,
+		Name:     name,
+		Versions: versions,
+	})
+}
+
+// GetNpmPackageDetail godoc
+// @Summary      Get NPM Package Detail
+// @ID           getNpmPackageDetail
+// @Description  Get tarball info for a specific npm package by scope, name, and version. Use "-" as the scope for unscoped packages.
+// @Tags         packages
+// @Param        uuid path string true "Repository UUID"
+// @Param        scope path string true "NPM package scope (e.g. @types). Use - for unscoped packages."
+// @Param        name path string true "NPM package name"
+// @Param        version path string true "NPM package version"
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} api.NpmPackageDetailResponse
+// @Failure      400 {object} ce.ErrorResponse
+// @Failure      404 {object} ce.ErrorResponse
+// @Failure      500 {object} ce.ErrorResponse
+// @Router       /repositories/{uuid}/npm_packages/{scope}/{name}/{version} [get]
+func (ph *PackageHandler) getNpmPackageDetail(c echo.Context) error {
+	uuid := c.Param("uuid")
+	scope := c.Param("scope")
+	name := c.Param("name")
+	version := c.Param("version")
+	packageName := npmPackageName(scope, name)
+	ctx := c.Request().Context()
+
+	repo, err := ph.DaoRegistry.RepositoryConfig.Fetch(ctx, config.LightwellOrg, uuid)
+	if err != nil {
+		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error fetching repository", err.Error())
+	}
+
+	if repo.ContentType != config.ContentTypeNpm {
+		return ce.NewErrorResponse(http.StatusBadRequest, "Bad Request", "Repository is not an npm repository")
+	}
+
+	if repo.PublishedDistBasePath == "" {
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Internal Server Error", "Repository distribution base path not available")
+	}
+
+	repositoryHref, err := ph.resolveRepositoryHref(ctx, config.LightwellOrg, repo.PublishedDistBasePath, repo.UUID)
+	if err != nil {
+		return ph.repositoryHrefErrorResponse(err)
+	}
+
+	tangResp, err := ph.TangClient.NpmPackageGet(ctx, repositoryHref, packageName, version)
+	if err != nil {
+		if errors.Is(err, tangy.ErrNpmPackageNotFound) {
+			return ce.NewErrorResponse(http.StatusNotFound, "Package not found", err.Error())
+		}
+		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package detail", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, mapNpmPackageDetailToAPI(tangResp, scope, name))
+}
+
+func mapNpmPackageDetailToAPI(tangDetail tangy.NpmPackageDetail, scope, name string) api.NpmPackageDetailResponse {
+	latestVersions := make([]api.ReleaseInfo, len(tangDetail.LatestVersions))
+	for i, ver := range tangDetail.LatestVersions {
+		latestVersions[i] = api.ReleaseInfo{
+			Version:   ver.Version,
+			CreatedAt: ver.CreatedAt,
+		}
+	}
+
+	return api.NpmPackageDetailResponse{
+		Scope:     scope,
+		Name:      name,
+		Version:   tangDetail.Version,
+		CreatedAt: tangDetail.CreatedAt,
+		Tarball: api.NpmTarball{
+			RelativePath: tangDetail.Tarball.RelativePath,
+			Filename:     tangDetail.Tarball.Filename,
+			Sha256:       tangDetail.Tarball.Sha256,
+			Size:         tangDetail.Tarball.Size,
+		},
+		UpstreamVersions: tangDetail.Versions,
+		LatestVersions:   latestVersions,
 	}
 }

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -1310,3 +1310,479 @@ func (suite *PackagesSuite) TestGetPythonPackageDetailTangError() {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusInternalServerError, code)
 }
+
+func (suite *PackagesSuite) TestListPackagesNpmSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440009"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	tangResp := tangy.NpmPackageListResponse{
+		Results: []tangy.NpmPackageListItem{
+			{
+				Name:     "@types/is-odd",
+				Versions: []string{"3.0.0"},
+				LatestVersions: []tangy.NpmVersionInfo{
+					{
+						Version:   "3.0.0",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  100,
+		Offset: 0,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageList", test.MockCtx(), repositoryHref, tangy.NpmPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PackageResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response.Results))
+	assert.Equal(t, "@types", response.Results[0].Group)
+	assert.Equal(t, "is-odd", response.Results[0].Name)
+	assert.Equal(t, 1, len(response.Results[0].Versions))
+	assert.Equal(t, 1, len(response.Results[0].LatestReleases))
+	assert.Equal(t, "3.0.0", response.Results[0].LatestReleases[0].Version)
+}
+
+func (suite *PackagesSuite) TestListPackagesNpmWithFilter() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440010"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	search := "@types/"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	tangResp := tangy.NpmPackageListResponse{
+		Results: []tangy.NpmPackageListItem{
+			{
+				Name:     "@types/is-odd",
+				Versions: []string{"3.0.0"},
+				LatestVersions: []tangy.NpmVersionInfo{
+					{
+						Version:   "3.0.0",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+				},
+			},
+		},
+		Total:  1,
+		Limit:  100,
+		Offset: 0,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageList", test.MockCtx(), repositoryHref, tangy.NpmPackageListFilters{Search: search}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangResp, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0&search=%s", api.FullRootPath(), repoUUID, search)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.PackageResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(response.Results))
+	assert.Equal(t, "@types", response.Results[0].Group)
+	assert.Equal(t, "is-odd", response.Results[0].Name)
+}
+
+func (suite *PackagesSuite) TestListPackagesNpmTangClientError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440011"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), config.LightwellOrg, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), config.LightwellOrg).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageList", test.MockCtx(), repositoryHref, tangy.NpmPackageListFilters{}, tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.NpmPackageListResponse{}, fmt.Errorf("failed to fetch packages"))
+
+	path := fmt.Sprintf("%s/repositories/%s/packages?limit=100&offset=0", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageVersionsSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	scope := "@types"
+	packageName := "is-odd"
+	fullName := "@types/is-odd"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	tangDetails := []tangy.NpmPackageDetail{
+		{
+			Name:      fullName,
+			Version:   "3.0.0",
+			CreatedAt: "2024-01-01T12:00:00Z",
+			Tarball: tangy.NpmTarballInfo{
+				RelativePath: "@types/is-odd/-/is-odd-3.0.0.tgz",
+				Filename:     "is-odd-3.0.0.tgz",
+				Sha256:       "abc123",
+				Size:         1024,
+			},
+			Versions:       []string{"3.0.0"},
+			LatestVersions: []tangy.NpmVersionInfo{{Version: "3.0.0", CreatedAt: "2024-01-01T12:00:00Z"}},
+		},
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageVersionsGet", test.MockCtx(), repositoryHref, fullName).Return(tangDetails, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/%s/%s", api.FullRootPath(), repoUUID, scope, packageName)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.NpmPackageVersionsResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, scope, response.Scope)
+	assert.Equal(t, packageName, response.Name)
+	require.Len(t, response.Versions, 1)
+	assert.Equal(t, "3.0.0", response.Versions[0].Version)
+	assert.Equal(t, "is-odd-3.0.0.tgz", response.Versions[0].Tarball.Filename)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageVersionsUnscopedSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440013"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	packageName := "is-odd"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	tangDetails := []tangy.NpmPackageDetail{
+		{
+			Name:      packageName,
+			Version:   "3.0.1",
+			CreatedAt: "2024-01-01T12:00:00Z",
+			Tarball: tangy.NpmTarballInfo{
+				Filename: "is-odd-3.0.1.tgz",
+			},
+			Versions:       []string{"3.0.1"},
+			LatestVersions: []tangy.NpmVersionInfo{{Version: "3.0.1", CreatedAt: "2024-01-01T12:00:00Z"}},
+		},
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageVersionsGet", test.MockCtx(), repositoryHref, packageName).Return(tangDetails, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/-/%s", api.FullRootPath(), repoUUID, packageName)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.NpmPackageVersionsResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, "-", response.Scope)
+	assert.Equal(t, packageName, response.Name)
+	require.Len(t, response.Versions, 1)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageVersionsNonNpmRepo() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440001"
+
+	repo := api.RepositoryResponse{
+		UUID:        repoUUID,
+		ContentType: config.ContentTypeMaven,
+	}
+
+	orgID := config.LightwellOrg
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageVersionsNotFound() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	fullName := "@types/is-odd"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageVersionsGet", test.MockCtx(), repositoryHref, fullName).Return([]tangy.NpmPackageDetail{}, tangy.ErrNpmPackageNotFound)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageVersionsTangError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	fullName := "@types/is-odd"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageVersionsGet", test.MockCtx(), repositoryHref, fullName).Return([]tangy.NpmPackageDetail{}, fmt.Errorf("failed to fetch package versions"))
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageDetailSuccess() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	scope := "@types"
+	packageName := "is-odd"
+	packageVersion := "3.0.0"
+	fullName := "@types/is-odd"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	tangDetail := tangy.NpmPackageDetail{
+		Name:      fullName,
+		Version:   packageVersion,
+		CreatedAt: "2024-01-01T12:00:00Z",
+		Tarball: tangy.NpmTarballInfo{
+			RelativePath: "@types/is-odd/-/is-odd-3.0.0.tgz",
+			Filename:     "is-odd-3.0.0.tgz",
+			Sha256:       "abc123",
+			Size:         1024,
+		},
+		Versions:       []string{"3.0.0"},
+		LatestVersions: []tangy.NpmVersionInfo{{Version: "3.0.0", CreatedAt: "2024-01-01T12:00:00Z"}},
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageGet", test.MockCtx(), repositoryHref, fullName, packageVersion).Return(tangDetail, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/%s/%s/%s", api.FullRootPath(), repoUUID, scope, packageName, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+
+	var response api.NpmPackageDetailResponse
+	err = json.Unmarshal(body, &response)
+	assert.Nil(t, err)
+	assert.Equal(t, scope, response.Scope)
+	assert.Equal(t, packageName, response.Name)
+	assert.Equal(t, packageVersion, response.Version)
+	assert.Equal(t, "2024-01-01T12:00:00Z", response.CreatedAt)
+	assert.Equal(t, "is-odd-3.0.0.tgz", response.Tarball.Filename)
+	assert.Equal(t, "abc123", response.Tarball.Sha256)
+	assert.Equal(t, int64(1024), response.Tarball.Size)
+	assert.Equal(t, []string{"3.0.0"}, response.UpstreamVersions)
+	require.Len(t, response.LatestVersions, 1)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageDetailNonNpmRepo() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440001"
+
+	repo := api.RepositoryResponse{
+		UUID:        repoUUID,
+		ContentType: config.ContentTypeMaven,
+	}
+
+	orgID := config.LightwellOrg
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd/3.0.0", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageDetailNotFound() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	fullName := "@types/is-odd"
+	packageVersion := "9.9.9"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageGet", test.MockCtx(), repositoryHref, fullName, packageVersion).Return(tangy.NpmPackageDetail{}, tangy.ErrNpmPackageNotFound)
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd/%s", api.FullRootPath(), repoUUID, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func (suite *PackagesSuite) TestGetNpmPackageDetailTangError() {
+	t := suite.T()
+	repoUUID := "550e8400-e29b-41d4-a716-446655440012"
+	basePath := "npm/remediated"
+	repositoryHref := "/api/pulp/default/api/v3/repositories/npm/npm/018c1c95-4281-76eb-b277-842cbad524f6/"
+	domainName := "test-domain"
+	fullName := "@types/is-odd"
+	packageVersion := "3.0.0"
+
+	repo := api.RepositoryResponse{
+		UUID:                  repoUUID,
+		ContentType:           config.ContentTypeNpm,
+		PublishedDistBasePath: basePath,
+	}
+
+	orgID := config.LightwellOrg
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(repo, nil)
+	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
+	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
+	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
+	suite.tangClient.On("NpmPackageGet", test.MockCtx(), repositoryHref, fullName, packageVersion).Return(tangy.NpmPackageDetail{}, fmt.Errorf("failed to fetch package detail"))
+
+	path := fmt.Sprintf("%s/repositories/%s/npm_packages/@types/is-odd/%s", api.FullRootPath(), repoUUID, packageVersion)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.servePackagesRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusInternalServerError, code)
+}


### PR DESCRIPTION
This PR:
- Bumps `tang` to `v0.0.29` and adds `ContentTypeNpm`
- Adds npm package list/detail APIs via tang (`NpmPackageList`, `NpmPackageGet`, etc.)
- Uses `{scope}/{name}` routes; `-` for unscoped (e.g. `@types`/`is-odd`)
- Reuses `PackageItem.group` for npm scope in list responses
- Adds handler unit tests and regenerates OpenAPI spec