### PR TITLE
HMS-10597: If add-uploads task fails, retrying same doesn't work

### DIFF
--- a/pkg/tasks/add_uploads.go
+++ b/pkg/tasks/add_uploads.go
@@ -116,6 +116,7 @@ func (ur *AddUploads) Run() (err error) {
 				log.Debug().Msgf("added content to repository %v, but no new version created, likely already present", ur.payload.RepositoryConfigUUID)
 				return nil
 			}
+			log.Info().Msgf("using orphaned repo version %v for repository %v", *orphanedHref, ur.payload.RepositoryConfigUUID)
 			versionHref = *orphanedHref
 		}
 		ur.payload.VersionHref = &versionHref

--- a/pkg/tasks/add_uploads.go
+++ b/pkg/tasks/add_uploads.go
@@ -107,8 +107,16 @@ func (ur *AddUploads) Run() (err error) {
 			return err
 		}
 		if versionHref == "" {
-			log.Debug().Msgf("added content to repository %v, but no new version created, likely already present", ur.payload.RepositoryConfigUUID)
-			return nil
+			// Nothing updated, but maybe the previous version was orphaned?
+			orphanedHref, orphanErr := GetOrphanedLatestVersion(ur.ctx, ur.pulpClient, ur.daoReg, ur.payload.RepositoryConfigUUID)
+			if orphanErr != nil {
+				return fmt.Errorf("failed to get orphaned latest version: %w", orphanErr)
+			}
+			if orphanedHref == nil {
+				log.Debug().Msgf("added content to repository %v, but no new version created, likely already present", ur.payload.RepositoryConfigUUID)
+				return nil
+			}
+			versionHref = *orphanedHref
 		}
 		ur.payload.VersionHref = &versionHref
 		err = ur.UpdatePayload()

--- a/pkg/tasks/add_uploads_test.go
+++ b/pkg/tasks/add_uploads_test.go
@@ -1,0 +1,227 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	"github.com/content-services/content-sources-backend/pkg/utils"
+	zest "github.com/content-services/zest/release/v2026"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type AddUploadsSuite struct {
+	suite.Suite
+	mockDaoRegistry *dao.MockDaoRegistry
+	MockPulpClient  pulp_client.MockPulpClient
+	MockQueue       queue.MockQueue
+	Queue           queue.Queue
+}
+
+func TestAddUploadsSuite(t *testing.T) {
+	suite.Run(t, new(AddUploadsSuite))
+}
+
+func (s *AddUploadsSuite) SetupTest() {
+	s.mockDaoRegistry = dao.GetMockDaoRegistry(s.T())
+	s.MockPulpClient = *pulp_client.NewMockPulpClient(s.T())
+	s.MockQueue = *queue.NewMockQueue(s.T())
+	s.Queue = &s.MockQueue
+	config.Get().Clients.Pulp.RepoContentGuards = false
+}
+
+func (s *AddUploadsSuite) TestAddUploadsNoNewVersion() {
+	ctx := context.Background()
+	domainName := "myDomain"
+	artifactSha := "abc123"
+	artifactHref := "/pulp/artifact/abc123/"
+	packageHref := "/pulp/content/rpm/packages/abc123/"
+	repoHref := "repoHref"
+
+	repoConfig := api.RepositoryResponse{
+		OrgID:          "OrgId",
+		UUID:           uuid.NewString(),
+		RepositoryUUID: uuid.NewString(),
+		Origin:         config.OriginUpload,
+		Snapshot:       true,
+	}
+
+	s.MockPulpClient.On("LookupPackage", ctx, artifactSha).Return(&packageHref, nil)
+	repoResp := zest.RpmRpmRepositoryResponse{PulpHref: &repoHref, LatestVersionHref: utils.Ptr("existing_Href")}
+	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(&repoResp, nil)
+
+	modifyTaskHref := "modifyTaskHref"
+	s.MockPulpClient.On("ModifyRpmRepositoryContent", ctx, repoHref, []string{packageHref}, []string{}).Return(modifyTaskHref, nil)
+	status := pulp_client.COMPLETED
+	modifyTask := zest.TaskResponse{
+		PulpHref:         &modifyTaskHref,
+		State:            &status,
+		CreatedResources: []string{},
+	}
+	s.MockPulpClient.On("PollTask", ctx, modifyTaskHref).Return(&modifyTask, nil)
+	s.mockDaoRegistry.Snapshot.On("FetchSnapshotByVersionHref", ctx, repoConfig.UUID, "existing_Href").Return(&api.SnapshotResponse{UUID: uuid.NewString()}, nil)
+
+	task := models.TaskInfo{
+		Id:    uuid.UUID{},
+		OrgId: repoConfig.OrgID,
+	}
+	payload := AddUploadsPayload{
+		RepositoryConfigUUID: repoConfig.UUID,
+		Artifacts:            []api.Artifact{{Sha256: artifactSha, Href: artifactHref}},
+	}
+	ur := AddUploads{
+		orgID:      repoConfig.OrgID,
+		domainName: domainName,
+		ctx:        ctx,
+		payload:    &payload,
+		task:       &task,
+		daoReg:     s.mockDaoRegistry.ToDaoRegistry(),
+		repo:       repoConfig,
+		pulpClient: &s.MockPulpClient,
+		queue:      &s.Queue,
+		logger:     &log.Logger,
+	}
+
+	err := ur.Run()
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), ur.payload.VersionHref)
+}
+
+func (s *AddUploadsSuite) TestAddUploadsWithOrphanVersion() {
+	ctx := context.Background()
+	domainName := "myDomain"
+	snapshotId := "testAddUploadsWithOrphanVersion"
+	artifactSha := "abc123"
+	artifactHref := "/pulp/artifact/abc123/"
+	packageHref := "/pulp/content/rpm/packages/abc123/"
+	repoHref := "repoHref"
+	existingVersionHref := "existing_Href"
+
+	repoConfig := api.RepositoryResponse{
+		OrgID:          "OrgId",
+		UUID:           uuid.NewString(),
+		RepositoryUUID: uuid.NewString(),
+		Origin:         config.OriginUpload,
+		Snapshot:       true,
+	}
+
+	s.MockPulpClient.On("LookupPackage", ctx, artifactSha).Return(&packageHref, nil)
+	repoResp := zest.RpmRpmRepositoryResponse{PulpHref: &repoHref, LatestVersionHref: &existingVersionHref}
+	s.MockPulpClient.On("GetRpmRepositoryByName", ctx, repoConfig.UUID).Return(&repoResp, nil)
+
+	modifyTaskHref := "modifyTaskHref"
+	s.MockPulpClient.On("ModifyRpmRepositoryContent", ctx, repoHref, []string{packageHref}, []string{}).Return(modifyTaskHref, nil)
+	status := pulp_client.COMPLETED
+	modifyTask := zest.TaskResponse{
+		PulpHref:         &modifyTaskHref,
+		State:            &status,
+		CreatedResources: []string{},
+	}
+	s.MockPulpClient.On("PollTask", ctx, modifyTaskHref).Return(&modifyTask, nil)
+	s.mockDaoRegistry.Snapshot.On("FetchSnapshotByVersionHref", ctx, repoConfig.UUID, existingVersionHref).Return(nil, nil)
+
+	task := models.TaskInfo{
+		Id:    uuid.UUID{},
+		OrgId: repoConfig.OrgID,
+	}
+
+	pubHref, _ := s.mockPublish(ctx, existingVersionHref)
+	distHref, _ := s.mockCreateDist(ctx, pubHref)
+
+	s.MockQueue.On("UpdatePayload", &task, mock.Anything).Return(&task, nil)
+
+	counts := zest.ContentSummaryResponse{
+		Present: map[string]map[string]interface{}{},
+		Added:   map[string]map[string]interface{}{},
+		Removed: map[string]map[string]interface{}{},
+	}
+	rpmVersion := zest.RepositoryVersionResponse{
+		PulpHref:       &existingVersionHref,
+		ContentSummary: &counts,
+	}
+	s.MockPulpClient.On("GetRpmRepositoryVersion", ctx, existingVersionHref).Return(&rpmVersion, nil)
+	current, added, removed := models.ContentSummaryToContentCounts(&counts)
+	distPath := fmt.Sprintf("%s/%s", repoConfig.UUID, snapshotId)
+	expectedSnap := models.Snapshot{
+		VersionHref:                 existingVersionHref,
+		PublicationHref:             pubHref,
+		DistributionHref:            distHref,
+		DistributionPath:            distPath,
+		RepositoryConfigurationUUID: repoConfig.UUID,
+		ContentCounts:               current,
+		AddedCounts:                 added,
+		RemovedCounts:               removed,
+		RepositoryPath:              fmt.Sprintf("%v/%v", domainName, distPath),
+	}
+	s.mockDaoRegistry.Snapshot.On("Create", ctx, &expectedSnap).Return(nil).Once()
+
+	s.MockPulpClient.On("ListVersionAllPackages", ctx, existingVersionHref).Return([]zest.RpmPackageResponse{}, nil)
+	s.mockDaoRegistry.Rpm.On("InsertForRepository", ctx, repoConfig.RepositoryUUID, mock.Anything).Return(int64(0), nil)
+	s.mockDaoRegistry.Repository.On("Update", ctx, mock.AnythingOfType("dao.RepositoryUpdate")).Return(nil)
+
+	payload := AddUploadsPayload{
+		RepositoryConfigUUID: repoConfig.UUID,
+		Artifacts:            []api.Artifact{{Sha256: artifactSha, Href: artifactHref}},
+		SnapshotIdent:        &snapshotId,
+	}
+	ur := AddUploads{
+		orgID:      repoConfig.OrgID,
+		domainName: domainName,
+		ctx:        ctx,
+		payload:    &payload,
+		task:       &task,
+		daoReg:     s.mockDaoRegistry.ToDaoRegistry(),
+		repo:       repoConfig,
+		pulpClient: &s.MockPulpClient,
+		queue:      &s.Queue,
+		logger:     &log.Logger,
+	}
+
+	err := ur.Run()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), existingVersionHref, *ur.payload.VersionHref)
+}
+
+func (s *AddUploadsSuite) mockCreateDist(ctx context.Context, pubHref string) (string, string) {
+	distPath := mock.AnythingOfType("string")
+	var guardPath *string
+	distHref := "/pulp/DNAME/api/v3/distributions/rpm/rpm/" + uuid.NewString() + "/"
+	distTaskhref := "distTaskHref"
+
+	s.MockPulpClient.On("FindDistributionByPath", ctx, distPath).Return(nil, nil)
+	s.MockPulpClient.On("CreateRpmDistribution", ctx, pubHref, mock.AnythingOfType("string"), distPath, guardPath).Return(&distTaskhref, nil).Twice()
+	status := pulp_client.COMPLETED
+	task := zest.TaskResponse{
+		PulpHref:         &distTaskhref,
+		State:            &status,
+		CreatedResources: []string{distHref},
+	}
+	s.MockPulpClient.On("PollTask", ctx, distTaskhref).Return(&task, nil).Twice()
+	return distHref, distTaskhref
+}
+
+func (s *AddUploadsSuite) mockPublish(ctx context.Context, versionHref string) (string, string) {
+	publishTaskHref := "publishTaskHref"
+	pubHref := "/pulp/DNAME/api/v3/publications/rpm/rpm/" + uuid.NewString() + "/"
+
+	s.MockPulpClient.On("FindRpmPublicationByVersion", ctx, versionHref).Return(nil, nil).Once()
+	s.MockPulpClient.On("CreateRpmPublication", ctx, versionHref).Return(&publishTaskHref, nil).Once()
+	status := pulp_client.COMPLETED
+	task := zest.TaskResponse{
+		PulpHref:         &publishTaskHref,
+		State:            &status,
+		CreatedResources: []string{pubHref},
+	}
+	s.MockPulpClient.On("PollTask", ctx, publishTaskHref).Return(&task, nil).Once()
+	return pubHref, publishTaskHref
+}

--- a/pkg/tasks/orphaned_version.go
+++ b/pkg/tasks/orphaned_version.go
@@ -15,7 +15,7 @@ import (
 func GetOrphanedLatestVersion(ctx context.Context, pulpClient pulp_client.PulpClient, daoReg *dao.DaoRegistry, repoConfigUUID string) (*string, error) {
 	repoResp, err := pulpClient.GetRpmRepositoryByName(ctx, repoConfigUUID)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	if repoResp == nil || repoResp.LatestVersionHref == nil {
 		return nil, nil

--- a/pkg/tasks/orphaned_version.go
+++ b/pkg/tasks/orphaned_version.go
@@ -1,0 +1,33 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+)
+
+// GetOrphanedLatestVersion returns the latest version href for a repository if it is orphaned, otherwise nil
+//
+//	If a snapshot is made, but something bad happens between the repo version being made and its publication or distribution,
+//		the repo version is 'lost', as there is no snapshot referring to it.  If this happens we can grab the latest
+//		repo version from pulp, and check if any snapshot exists with that version href.  If not then this is an orphaned version
+func GetOrphanedLatestVersion(ctx context.Context, pulpClient pulp_client.PulpClient, daoReg *dao.DaoRegistry, repoConfigUUID string) (*string, error) {
+	repoResp, err := pulpClient.GetRpmRepositoryByName(ctx, repoConfigUUID)
+	if err != nil {
+		return nil, nil
+	}
+	if repoResp == nil || repoResp.LatestVersionHref == nil {
+		return nil, nil
+	}
+	snap, err := daoReg.Snapshot.FetchSnapshotByVersionHref(ctx, repoConfigUUID, *repoResp.LatestVersionHref)
+	if err != nil {
+		return nil, err
+	}
+	// The latest version from pulp is NOT tracked by a snapshot, so return it
+	if snap == nil {
+		return repoResp.LatestVersionHref, nil
+	}
+	// It is tracked by a snapshot, so the repo must not have changed
+	return nil, nil
+}

--- a/pkg/tasks/repository_snapshot.go
+++ b/pkg/tasks/repository_snapshot.go
@@ -151,7 +151,7 @@ func (sr *SnapshotRepository) Run() (err error) {
 
 	if versionHref == nil {
 		// Nothing updated, but maybe the previous version was orphaned?
-		versionHref, err = sr.GetOrphanedLatestVersion(sr.repoConfig.UUID)
+		versionHref, err = GetOrphanedLatestVersion(sr.ctx, sr.pulpClient, sr.daoReg, sr.repoConfig.UUID)
 		if err != nil {
 			return fmt.Errorf("failed to get orphaned latest version: %w", err)
 		}
@@ -287,31 +287,6 @@ func (sr *SnapshotRepository) cleanupOnCancel() error {
 	}
 
 	return nil
-}
-
-// GetOrphanedLatestVersion
-//
-//	 If a snapshot is made, but something bad happens between the repo version being made and its publication or distribution,
-//			the repo version is 'lost', as there is no snapshot referring to it.  If this happens we can grab the latest
-//		    repo version from pulp, and check if any snapshot exists with that version href.  If not then this is an orphaned version
-func (sr *SnapshotRepository) GetOrphanedLatestVersion(repoConfigUUID string) (*string, error) {
-	repoResp, err := sr.pulpClient.GetRpmRepositoryByName(sr.ctx, repoConfigUUID)
-	if err != nil {
-		return nil, nil
-	}
-	if repoResp == nil || repoResp.LatestVersionHref == nil {
-		return nil, nil
-	}
-	snap, err := sr.daoReg.Snapshot.FetchSnapshotByVersionHref(sr.ctx, repoConfigUUID, *repoResp.LatestVersionHref)
-	if err != nil {
-		return nil, err
-	}
-	// The latest version from pulp is NOT tracked by a snapshot, so return it
-	if snap == nil {
-		return repoResp.LatestVersionHref, nil
-	} else { // It is tracked by a snapshot, so the repo must not have changed
-		return nil, nil
-	}
 }
 
 func (sr *SnapshotRepository) SavePublicationTaskHref(href string) error {


### PR DESCRIPTION
## Summary

Add orphan repo version check to upload repo
    
    HMS-10544: Add lookup for orphaned distributions

## Testing steps

`go test ./pkg/tasks/ -run 'TestAddUploadsSuite' -v -count=1`

For local manual test:
make compose-up, make run

Create an upload repository (snapshot enabled).
Upload an RPM (UI, or docs/upload-rpm.py against your local API).
Simulate the orphan: delete the CS snapshot row for that repo, leave Pulp alone. Or kill the worker after ModifyRpmRepositoryContent and before snapshot create.
Re-upload the same RPM.
Expect:
Task succeeds
Log: using orphaned repo version ...
New snapshot exists and the RPM shows in the repo
Without the fix, step 4 succeeds but the repo still has no packages or snapshot

You might need to add:
 `Permission: "content-sources:*:upload",` and ` Permission: "content-sources:repositories:upload",`
to your `pkg/test/mocks/rbac/rbac.go` file.