### PR TITLE
HMS-10710: list/get partner repositories

### DIFF
--- a/_playwright-tests/test-utils/src/client/apis/RepositoriesApi.ts
+++ b/_playwright-tests/test-utils/src/client/apis/RepositoriesApi.ts
@@ -190,6 +190,7 @@ export interface ListRepositoriesRequest {
     extendedRelease?: string;
     extendedReleaseVersion?: string;
     featureName?: string;
+    partner?: string;
 }
 
 export interface PartialUpdateRepositoryRequest {
@@ -1088,6 +1089,10 @@ export class RepositoriesApi extends runtime.BaseAPI {
 
         if (requestParameters['featureName'] != null) {
             queryParameters['feature_name'] = requestParameters['featureName'];
+        }
+
+        if (requestParameters['partner'] != null) {
+            queryParameters['partner'] = requestParameters['partner'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/api/docs.go
+++ b/api/docs.go
@@ -487,6 +487,12 @@ const docTemplate = `{
                         "description": "A comma separated list of feature names to filter on (e.g. feature1,feature2)",
                         "name": "feature_name",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter repositories by type partner",
+                        "name": "partner",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3068,6 +3068,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Filter repositories by type partner",
+                        "in": "query",
+                        "name": "partner",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {

--- a/pkg/dao/partner_visibility_test.go
+++ b/pkg/dao/partner_visibility_test.go
@@ -195,5 +195,5 @@ func (s *PartnerVisibilitySuite) TestForeignPartnerVisibleExpr() {
 		Scopes(ForeignPartnerVisibleExpr(viewerOrg)).
 		Pluck("uuid", &visibleUUIDs).Error
 	require.NoError(t, err)
-	assert.Equal(t, []string{visibleRepoConfig.UUID}, visibleUUIDs)
+	assert.Contains(t, visibleUUIDs, visibleRepoConfig.UUID)
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -603,6 +603,7 @@ func (r repositoryConfigDaoImpl) List(
 		}
 	}
 
+	applyPartnerResponseOverrides(ctx, r.db, repoConfigs, OrgID)
 	repos := convertToResponses(repoConfigs, contentPath)
 
 	return api.RepositoryCollectionResponse{Data: repos}, totalRepos, nil
@@ -610,7 +611,11 @@ func (r repositoryConfigDaoImpl) List(
 
 func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gorm.DB, filterData api.FilterData, accessibleFeatures []string) (*gorm.DB, error) {
 	orgs := []string{OrgID, config.RedHatOrg, config.CommunityOrg, config.LightwellOrg, config.LightwellDemoOrg}
-	filteredDB = filteredDB.Where("repository_configurations.org_id in ?", orgs).
+	filteredDB = filteredDB.
+		Where(
+			r.db.Where("repository_configurations.org_id in ?", orgs).
+				Or(foreignPartnerVisibleSQL, OrgID),
+		).
 		Joins("inner join repositories on repository_configurations.repository_uuid = repositories.uuid")
 
 	if filterData.Name != "" {
@@ -725,6 +730,13 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 			FROM unnest(string_to_array(repository_configurations.feature_name, ',')) AS t(token)
 			WHERE btrim(t.token) IN ?
 		)`, features)
+	}
+
+	switch filterData.Partner {
+	case "true":
+		filteredDB = filteredDB.Where("repository_configurations.partner = true")
+	case "false":
+		filteredDB = filteredDB.Where("repository_configurations.partner = false")
 	}
 
 	if filterData.ExtendedRelease == "none" {
@@ -845,25 +857,35 @@ func (r repositoryConfigDaoImpl) Fetch(ctx context.Context, orgID string, uuid s
 			return api.RepositoryResponse{}, err
 		}
 	}
-	repo = convertToResponses([]models.RepositoryConfiguration{repoConfig}, contentPath)[0]
+	repoConfigs := []models.RepositoryConfiguration{repoConfig}
+	applyPartnerResponseOverrides(ctx, r.db, repoConfigs, orgID)
+	repo = convertToResponses(repoConfigs, contentPath)[0]
 
 	return repo, nil
 }
 
-// fetchRepConfig: "includeSharedRepos" allows the fetching of red_hat and community repositories
+// fetchRepoConfig: "includeSharedRepos" allows the fetching of red_hat, community,
+// lightwell, and foreign partner repositories (partner repos require a published snapshot).
 func (r repositoryConfigDaoImpl) fetchRepoConfig(ctx context.Context, orgID string, uuid string, includeSharedRepos bool) (models.RepositoryConfiguration, error) {
 	found := models.RepositoryConfiguration{}
 
 	orgIdsToCheck := []string{orgID}
 
+	query := r.db.WithContext(ctx).
+		Preload("Repository").Preload("LastSnapshot").Preload("LastSnapshotTask")
+
 	if includeSharedRepos {
 		orgIdsToCheck = append(orgIdsToCheck, config.RedHatOrg, config.CommunityOrg, config.LightwellOrg, config.LightwellDemoOrg)
+		query = query.Where("UUID = ?", UuidifyString(uuid)).
+			Where(
+				r.db.Where("ORG_ID IN ?", orgIdsToCheck).
+					Or(foreignPartnerVisibleSQL, orgID),
+			)
+	} else {
+		query = query.Where("UUID = ? AND ORG_ID IN ?", UuidifyString(uuid), orgIdsToCheck)
 	}
 
-	result := r.db.WithContext(ctx).
-		Preload("Repository").Preload("LastSnapshot").Preload("LastSnapshotTask").
-		Where("UUID = ? AND ORG_ID IN ?", UuidifyString(uuid), orgIdsToCheck).
-		First(&found)
+	result := query.First(&found)
 
 	if result.Error != nil {
 		return found, RepositoryDBErrorToApi(result.Error, &uuid)
@@ -1647,6 +1669,35 @@ func ModelToImportRepoApi(model models.RepositoryConfiguration, warnings []map[s
 		resp.Warnings = warnings
 	} else {
 		resp.Warnings = []map[string]interface{}{}
+	}
+}
+
+// applyPartnerResponseOverrides masks a foreign partner repo as a community repo
+// and ensures LastSnapshot points to the latest published snapshot.
+func applyPartnerResponseOverrides(ctx context.Context, db *gorm.DB, repoConfigs []models.RepositoryConfiguration, viewerOrgID string) {
+	for i := range repoConfigs {
+		if !IsForeignPartnerView(repoConfigs[i], viewerOrgID) {
+			continue
+		}
+		repoConfigs[i].Repository.Origin = config.OriginCommunity
+		repoConfigs[i].OrgID = config.CommunityOrg
+		repoConfigs[i].AccountID = ""
+
+		if repoConfigs[i].LastSnapshot != nil && repoConfigs[i].LastSnapshot.Published {
+			continue
+		}
+		var snap models.Snapshot
+		err := db.WithContext(ctx).
+			Where("repository_configuration_uuid = ? AND published = true AND deleted_at IS NULL", repoConfigs[i].UUID).
+			Order("created_at DESC").
+			First(&snap).Error
+		if err != nil {
+			repoConfigs[i].LastSnapshotUUID = ""
+			repoConfigs[i].LastSnapshot = nil
+			continue
+		}
+		repoConfigs[i].LastSnapshotUUID = snap.UUID
+		repoConfigs[i].LastSnapshot = &snap
 	}
 }
 

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -1553,6 +1553,7 @@ func (suite *RepositoryConfigSuite) TestList() {
 		Arch:    "",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 	var err error
 
@@ -1625,6 +1626,7 @@ func (suite *RepositoryConfigSuite) TestListErrorGettingEntitledFeatures() {
 		Arch:    "",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 	var err error
 
@@ -1669,6 +1671,7 @@ func (suite *RepositoryConfigSuite) TestListPageDataLimit0() {
 		Arch:    "",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 	var err error
 
@@ -1706,6 +1709,7 @@ func (suite *RepositoryConfigSuite) TestListNoRepositories() {
 		Arch:    "",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	result := suite.tx.Where("org_id = ?", orgID).Find(&repoConfigs).Count(&total)
@@ -1736,6 +1740,7 @@ func (suite *RepositoryConfigSuite) TestListPageLimit() {
 		Arch:    "",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	var total int64
@@ -1797,7 +1802,7 @@ func (suite *RepositoryConfigSuite) TestListFilterUrl() {
 	suite.mockPulpForListOrFetch(4)
 	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"RHEL-OS-x86_64"}, nil)
 
-	filterData := api.FilterData{Origin: originCustom}
+	filterData := api.FilterData{Origin: originCustom, Partner: "false"}
 
 	_, err := seeds.SeedRepositoryConfigurations(suite.tx, 3, seeds.SeedOptions{OrgID: orgID, Versions: &[]string{config.El9}})
 	assert.Nil(t, err)
@@ -1838,7 +1843,7 @@ func (suite *RepositoryConfigSuite) TestListFilterFeature() {
 	suite.mockPulpForListOrFetch(5)
 	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), orgID).Return([]string{"feature1", "feature2", "feature3"}, nil)
 
-	filterData := api.FilterData{Origin: originCustom}
+	filterData := api.FilterData{Origin: originCustom, Partner: "false"}
 
 	// Create repos with different feature names
 	feature1 := "feature1"
@@ -1966,6 +1971,7 @@ func (suite *RepositoryConfigSuite) TestListFilterVersion() {
 		Arch:    "",
 		Version: config.El9,
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	_, err := seeds.SeedRepositoryConfigurations(suite.tx, nonEUSQuantity, seeds.SeedOptions{OrgID: orgID, Versions: &[]string{config.El9}})
@@ -1993,6 +1999,7 @@ func (suite *RepositoryConfigSuite) TestListFilterVersion() {
 		Arch:    "",
 		Version: extendedReleaseVersion,
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
@@ -2006,6 +2013,7 @@ func (suite *RepositoryConfigSuite) TestListFilterVersion() {
 		Arch:    "",
 		Version: fmt.Sprintf("%v,%v", config.El9, extendedReleaseVersion),
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	response, total, err = repoConfigDao.List(context.Background(), orgID, pageData, filterData)
@@ -2125,6 +2133,7 @@ func (suite *RepositoryConfigSuite) TestListFilterContentType() {
 	filterData := api.FilterData{
 		ContentType: config.ContentTypeRpm,
 		Origin:      originCustom,
+		Partner:     "false",
 	}
 
 	var total int64
@@ -2436,6 +2445,7 @@ func (suite *RepositoryConfigSuite) TestListFilterMultipleArch() {
 		Arch:    "x86_64,s390x",
 		Version: "",
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	quantity := 20
@@ -2480,6 +2490,7 @@ func (suite *RepositoryConfigSuite) TestListFilterMultipleVersions() {
 		Arch:    "",
 		Version: config.El7 + "," + config.El9,
 		Origin:  originCustom,
+		Partner: "false",
 	}
 
 	quantity := 20
@@ -4200,7 +4211,7 @@ func (suite *RepositoryConfigSuite) TestListPartnerFilter() {
 
 	// partner=true should include only partner repos
 	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), ownerOrg).Return([]string{}, nil)
-	suite.mockPulpForListOrFetch(3)
+	suite.mockPulpForListOrFetch(2)
 
 	response, _, err := rDao.List(context.Background(), ownerOrg, api.PaginationData{Limit: 100},
 		api.FilterData{Origin: config.OriginUpload, Partner: "true"})

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -4092,3 +4092,236 @@ func (s *RepositoryConfigSuite) TestSetPartnerRepo_UnmarkWithDeletedPublishedSna
 	require.NoError(t, s.tx.Where("uuid = ?", repoConfig.UUID).First(&updated).Error)
 	assert.False(t, updated.Partner)
 }
+
+func (suite *RepositoryConfigSuite) TestListPartnerRepoVisibleToForeignOrg() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-visible-repo", true)
+
+	publishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/pub",
+		PublicationHref:             "/pulp/publication/pub",
+		DistributionPath:            "/content/pub",
+		RepositoryPath:              "/content/pub",
+		DistributionHref:            "/pulp/distribution/pub",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(t, suite.tx.Create(&publishedSnap).Error)
+	require.NoError(t, suite.tx.Model(&partnerRC).Update("last_snapshot_uuid", publishedSnap.UUID).Error)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), viewerOrg).Return([]string{}, nil).Once()
+	suite.mockPulpForListOrFetch(1)
+
+	response, total, err := rDao.List(context.Background(), viewerOrg, api.PaginationData{Limit: 100}, api.FilterData{})
+	require.NoError(t, err)
+
+	var found *api.RepositoryResponse
+	for i := range response.Data {
+		if response.Data[i].UUID == partnerRC.UUID {
+			found = &response.Data[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "partner repo with published snapshot should be visible to foreign org, total=%d", total)
+	assert.Equal(t, config.OriginCommunity, found.Origin)
+	assert.Equal(t, config.CommunityOrg, found.OrgID)
+	assert.NotNil(t, found.LastSnapshot)
+	assert.Equal(t, publishedSnap.UUID, found.LastSnapshotUUID)
+}
+
+func (suite *RepositoryConfigSuite) TestListPartnerRepoNotVisibleWithoutPublishedSnapshot() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-no-snap", true)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), viewerOrg).Return([]string{}, nil).Once()
+	suite.mockPulpForListOrFetch(1)
+
+	response, _, err := rDao.List(context.Background(), viewerOrg, api.PaginationData{Limit: 100}, api.FilterData{})
+	require.NoError(t, err)
+
+	for _, r := range response.Data {
+		assert.NotEqual(t, partnerRC.UUID, r.UUID, "partner repo without published snapshot should not be visible to foreign org")
+	}
+}
+
+func (suite *RepositoryConfigSuite) TestListPartnerRepoVisibleToOwner() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-owner-view", true)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), ownerOrg).Return([]string{}, nil).Once()
+	suite.mockPulpForListOrFetch(1)
+
+	response, _, err := rDao.List(context.Background(), ownerOrg, api.PaginationData{Limit: 100}, api.FilterData{Origin: config.OriginUpload})
+	require.NoError(t, err)
+
+	var found *api.RepositoryResponse
+	for i := range response.Data {
+		if response.Data[i].UUID == partnerRC.UUID {
+			found = &response.Data[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "partner repo should always be visible to owner")
+	assert.Equal(t, config.OriginUpload, found.Origin, "owner should see the real origin")
+	assert.Equal(t, ownerOrg, found.OrgID, "owner should see the real org ID")
+}
+
+func (suite *RepositoryConfigSuite) TestListPartnerFilter() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+
+	repo1 := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo1, ownerOrg, "partner-filter-yes", true)
+	repo2 := createTestUploadRepository(t, suite.tx)
+	nonPartnerRC := createTestPartnerRepoConfig(t, suite.tx, repo2, ownerOrg, "partner-filter-no", false)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+
+	// partner=true should include only partner repos
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), ownerOrg).Return([]string{}, nil)
+	suite.mockPulpForListOrFetch(3)
+
+	response, _, err := rDao.List(context.Background(), ownerOrg, api.PaginationData{Limit: 100},
+		api.FilterData{Origin: config.OriginUpload, Partner: "true"})
+	require.NoError(t, err)
+
+	uuids := make([]string, len(response.Data))
+	for i, r := range response.Data {
+		uuids[i] = r.UUID
+	}
+	assert.Contains(t, uuids, partnerRC.UUID)
+	assert.NotContains(t, uuids, nonPartnerRC.UUID)
+
+	// partner=false should exclude partner repos
+	response, _, err = rDao.List(context.Background(), ownerOrg, api.PaginationData{Limit: 100},
+		api.FilterData{Origin: config.OriginUpload, Partner: "false"})
+	require.NoError(t, err)
+
+	uuids = make([]string, len(response.Data))
+	for i, r := range response.Data {
+		uuids[i] = r.UUID
+	}
+	assert.NotContains(t, uuids, partnerRC.UUID)
+	assert.Contains(t, uuids, nonPartnerRC.UUID)
+}
+
+func (suite *RepositoryConfigSuite) TestFetchPartnerRepoByForeignOrg() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-fetch-foreign", true)
+
+	publishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/fetch",
+		PublicationHref:             "/pulp/publication/fetch",
+		DistributionPath:            "/content/fetch",
+		RepositoryPath:              "/content/fetch",
+		DistributionHref:            "/pulp/distribution/fetch",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(t, suite.tx.Create(&publishedSnap).Error)
+	require.NoError(t, suite.tx.Model(&partnerRC).Update("last_snapshot_uuid", publishedSnap.UUID).Error)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+	suite.mockPulpForListOrFetch(1)
+
+	fetched, err := rDao.Fetch(context.Background(), viewerOrg, partnerRC.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, partnerRC.UUID, fetched.UUID)
+	assert.Equal(t, config.OriginCommunity, fetched.Origin)
+	assert.Equal(t, config.CommunityOrg, fetched.OrgID)
+}
+
+func (suite *RepositoryConfigSuite) TestFetchPartnerRepoNotFoundWithoutPublishedSnapshot() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-fetch-no-snap", true)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+
+	_, err := rDao.Fetch(context.Background(), viewerOrg, partnerRC.UUID)
+	assert.Error(t, err)
+	daoError, ok := err.(*ce.DaoError)
+	require.True(t, ok)
+	assert.True(t, daoError.NotFound)
+}
+
+func (suite *RepositoryConfigSuite) TestPartnerSnapshotOverrideUsesPublished() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-snap-override", true)
+
+	publishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/published",
+		PublicationHref:             "/pulp/publication/published",
+		DistributionPath:            "/content/published",
+		RepositoryPath:              "/content/published",
+		DistributionHref:            "/pulp/distribution/published",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(t, suite.tx.Create(&publishedSnap).Error)
+
+	unpublishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/unpublished",
+		PublicationHref:             "/pulp/publication/unpublished",
+		DistributionPath:            "/content/unpublished",
+		RepositoryPath:              "/content/unpublished",
+		DistributionHref:            "/pulp/distribution/unpublished",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   false,
+	}
+	require.NoError(t, suite.tx.Create(&unpublishedSnap).Error)
+
+	// Set last_snapshot_uuid to the unpublished one (simulating raw state)
+	require.NoError(t, suite.tx.Model(&partnerRC).Update("last_snapshot_uuid", unpublishedSnap.UUID).Error)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+	suite.mockPulpForListOrFetch(1)
+
+	fetched, err := rDao.Fetch(context.Background(), viewerOrg, partnerRC.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, publishedSnap.UUID, fetched.LastSnapshotUUID, "foreign viewer should see published snapshot, not the raw unpublished one")
+}

--- a/pkg/dao/rpms_test.go
+++ b/pkg/dao/rpms_test.go
@@ -1647,6 +1647,59 @@ func (s *RpmSuite) TestFetchTemplateErrataIDs() {
 	assert.True(s.T(), slices.IsSorted(ids))
 }
 
+func (s *RpmSuite) TestReadableRepositoryQueryPartnerVisibility() {
+	t := s.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	partnerRepo := models.Repository{
+		Base:        models.Base{UUID: uuid.NewString()},
+		Origin:      config.OriginUpload,
+		ContentType: config.ContentTypeRpm,
+		Public:      false,
+	}
+	require.NoError(t, s.tx.Create(&partnerRepo).Error)
+
+	partnerRepoConfig := createTestPartnerRepoConfig(t, s.tx, partnerRepo, ownerOrg, "partner rpm repo", true)
+
+	rpm := models.Rpm{
+		Base:     models.Base{UUID: uuid.NewString()},
+		Name:     "partner-pkg",
+		Arch:     "x86_64",
+		Version:  "1.0",
+		Release:  "1",
+		Epoch:    0,
+		Summary:  "partner package",
+		Checksum: uuid.NewString(),
+	}
+	require.NoError(t, s.tx.Create(&rpm).Error)
+	require.NoError(t, s.tx.Create(&models.RepositoryRpm{
+		RepositoryUUID: partnerRepo.UUID,
+		RpmUUID:        rpm.UUID,
+	}).Error)
+
+	uuids := []string{partnerRepoConfig.UUID}
+
+	// Before public=true: viewer org should NOT find the partner repo
+	var repoUUIDs []string
+	err := readableRepositoryQuery(s.tx, viewerOrg, []string{}, uuids).Pluck("repositories.uuid", &repoUUIDs).Error
+	require.NoError(t, err)
+	assert.Empty(t, repoUUIDs)
+
+	// Owner org should always find its own partner repo
+	repoUUIDs = nil
+	err = readableRepositoryQuery(s.tx, ownerOrg, []string{}, uuids).Pluck("repositories.uuid", &repoUUIDs).Error
+	require.NoError(t, err)
+	assert.Contains(t, repoUUIDs, partnerRepo.UUID)
+
+	// After public=true: viewer org should find the partner repo
+	require.NoError(t, s.tx.Model(&partnerRepo).Update("public", true).Error)
+	repoUUIDs = nil
+	err = readableRepositoryQuery(s.tx, viewerOrg, []string{}, uuids).Pluck("repositories.uuid", &repoUUIDs).Error
+	require.NoError(t, err)
+	assert.Contains(t, repoUUIDs, partnerRepo.UUID)
+}
+
 func makeErrataListItems(count int) []tangy.ErrataListItem {
 	items := make([]tangy.ErrataListItem, count)
 	for i := range items {

--- a/pkg/dao/suite_test.go
+++ b/pkg/dao/suite_test.go
@@ -176,6 +176,7 @@ func (s *DaoSuite) SetupTest() {
 	// s.tx = s.db
 	s.SeedPreexistingRHRepo()
 	s.SeedPreexistingCommunityRepo()
+	s.SeedPreexistingPartnerRepo()
 }
 
 // SeedPreexistingRHRepo seeds a red hat repo with a snapshot task to verify that tests with Red Hat repo filters
@@ -201,6 +202,27 @@ func (s *DaoSuite) SeedPreexistingCommunityRepo() {
 	require.NoError(s.T(), err)
 	_, err = seeds.SeedTasks(s.tx, 1,
 		seeds.TaskSeedOptions{OrgID: config.CommunityOrg,
+			RepoConfigUUID: repoConfigs[0].UUID,
+			Typename:       config.RepositorySnapshotTask,
+			Status:         config.TaskStatusCompleted})
+	require.NoError(s.T(), err)
+}
+
+// SeedPreexistingPartnerRepo seeds a partner repo with a published snapshot to verify that tests
+// account for preexisting partner repos visible via the foreign-partner visibility clause.
+func (s *DaoSuite) SeedPreexistingPartnerRepo() {
+	partnerOrg := seeds.RandomOrgId()
+	repoConfigs, err := seeds.SeedRepositoryConfigurations(s.tx, 1, seeds.SeedOptions{
+		OrgID:   partnerOrg,
+		Origin:  utils.Ptr(config.OriginUpload),
+		Partner: utils.Ptr(true),
+	})
+	require.NoError(s.T(), err)
+	snaps, err := seeds.SeedSnapshots(s.tx, repoConfigs[0].UUID, 1)
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), s.tx.Model(&snaps[0]).Update("published", true).Error)
+	_, err = seeds.SeedTasks(s.tx, 1,
+		seeds.TaskSeedOptions{OrgID: partnerOrg,
 			RepoConfigUUID: repoConfigs[0].UUID,
 			Typename:       config.RepositorySnapshotTask,
 			Status:         config.TaskStatusCompleted})

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -262,6 +262,7 @@ func ParseFilters(c echo.Context) api.FilterData {
 		String("extended_release", &filterData.ExtendedRelease).
 		String("extended_release_version", &filterData.ExtendedReleaseVersion).
 		String("feature_name", &filterData.FeatureName).
+		String("partner", &filterData.Partner).
 		BindError()
 
 	if err != nil {

--- a/pkg/handler/repositories.go
+++ b/pkg/handler/repositories.go
@@ -102,6 +102,7 @@ func getAccountIdOrgId(c echo.Context) (string, string) {
 // @Param		 extended_release query string false "A comma separated list of extended release types to filter on (eus, e4s), or 'none' to filter out extended release repositories"
 // @Param		 extended_release_version query string false "A comma separated list of extended release versions to filter on (e.g. 9.4,9.6). Use 'none' to filter repositories without extended release versions."
 // @Param		 feature_name query string false "A comma separated list of feature names to filter on (e.g. feature1,feature2)"
+// @Param		 partner query string false "Filter repositories by type partner"
 // @Accept       json
 // @Produce      json
 // @Success      200 {object} api.RepositoryCollectionResponse

--- a/pkg/seeds/seeds.go
+++ b/pkg/seeds/seeds.go
@@ -28,6 +28,7 @@ type SeedOptions struct {
 	ExtendedReleaseVersion *string
 	ExtendedRelease        *string
 	FeatureName            *string
+	Partner                *bool
 }
 
 type IntrospectionStatusMetadata struct {
@@ -78,7 +79,6 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) ([
 	for i := 0; i < size; i++ {
 		introspectionMetadata := randomIntrospectionStatusMetadata(options.Status)
 		repo := models.Repository{
-			URL:                          randomURL(),
 			LastIntrospectionTime:        introspectionMetadata.lastIntrospectionTime,
 			LastIntrospectionSuccessTime: introspectionMetadata.lastIntrospectionSuccessTime,
 			LastIntrospectionUpdateTime:  introspectionMetadata.lastIntrospectionUpdateTime,
@@ -86,6 +86,9 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) ([
 			LastIntrospectionStatus:      *introspectionMetadata.LastIntrospectionStatus,
 			Origin:                       *options.Origin,
 			ContentType:                  *options.ContentType,
+		}
+		if *options.Origin != config.OriginUpload {
+			repo.URL = randomURL()
 		}
 		repos = append(repos, repo)
 	}
@@ -112,6 +115,9 @@ func SeedRepositoryConfigurations(db *gorm.DB, size int, options SeedOptions) ([
 		}
 		if options.FeatureName != nil && *options.FeatureName != "" {
 			repoConfig.FeatureName = *options.FeatureName
+		}
+		if options.Partner != nil {
+			repoConfig.Partner = *options.Partner
 		}
 		repoConfigurations = append(repoConfigurations, repoConfig)
 	}


### PR DESCRIPTION
## Summary
  - Extend repository list/fetch to include foreign partner repos with published snapshots, masked as origin=community / org_id=-2                                                                                                                                                                                                          
  - Foreign viewers see the latest published snapshot (not raw last_snapshot_uuid if unpublished); owner org always sees real values                                                                                                                                                                                                        
  - Add ?partner=true/false query filter                                                                                                                                                                                                                                                                                                    
  - Fetch returns 404 for foreign viewers when no published snapshot exists                                                                                                                                                                                                                           
## Testing steps
Depends on other PRs, so the database needs to be changed manually to test

1. Set up partner repo: `UPDATE repository_configurations SET partner = true WHERE uuid = '<uuid>';` (must be upload)
2. Publish a snapshot: `UPDATE snapshots SET published = true WHERE uuid = '<snap_uuid>';` 
3. Sync public flag: `UPDATE repositories SET public = true WHERE uuid = (SELECT repository_uuid FROM repository_configurations WHERE uuid = '<repo_config_uuid>');`
4. From a different org, `GET /repositories/` - partner repo appears with origin=community, org_id=-2
5. From a different org, `GET /repositories/<uuid>` - same masking, snapshot is the published one
6. From a different org, `GET /repositories/?partner=true` - only partner repos returned
7. From owner org, `GET /repositories/?partner=true` - partner repo shows real origin/org
8. Unpublish: `UPDATE snapshots SET published = false WHERE uuid = '<snap_uuid>';` - partner repo disappears from foreign org list and fetch returns 404
