### PR TITLE
HMS-10989: Update Tang for version duplication fix

### DIFF
--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -147,6 +147,7 @@ clients:
       rbac: 1m
       subscription_check: 1h
       roadmap: 24h
+      content_counts: 10m
   feature_service:
     server: #https://feature.stage.api.redhat.com/features
     client_cert:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/content-services/lecho/v3 v3.5.2
-	github.com/content-services/tang v0.0.29
+	github.com/content-services/tang v0.0.30
 	github.com/content-services/yummy v1.0.19
 	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-openapi/spec v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/content-services/caliri/release/v4 v4.8.1 h1:ttaBJkDrjxt89Efgzws0P5jq
 github.com/content-services/caliri/release/v4 v4.8.1/go.mod h1:lFbop4Wy5Z7tLmj5XoMqMep1rOEz1Od4VG9Z7cq+Xs0=
 github.com/content-services/lecho/v3 v3.5.2 h1:lNGYoG/6RnPtnGtWkKSUwO2Huw6lxDrW1Ogz1Ct2jT0=
 github.com/content-services/lecho/v3 v3.5.2/go.mod h1:hALn6ZuFGV3AIYlkhZDU1C5JoWM4TeIx//VO2xt8oZA=
-github.com/content-services/tang v0.0.29 h1:+RpzxOFlIbAgts7Ii0rIiNMI0Lnj9FePfmuoUS37lt8=
-github.com/content-services/tang v0.0.29/go.mod h1:Z969TdEJaoRHxhpZ89Gi25RFVj1dBjEiFzhsGppyz8g=
+github.com/content-services/tang v0.0.30 h1:t/d6tYTKaq5nU0Qc9v4VW79OrJO2i8oxWSt4JGn1hLM=
+github.com/content-services/tang v0.0.30/go.mod h1:Z969TdEJaoRHxhpZ89Gi25RFVj1dBjEiFzhsGppyz8g=
 github.com/content-services/yummy v1.0.19 h1:gVevHg/GeIUk4lnjafZWdHRr/zWQES4KiYZebpjSzdM=
 github.com/content-services/yummy v1.0.19/go.mod h1:qpXbSMEJvQ1hs59Tn2tA2MAApvht867BUUUETntvO6U=
 github.com/content-services/zest/release/v2026 v2026.7.1783082453 h1:mZ8LExJlcMcoIUCv7eW+qQwZ9in18byKtuA99WWG0+M=

--- a/pkg/handler/packages.go
+++ b/pkg/handler/packages.go
@@ -266,24 +266,26 @@ func (ph *PackageHandler) listMavenPackageVersions(c echo.Context) error {
 		return ph.repositoryHrefErrorResponse(err)
 	}
 
-	tangResp, err := ph.TangClient.MavenBuildList(ctx, repositoryHref, groupID, name, "", tangy.PageOptions{})
+	tangResp, err := ph.TangClient.MavenVersionsList(ctx, repositoryHref, groupID, name, "", tangy.PageOptions{})
 	if err != nil {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package versions", err.Error())
 	}
 
 	versions := make([]api.MavenPackageDetailResponse, len(tangResp.Results))
 	for i, item := range tangResp.Results {
+		builds := make([]api.ReleaseInfo, len(item.Builds))
+		for j, b := range item.Builds {
+			builds[j] = api.ReleaseInfo{
+				Version:   b.Version,
+				Release:   b.Release,
+				CreatedAt: b.CreatedAt,
+			}
+		}
 		versions[i] = api.MavenPackageDetailResponse{
 			Group:   groupID,
 			Name:    name,
 			Version: item.Version,
-			Builds: []api.ReleaseInfo{
-				{
-					Version:   item.Version,
-					Release:   item.Release,
-					CreatedAt: item.CreatedAt,
-				},
-			},
+			Builds:  builds,
 		}
 	}
 
@@ -349,7 +351,7 @@ func (ph *PackageHandler) getMavenPackageDetail(c echo.Context) error {
 	}
 
 	pageData := ParsePagination(c)
-	tangResp, err := ph.TangClient.MavenBuildList(ctx, repositoryHref, groupID, name, version, tangy.PageOptions{
+	tangResp, err := ph.TangClient.MavenVersionsList(ctx, repositoryHref, groupID, name, version, tangy.PageOptions{
 		Offset: pageData.Offset,
 		Limit:  pageData.Limit,
 	})
@@ -357,13 +359,18 @@ func (ph *PackageHandler) getMavenPackageDetail(c echo.Context) error {
 		return ce.NewErrorResponse(http.StatusInternalServerError, "Error retrieving package builds", err.Error())
 	}
 
-	builds := make([]api.ReleaseInfo, len(tangResp.Results))
-	for i, item := range tangResp.Results {
-		builds[i] = api.ReleaseInfo{
-			Version:   item.Version,
-			Release:   item.Release,
-			CreatedAt: item.CreatedAt,
+	var builds []api.ReleaseInfo
+	if len(tangResp.Results) > 0 {
+		for _, b := range tangResp.Results[0].Builds {
+			builds = append(builds, api.ReleaseInfo{
+				Version:   b.Version,
+				Release:   b.Release,
+				CreatedAt: b.CreatedAt,
+			})
 		}
+	}
+	if builds == nil {
+		builds = []api.ReleaseInfo{}
 	}
 
 	response := api.MavenPackageDetailResponse{

--- a/pkg/handler/packages_test.go
+++ b/pkg/handler/packages_test.go
@@ -213,21 +213,31 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsSuccess() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{
 			{
 				GroupID:    groupID,
 				ArtifactID: packageName,
 				Version:    "3.16.0",
-				Release:    "rhlw-4000",
-				CreatedAt:  "2024-02-01T14:20:00Z",
+				Builds: []tangy.MavenBuildInfo{
+					{
+						Version:   "3.16.0",
+						Release:   "rhlw-4000",
+						CreatedAt: "2024-02-01T14:20:00Z",
+					},
+				},
 			},
 			{
 				GroupID:    groupID,
 				ArtifactID: packageName,
 				Version:    "3.15.0",
-				Release:    "rhlw-3001",
-				CreatedAt:  "2024-01-15T10:30:00Z",
+				Builds: []tangy.MavenBuildInfo{
+					{
+						Version:   "3.15.0",
+						Release:   "rhlw-3001",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+				},
 			},
 		},
 		Total:  2,
@@ -241,7 +251,7 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsSuccess() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(versionsResp, nil)
 	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), groupID, packageName).Return(&models.MavenPackage{
 		Name:       packageName,
 		Summary:    utils.Ptr("A reactive library."),
@@ -341,7 +351,7 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsTangError() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(tangy.MavenBuildListResponse{}, fmt.Errorf("failed to fetch versions"))
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(tangy.MavenVersionsResponse{}, fmt.Errorf("failed to fetch versions"))
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s", api.FullRootPath(), repoUUID, groupID, packageName)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -370,8 +380,8 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsEmpty() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{},
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{},
 		Total:   0,
 		Limit:   500,
 		Offset:  0,
@@ -383,7 +393,7 @@ func (suite *PackagesSuite) TestListMavenPackageVersionsEmpty() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, "", tangy.PageOptions{}).Return(versionsResp, nil)
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s", api.FullRootPath(), repoUUID, groupID, packageName)
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -680,24 +690,27 @@ func (suite *PackagesSuite) TestGetPackageDetailSuccess() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{
 			{
 				GroupID:    groupID,
 				ArtifactID: packageName,
-				Version:    "3.15.0",
-				Release:    "rhlw-3001",
-				CreatedAt:  "2024-01-15T10:30:00Z",
-			},
-			{
-				GroupID:    groupID,
-				ArtifactID: packageName,
-				Version:    "3.16.0",
-				Release:    "rhlw-4000",
-				CreatedAt:  "2024-02-01T14:20:00Z",
+				Version:    packageVersion,
+				Builds: []tangy.MavenBuildInfo{
+					{
+						Version:   "3.15.0",
+						Release:   "rhlw-3001",
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+					{
+						Version:   "3.16.0",
+						Release:   "rhlw-4000",
+						CreatedAt: "2024-02-01T14:20:00Z",
+					},
+				},
 			},
 		},
-		Total:  2,
+		Total:  1,
 		Limit:  100,
 		Offset: 0,
 	}
@@ -708,7 +721,7 @@ func (suite *PackagesSuite) TestGetPackageDetailSuccess() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(versionsResp, nil)
 	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), groupID, packageName).Return(nil, nil)
 	suite.reg.MavenPackages.On("Create", test.MockCtx(), mock.Anything).Return(nil).Maybe()
 
@@ -754,13 +767,18 @@ func (suite *PackagesSuite) TestGetPackageDetailReturnsCachedMetadata() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{
 			{
 				GroupID:    groupID,
 				ArtifactID: packageName,
 				Version:    packageVersion,
-				CreatedAt:  "2024-01-15T10:30:00Z",
+				Builds: []tangy.MavenBuildInfo{
+					{
+						Version:   packageVersion,
+						CreatedAt: "2024-01-15T10:30:00Z",
+					},
+				},
 			},
 		},
 		Total:  1,
@@ -774,7 +792,7 @@ func (suite *PackagesSuite) TestGetPackageDetailReturnsCachedMetadata() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(versionsResp, nil)
 	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), groupID, packageName).Return(&models.MavenPackage{
 		GroupID:    groupID,
 		Name:       packageName,
@@ -824,8 +842,8 @@ func (suite *PackagesSuite) TestGetPackageDetailMetadataFetchError() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{},
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{},
 		Total:   0,
 		Limit:   100,
 		Offset:  0,
@@ -837,7 +855,7 @@ func (suite *PackagesSuite) TestGetPackageDetailMetadataFetchError() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(versionsResp, nil)
 	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), groupID, packageName).Return(nil, fmt.Errorf("database unavailable"))
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s/%s?limit=100&offset=0", api.FullRootPath(), repoUUID, groupID, packageName, packageVersion)
@@ -915,7 +933,7 @@ func (suite *PackagesSuite) TestGetPackageDetailTangBuildListError() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, "3.15.0", tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.MavenBuildListResponse{}, fmt.Errorf("failed to fetch builds"))
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, "3.15.0", tangy.PageOptions{Offset: 0, Limit: 100}).Return(tangy.MavenVersionsResponse{}, fmt.Errorf("failed to fetch builds"))
 
 	path := fmt.Sprintf("%s/repositories/%s/maven_packages/%s/%s/%s?limit=100&offset=0", api.FullRootPath(), repoUUID, groupID, packageName, "3.15.0")
 	req := httptest.NewRequest(http.MethodGet, path, nil)
@@ -945,8 +963,8 @@ func (suite *PackagesSuite) TestGetPackageDetailEmptyBuilds() {
 	dist := zest.DistributionResponse{}
 	dist.SetRepository(repositoryHref)
 
-	buildListResp := tangy.MavenBuildListResponse{
-		Results: []tangy.MavenBuildListItem{},
+	versionsResp := tangy.MavenVersionsResponse{
+		Results: []tangy.MavenVersionsItem{},
 		Total:   0,
 		Limit:   100,
 		Offset:  0,
@@ -958,7 +976,7 @@ func (suite *PackagesSuite) TestGetPackageDetailEmptyBuilds() {
 	suite.reg.Domain.On("FetchOrCreateDomain", test.MockCtx(), orgID).Return(domainName, nil)
 	suite.pulpClient.On("WithDomain", domainName).Return(suite.pulpClient)
 	suite.pulpClient.On("ResolveRepositoryFromBasePath", test.MockCtx(), basePath).Return(&repositoryHref, nil)
-	suite.tangClient.On("MavenBuildList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(buildListResp, nil)
+	suite.tangClient.On("MavenVersionsList", test.MockCtx(), repositoryHref, groupID, packageName, packageVersion, tangy.PageOptions{Offset: 0, Limit: 100}).Return(versionsResp, nil)
 	suite.reg.MavenPackages.On("Fetch", test.MockCtx(), groupID, packageName).Return(nil, nil)
 	suite.reg.MavenPackages.On("Create", test.MockCtx(), mock.Anything).Return(nil).Maybe()
 

--- a/scripts/create_maven_repo.sh
+++ b/scripts/create_maven_repo.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 #
-# Creates a Maven repository in Pulp backed by Maven Central, then imports it
-# into the application as a lightwell repository.
+# Creates Maven repositories in Pulp and imports them into the application as
+# lightwell repositories.
 #
-# Intended for local development against the Pulp instance started via docker-compose.
+# By default, creates two repositories backed by static fixture data that
+# mirrors the real lightwell structure:
+#   - maven-upstream  (base_path: java/validated)
+#   - maven-releases  (base_path: java/remediated)
+#
+# With --seed-from-maven-central, creates a single repository backed by Maven
+# Central with a unique suffix. This mode produces more data but is less
+# representative of real data. Multiple repos can be created this way.
+#
+# Intended for local development against the Pulp instance started via
+# docker-compose.
 #
 # Usage:
-#   ./scripts/create_maven_repo.sh [--domain DOMAIN] [--remote-url URL]
+#   ./scripts/create_maven_repo.sh [--domain DOMAIN]
+#   ./scripts/create_maven_repo.sh --seed-from-maven-central [--remote-url URL]
 #
-# Defaults:
-#   DOMAIN     = lightwell
-#   REMOTE_URL = https://repo.maven.apache.org/maven2/
 
 set -euo pipefail
 
@@ -29,15 +37,21 @@ SUFFIX="$(date +%s)"
 REPO_DIR="$(cd "$(dirname "$0")/.."; pwd)"
 LIGHTWELL_JSON="${REPO_DIR}/pkg/external_repos/lightwell_repos.json"
 
+SEED_FROM_MAVEN_CENTRAL=false
+ diff
+FIXTURE_UPSTREAM_URL="https://content-services.github.io/fixtures/maven/maven-upstream/"
+FIXTURE_RELEASES_URL="https://content-services.github.io/fixtures/maven/maven-releases/"
+
 # ---------------------------------------------------------------------------
 # Parse flags
 # ---------------------------------------------------------------------------
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --domain)     DOMAIN="$2";     shift 2 ;;
-    --remote-url) REMOTE_URL="$2"; shift 2 ;;
-    *)            echo "Unknown option: $1" >&2; exit 1 ;;
+    --domain)                    DOMAIN="$2";              shift 2 ;;
+    --remote-url)                REMOTE_URL="$2";          shift 2 ;;
+    --seed-from-maven-central)   SEED_FROM_MAVEN_CENTRAL=true; shift ;;
+    *)                           echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
@@ -119,6 +133,74 @@ wait_for_task() {
   exit 1
 }
 
+# Creates a Maven remote, repository, and distribution in Pulp.
+#   create_pulp_repo <REMOTE_URL> <BASE_PATH> <LABEL>
+# Sets: remote_href, repo_href
+create_pulp_repo() {
+  local url="$1"
+  local base_path="$2"
+  local label="$3"
+
+  echo "==> Creating Maven remote for ${label} -> ${url}..."
+  pulp_create "remote" \
+    "${API_ROOT}/${DOMAIN}/api/v3/remotes/maven/maven/" \
+    "{\"name\": \"${label}-remote-${SUFFIX}\", \"url\": \"${url}\"}" \
+    '.pulp_href'
+  remote_href="$RESULT"
+  echo "    Remote: ${remote_href}"
+
+  echo "==> Creating Maven repository for ${label}..."
+  pulp_create "repository" \
+    "${API_ROOT}/${DOMAIN}/api/v3/repositories/maven/maven/" \
+    "{\"name\": \"${label}-repo-${SUFFIX}\", \"remote\": \"${remote_href}\"}" \
+    '.pulp_href'
+  repo_href="$RESULT"
+  echo "    Repository: ${repo_href}"
+
+  echo "==> Creating Maven distribution (base_path=${base_path})..."
+  pulp_create "distribution" \
+    "${API_ROOT}/${DOMAIN}/api/v3/distributions/maven/maven/" \
+    "{
+      \"name\": \"${base_path}\",
+      \"base_path\": \"${base_path}\",
+      \"repository\": \"${repo_href}\",
+      \"remote\": \"${remote_href}\"
+    }" \
+    '.task'
+  local task_href="$RESULT"
+
+  echo "==> Waiting for distribution task to complete..."
+  wait_for_task "$task_href"
+  echo "    Distribution created successfully."
+}
+
+# Fetches a list of packages through a distribution to populate the Pulp cache.
+#   fetch_packages <CONTENT_URL> <PACKAGES_ARRAY_NAME>
+fetch_packages() {
+  local content_url="$1"
+  local -n pkgs=$2
+
+  echo ""
+  echo "==> Fetching ${#pkgs[@]} packages to populate the Pulp cache..."
+
+  local success=0
+  local failed=0
+  for pkg in "${pkgs[@]}"; do
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" "${content_url}${pkg}")
+    local name
+    name=$(basename "$pkg")
+    if [[ "$status" -ge 200 && "$status" -lt 400 ]]; then
+      success=$((success + 1))
+    else
+      failed=$((failed + 1))
+      echo "    WARN: ${name} returned HTTP ${status}"
+    fi
+    printf "    [%d/%d] fetched\r" "$((success + failed))" "${#pkgs[@]}"
+  done
+  echo "    Fetched ${success}/${#pkgs[@]} packages successfully.    "
+}
+
 # ---------------------------------------------------------------------------
 # Step 1: Look up or create the Pulp domain
 # ---------------------------------------------------------------------------
@@ -146,57 +228,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: Create Maven remote -> repository -> distribution
+# Step 2 & 3: Create repos and import (mode-dependent)
 # ---------------------------------------------------------------------------
 
-echo "==> Creating Maven remote -> ${REMOTE_URL}..."
-pulp_create "remote" \
-  "${API_ROOT}/${DOMAIN}/api/v3/remotes/maven/maven/" \
-  "{\"name\": \"maven-remote-${SUFFIX}\", \"url\": \"${REMOTE_URL}\"}" \
-  '.pulp_href'
-remote_href="$RESULT"
-echo "    Remote: ${remote_href}"
+if [[ "$SEED_FROM_MAVEN_CENTRAL" == "true" ]]; then
+  # -------------------------------------------------------------------------
+  # Maven Central mode: single repo with dynamic suffix (original behavior)
+  # -------------------------------------------------------------------------
 
-echo "==> Creating Maven repository..."
-pulp_create "repository" \
-  "${API_ROOT}/${DOMAIN}/api/v3/repositories/maven/maven/" \
-  "{\"name\": \"maven-repo-${SUFFIX}\", \"remote\": \"${remote_href}\"}" \
-  '.pulp_href'
-repo_href="$RESULT"
-echo "    Repository: ${repo_href}"
+  dist_path="java/dev-${SUFFIX}"
+  create_pulp_repo "$REMOTE_URL" "$dist_path" "maven"
 
-dist_path="java/dev-${SUFFIX}"
-echo "==> Creating Maven distribution (base_path=${dist_path})..."
-pulp_create "distribution" \
-  "${API_ROOT}/${DOMAIN}/api/v3/distributions/maven/maven/" \
-  "{
-    \"name\": \"${dist_path}\",
-    \"base_path\": \"${dist_path}\",
-    \"repository\": \"${repo_href}\",
-    \"remote\": \"${remote_href}\"
-  }" \
-  '.task'
-task_href="$RESULT"
+  # Import the repo via the application's lightwell import
+  echo ""
+  echo "==> Importing repository into the application..."
 
-echo "==> Waiting for distribution task to complete..."
-wait_for_task "$task_href"
-echo "    Distribution created successfully."
+  cp "${LIGHTWELL_JSON}" "${LIGHTWELL_JSON}.bak"
+  trap 'mv -f "${LIGHTWELL_JSON}.bak" "${LIGHTWELL_JSON}" 2>/dev/null; echo "    Restored lightwell_repos.json"' EXIT
 
-# ---------------------------------------------------------------------------
-# Step 3: Import the repo via the application's lightwell import
-#
-# lightwell_repos.json is compiled into the Go binary via go:embed, so we
-# temporarily replace it with a single entry pointing at the distribution we
-# just created, run `go run` (which recompiles), then restore the original.
-# ---------------------------------------------------------------------------
-
-echo ""
-echo "==> Importing repository into the application..."
-
-cp "${LIGHTWELL_JSON}" "${LIGHTWELL_JSON}.bak"
-trap 'mv -f "${LIGHTWELL_JSON}.bak" "${LIGHTWELL_JSON}" 2>/dev/null; echo "    Restored lightwell_repos.json"' EXIT
-
-cat > "${LIGHTWELL_JSON}" <<JSONEOF
+  cat > "${LIGHTWELL_JSON}" <<JSONEOF
 [
   {
     "name": "lightwell/java/dev-${SUFFIX}",
@@ -207,71 +257,160 @@ cat > "${LIGHTWELL_JSON}" <<JSONEOF
 ]
 JSONEOF
 
-import_err=0
-(cd "${REPO_DIR}" && FEATURES_LIGHTWELL_ENABLED=true go run ./cmd/external-repos/main.go import) || import_err=$?
+  import_err=0
+  (cd "${REPO_DIR}" && FEATURES_LIGHTWELL_ENABLED=true go run ./cmd/external-repos/main.go import) || import_err=$?
 
-if [[ "$import_err" -ne 0 ]]; then
-  echo "ERROR: import failed (exit code ${import_err})" >&2
-  exit 1
-fi
-
-# ---------------------------------------------------------------------------
-# Step 4: Fetch packages through the distribution to populate the Pulp cache
-# ---------------------------------------------------------------------------
-
-content_url="${PULP_CONTENT_URL}/api/pulp-content/${DOMAIN}/${dist_path}"
-
-packages=(
-  /blissed/blissed/1.0-beta-3/blissed-1.0-beta-3.pom
-  /avalon-util/avalon-util-exception/1.0.0/avalon-util-exception-1.0.0.pom
-  /commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.pom
-  /commons-io/commons-io/2.11.0/commons-io-2.11.0.pom
-  /commons-codec/commons-codec/1.15/commons-codec-1.15.pom
-  /commons-lang/commons-lang/2.6/commons-lang-2.6.pom
-  /commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.pom
-  /junit/junit/4.13.2/junit-4.13.2.pom
-  /org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom
-  /org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.pom
-  /com/google/guava/guava/31.1-jre/guava-31.1-jre.pom
-  /com/google/code/gson/gson/2.10.1/gson-2.10.1.pom
-  /org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom
-  /org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.pom
-  /org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom
-  /org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
-  /org/yaml/snakeyaml/1.33/snakeyaml-1.33.pom
-  /com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.pom
-  /com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2.pom
-  /org/mockito/mockito-core/5.3.1/mockito-core-5.3.1.pom
-)
-
-echo ""
-echo "==> Fetching ${#packages[@]} packages to populate the Pulp cache..."
-
-success=0
-failed=0
-for pkg in "${packages[@]}"; do
-  status=$(curl -s -o /dev/null -w "%{http_code}" "${content_url}${pkg}")
-  name=$(basename "$pkg")
-  if [[ "$status" -ge 200 && "$status" -lt 400 ]]; then
-    success=$((success + 1))
-  else
-    failed=$((failed + 1))
-    echo "    WARN: ${name} returned HTTP ${status}"
+  if [[ "$import_err" -ne 0 ]]; then
+    echo "ERROR: import failed (exit code ${import_err})" >&2
+    exit 1
   fi
-  printf "    [%d/%d] fetched\r" "$((success + failed))" "${#packages[@]}"
-done
-echo "    Fetched ${success}/${#packages[@]} packages successfully.    "
 
-# ---------------------------------------------------------------------------
-# Done
-# ---------------------------------------------------------------------------
+  # Fetch packages to populate the Pulp cache
+  content_url="${PULP_CONTENT_URL}/api/pulp-content/${DOMAIN}/${dist_path}"
 
-echo ""
-echo "Done! Maven repository created in Pulp and imported into the application."
-echo ""
-echo "  Domain:       ${DOMAIN}"
-echo "  Remote:       ${remote_href}"
-echo "  Repository:   ${repo_href}"
-echo "  Distribution: ${dist_path}"
-echo "  Content URL:  ${content_url}"
-echo "  Packages:     ${success} cached"
+  central_packages=(
+    /blissed/blissed/1.0-beta-3/blissed-1.0-beta-3.pom
+    /blissed/blissed/1.0-beta-3/blissed-1.0-beta-3.jar
+    /avalon-util/avalon-util-exception/1.0.0/avalon-util-exception-1.0.0.pom
+    /avalon-util/avalon-util-exception/1.0.0/avalon-util-exception-1.0.0.jar
+    /commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.pom
+    /commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar
+    /commons-io/commons-io/2.11.0/commons-io-2.11.0.pom
+    /commons-io/commons-io/2.11.0/commons-io-2.11.0.jar
+    /commons-codec/commons-codec/1.15/commons-codec-1.15.pom
+    /commons-codec/commons-codec/1.15/commons-codec-1.15.jar
+    /commons-lang/commons-lang/2.6/commons-lang-2.6.pom
+    /commons-lang/commons-lang/2.6/commons-lang-2.6.jar
+    /commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.pom
+    /commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar
+    /junit/junit/4.13.2/junit-4.13.2.pom
+    /junit/junit/4.13.2/junit-4.13.2.jar
+    /org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom
+    /org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar
+    /org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.pom
+    /org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar
+    /com/google/guava/guava/31.1-jre/guava-31.1-jre.pom
+    /com/google/guava/guava/31.1-jre/guava-31.1-jre.jar
+    /com/google/code/gson/gson/2.10.1/gson-2.10.1.pom
+    /com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
+    /org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom
+    /org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar
+    /org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.pom
+    /org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.jar
+    /org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.pom
+    /org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar
+    /org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.pom
+    /org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar
+    /org/yaml/snakeyaml/1.33/snakeyaml-1.33.pom
+    /org/yaml/snakeyaml/1.33/snakeyaml-1.33.jar
+    /com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.pom
+    /com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.jar
+    /com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2.pom
+    /com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2.jar
+    /org/mockito/mockito-core/5.3.1/mockito-core-5.3.1.pom
+    /org/mockito/mockito-core/5.3.1/mockito-core-5.3.1.jar
+  )
+
+  fetch_packages "$content_url" central_packages
+
+  echo ""
+  echo "Done! Maven repository created in Pulp and imported into the application."
+  echo ""
+  echo "  Domain:       ${DOMAIN}"
+  echo "  Distribution: ${dist_path}"
+  echo "  Content URL:  ${content_url}"
+
+else
+  # -------------------------------------------------------------------------
+  # Fixture mode (default): two repos with curated fixture data
+  # -------------------------------------------------------------------------
+
+  create_pulp_repo "$FIXTURE_UPSTREAM_URL" "java/validated" "maven-upstream"
+  upstream_repo_href="$repo_href"
+  upstream_remote_href="$remote_href"
+
+  create_pulp_repo "$FIXTURE_RELEASES_URL" "java/remediated" "maven-releases"
+  releases_repo_href="$repo_href"
+  releases_remote_href="$remote_href"
+
+  # Import both repos via the application's lightwell import
+  echo ""
+  echo "==> Importing repositories into the application..."
+
+  cp "${LIGHTWELL_JSON}" "${LIGHTWELL_JSON}.bak"
+  trap 'mv -f "${LIGHTWELL_JSON}.bak" "${LIGHTWELL_JSON}" 2>/dev/null; echo "    Restored lightwell_repos.json"' EXIT
+
+  cat > "${LIGHTWELL_JSON}" <<JSONEOF
+[
+  {
+    "name": "lightwell/java/validated",
+    "type": "maven",
+    "base_path": "java/validated",
+    "feature_name": "lightwell-network"
+  },
+  {
+    "name": "lightwell/java/remediated",
+    "type": "maven",
+    "base_path": "java/remediated",
+    "feature_name": "lightwell-network"
+  }
+]
+JSONEOF
+
+  import_err=0
+  (cd "${REPO_DIR}" && FEATURES_LIGHTWELL_ENABLED=true go run ./cmd/external-repos/main.go import) || import_err=$?
+
+  if [[ "$import_err" -ne 0 ]]; then
+    echo "ERROR: import failed (exit code ${import_err})" >&2
+    exit 1
+  fi
+
+  # Fetch packages to populate the Pulp cache for both repos
+  upstream_content_url="${PULP_CONTENT_URL}/api/pulp-content/${DOMAIN}/java/validated"
+  releases_content_url="${PULP_CONTENT_URL}/api/pulp-content/${DOMAIN}/java/remediated"
+
+  upstream_packages=(
+    /blissed/blissed/1.0-beta-3/blissed.blissed.1.0-beta-3.pom
+    /blissed/blissed/1.0-beta-3/blissed.blissed.1.0-beta-3.jar
+    /com/example/fixture/raccoon/1.0.0/com.example.fixture.raccoon.1.0.0.pom
+    /com/example/fixture/raccoon/1.0.0/com.example.fixture.raccoon.1.0.0.jar
+    /com/example/fixture/raccoon/1.1.0/com.example.fixture.raccoon.1.1.0.pom
+    /com/example/fixture/raccoon/1.1.0/com.example.fixture.raccoon.1.1.0.jar
+    /com/example/fixture/raccoon/2.0.0/com.example.fixture.raccoon.2.0.0.pom
+    /com/example/fixture/raccoon/2.0.0/com.example.fixture.raccoon.2.0.0.jar
+    /com/example/fixture/raccoon/3.0.0/com.example.fixture.raccoon.3.0.0.pom
+    /com/example/fixture/raccoon/3.0.0/com.example.fixture.raccoon.3.0.0.jar
+    /org/yaml/snakeyaml/1.33/org.yaml.snakeyaml.1.33.pom
+    /org/yaml/snakeyaml/1.33/org.yaml.snakeyaml.1.33.jar
+  )
+
+  releases_packages=(
+    /blissed/blissed/1.0-beta-3.rhlw-00001/blissed.blissed.1.0-beta-3.rhlw-00001.pom
+    /blissed/blissed/1.0-beta-3.rhlw-00001/blissed.blissed.1.0-beta-3.rhlw-00001.jar
+    /blissed/blissed/1.0-beta-3.rhlw-00002/blissed.blissed.1.0-beta-3.rhlw-00002.pom
+    /blissed/blissed/1.0-beta-3.rhlw-00002/blissed.blissed.1.0-beta-3.rhlw-00002.jar
+    /com/example/fixture/raccoon/1.0.0.rhlw-00001/com.example.fixture.raccoon.1.0.0.rhlw-00001.pom
+    /com/example/fixture/raccoon/1.0.0.rhlw-00001/com.example.fixture.raccoon.1.0.0.rhlw-00001.jar
+    /com/example/fixture/raccoon/1.0.0.rhlw-00002/com.example.fixture.raccoon.1.0.0.rhlw-00002.pom
+    /com/example/fixture/raccoon/1.0.0.rhlw-00002/com.example.fixture.raccoon.1.0.0.rhlw-00002.jar
+    /com/example/fixture/raccoon/2.0.0.rhlw-00001/com.example.fixture.raccoon.2.0.0.rhlw-00001.pom
+    /com/example/fixture/raccoon/2.0.0.rhlw-00001/com.example.fixture.raccoon.2.0.0.rhlw-00001.jar
+    /com/example/fixture/raccoon/2.0.0.rhlw-00002/com.example.fixture.raccoon.2.0.0.rhlw-00002.pom
+    /com/example/fixture/raccoon/2.0.0.rhlw-00002/com.example.fixture.raccoon.2.0.0.rhlw-00002.jar
+    /org/yaml/snakeyaml/1.33.rhlw-00001/org.yaml.snakeyaml.1.33.rhlw-00001.pom
+    /org/yaml/snakeyaml/1.33.rhlw-00001/org.yaml.snakeyaml.1.33.rhlw-00001.jar
+  )
+
+  fetch_packages "$upstream_content_url" upstream_packages
+  fetch_packages "$releases_content_url" releases_packages
+
+  echo ""
+  echo "Done! Fixture Maven repositories created in Pulp and imported into the application."
+  echo ""
+  echo "  Domain:       ${DOMAIN}"
+  echo "  Upstream:     java/validated  -> ${FIXTURE_UPSTREAM_URL}"
+  echo "  Releases:     java/remediated -> ${FIXTURE_RELEASES_URL}"
+  echo "  Content URLs:"
+  echo "    ${upstream_content_url}"
+  echo "    ${releases_content_url}"
+fi


### PR DESCRIPTION
## Summary
Tang was returning duplicated versions in latest_releases. It has also been refactored to replace MavenBuildList with MavenVersionsList, which more closely resembles the use-case for the method. These changes update to the new version of Tang. It also updates the `create_maven_repo.sh` script to use a fixture with curated metadata to test these fixes.

## Testing steps
1. Checkout Tang PR: https://github.com/content-services/tang/pull/43
2. Use `./scripts/create_maven_repo.sh` to import new repos
3. Check the maven PackagesList, VersionsList, and VersionDetails APIs for the expected Version and Release information.
