### PR TITLE
HMS-10706: partner repos snapshot updates

### DIFF
--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -4174,6 +4174,72 @@ func (_c *MockSnapshotDao_FetchLatestSnapshotModel_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// FetchLatestPublishedSnapshotModel provides a mock function for the type MockSnapshotDao
+func (_mock *MockSnapshotDao) FetchLatestPublishedSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error) {
+	ret := _mock.Called(ctx, repoConfigUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchLatestPublishedSnapshotModel")
+	}
+
+	var r0 models.Snapshot
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (models.Snapshot, error)); ok {
+		return returnFunc(ctx, repoConfigUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) models.Snapshot); ok {
+		r0 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r0 = ret.Get(0).(models.Snapshot)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FetchLatestPublishedSnapshotModel'
+type MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call struct {
+	*mock.Call
+}
+
+// FetchLatestPublishedSnapshotModel is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoConfigUUID string
+func (_e *MockSnapshotDao_Expecter) FetchLatestPublishedSnapshotModel(ctx interface{}, repoConfigUUID interface{}) *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call {
+	return &MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call{Call: _e.mock.On("FetchLatestPublishedSnapshotModel", ctx, repoConfigUUID)}
+}
+
+func (_c *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call) Run(run func(ctx context.Context, repoConfigUUID string)) *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call) Return(snapshot models.Snapshot, err error) *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call {
+	_c.Call.Return(snapshot, err)
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call) RunAndReturn(run func(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)) *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FetchModel provides a mock function for the type MockSnapshotDao
 func (_mock *MockSnapshotDao) FetchModel(ctx context.Context, uuid string, includeSoftDel bool) (models.Snapshot, error) {
 	ret := _mock.Called(ctx, uuid, includeSoftDel)

--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -4240,6 +4240,72 @@ func (_c *MockSnapshotDao_FetchLatestPublishedSnapshotModel_Call) RunAndReturn(r
 	return _c
 }
 
+// FetchLatestSnapshotForDistribution provides a mock function for the type MockSnapshotDao
+func (_mock *MockSnapshotDao) FetchLatestSnapshotForDistribution(ctx context.Context, repoConfigUUID string) (models.Snapshot, error) {
+	ret := _mock.Called(ctx, repoConfigUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchLatestSnapshotForDistribution")
+	}
+
+	var r0 models.Snapshot
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (models.Snapshot, error)); ok {
+		return returnFunc(ctx, repoConfigUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) models.Snapshot); ok {
+		r0 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r0 = ret.Get(0).(models.Snapshot)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSnapshotDao_FetchLatestSnapshotForDistribution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FetchLatestSnapshotForDistribution'
+type MockSnapshotDao_FetchLatestSnapshotForDistribution_Call struct {
+	*mock.Call
+}
+
+// FetchLatestSnapshotForDistribution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoConfigUUID string
+func (_e *MockSnapshotDao_Expecter) FetchLatestSnapshotForDistribution(ctx interface{}, repoConfigUUID interface{}) *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call {
+	return &MockSnapshotDao_FetchLatestSnapshotForDistribution_Call{Call: _e.mock.On("FetchLatestSnapshotForDistribution", ctx, repoConfigUUID)}
+}
+
+func (_c *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call) Run(run func(ctx context.Context, repoConfigUUID string)) *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call) Return(snapshot models.Snapshot, err error) *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call {
+	_c.Call.Return(snapshot, err)
+	return _c
+}
+
+func (_c *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call) RunAndReturn(run func(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)) *MockSnapshotDao_FetchLatestSnapshotForDistribution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FetchModel provides a mock function for the type MockSnapshotDao
 func (_mock *MockSnapshotDao) FetchModel(ctx context.Context, uuid string, includeSoftDel bool) (models.Snapshot, error) {
 	ret := _mock.Called(ctx, uuid, includeSoftDel)

--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -3897,8 +3897,8 @@ func (_c *MockSnapshotDao_Delete_Call) RunAndReturn(run func(ctx context.Context
 }
 
 // Fetch provides a mock function for the type MockSnapshotDao
-func (_mock *MockSnapshotDao) Fetch(ctx context.Context, uuid string) (api.SnapshotResponse, error) {
-	ret := _mock.Called(ctx, uuid)
+func (_mock *MockSnapshotDao) Fetch(ctx context.Context, orgID string, uuid string) (api.SnapshotResponse, error) {
+	ret := _mock.Called(ctx, orgID, uuid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Fetch")
@@ -3906,16 +3906,16 @@ func (_mock *MockSnapshotDao) Fetch(ctx context.Context, uuid string) (api.Snaps
 
 	var r0 api.SnapshotResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (api.SnapshotResponse, error)); ok {
-		return returnFunc(ctx, uuid)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (api.SnapshotResponse, error)); ok {
+		return returnFunc(ctx, orgID, uuid)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) api.SnapshotResponse); ok {
-		r0 = returnFunc(ctx, uuid)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) api.SnapshotResponse); ok {
+		r0 = returnFunc(ctx, orgID, uuid)
 	} else {
 		r0 = ret.Get(0).(api.SnapshotResponse)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, uuid)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, orgID, uuid)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3929,12 +3929,13 @@ type MockSnapshotDao_Fetch_Call struct {
 
 // Fetch is a helper method to define mock.On call
 //   - ctx context.Context
+//   - orgID string
 //   - uuid string
-func (_e *MockSnapshotDao_Expecter) Fetch(ctx interface{}, uuid interface{}) *MockSnapshotDao_Fetch_Call {
-	return &MockSnapshotDao_Fetch_Call{Call: _e.mock.On("Fetch", ctx, uuid)}
+func (_e *MockSnapshotDao_Expecter) Fetch(ctx interface{}, orgID interface{}, uuid interface{}) *MockSnapshotDao_Fetch_Call {
+	return &MockSnapshotDao_Fetch_Call{Call: _e.mock.On("Fetch", ctx, orgID, uuid)}
 }
 
-func (_c *MockSnapshotDao_Fetch_Call) Run(run func(ctx context.Context, uuid string)) *MockSnapshotDao_Fetch_Call {
+func (_c *MockSnapshotDao_Fetch_Call) Run(run func(ctx context.Context, orgID string, uuid string)) *MockSnapshotDao_Fetch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -3944,9 +3945,14 @@ func (_c *MockSnapshotDao_Fetch_Call) Run(run func(ctx context.Context, uuid str
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -3957,7 +3963,7 @@ func (_c *MockSnapshotDao_Fetch_Call) Return(snapshotResponse api.SnapshotRespon
 	return _c
 }
 
-func (_c *MockSnapshotDao_Fetch_Call) RunAndReturn(run func(ctx context.Context, uuid string) (api.SnapshotResponse, error)) *MockSnapshotDao_Fetch_Call {
+func (_c *MockSnapshotDao_Fetch_Call) RunAndReturn(run func(ctx context.Context, orgID string, uuid string) (api.SnapshotResponse, error)) *MockSnapshotDao_Fetch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -155,7 +155,7 @@ type SnapshotDao interface {
 	FetchSnapshotsByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) (api.ListSnapshotByDateResponse, error)
 	FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
 	GetRepositoryConfigurationFile(ctx context.Context, orgID, snapshotUUID string, isLatest bool) (string, error)
-	Fetch(ctx context.Context, uuid string) (api.SnapshotResponse, error)
+	Fetch(ctx context.Context, orgID string, uuid string) (api.SnapshotResponse, error)
 	FetchSnapshotsModelByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) ([]models.Snapshot, error)
 	SetDetectedOSVersion(ctx context.Context, uuid string) (string, error)
 }

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -153,6 +153,9 @@ type SnapshotDao interface {
 	FetchLatestSnapshot(ctx context.Context, repoConfigUUID string) (api.SnapshotResponse, error)
 	FetchLatestSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
 	FetchLatestPublishedSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
+	// FetchLatestSnapshotForDistribution returns the snapshot that should back Pulp "{repo}/latest"
+	// (newest published for partner repos; newest overall otherwise).
+	FetchLatestSnapshotForDistribution(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
 	FetchSnapshotsByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) (api.ListSnapshotByDateResponse, error)
 	FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
 	GetRepositoryConfigurationFile(ctx context.Context, orgID, snapshotUUID string, isLatest bool) (string, error)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -152,6 +152,7 @@ type SnapshotDao interface {
 	ClearDeletedAt(ctx context.Context, snapUUID string) error
 	FetchLatestSnapshot(ctx context.Context, repoConfigUUID string) (api.SnapshotResponse, error)
 	FetchLatestSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
+	FetchLatestPublishedSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
 	FetchSnapshotsByDateAndRepository(ctx context.Context, orgID string, request api.ListSnapshotByDateRequest) (api.ListSnapshotByDateResponse, error)
 	FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error)
 	GetRepositoryConfigurationFile(ctx context.Context, orgID, snapshotUUID string, isLatest bool) (string, error)

--- a/pkg/dao/partner_visibility.go
+++ b/pkg/dao/partner_visibility.go
@@ -17,6 +17,20 @@ const foreignPartnerVisibleSQL = `
 		AND snapshots.deleted_at IS NULL
 	)`
 
+// readableSnapshotOrgFilterSQL selects snapshots the viewer may read:
+// owned / RH / community repos, or published snapshots of foreign partner repos.
+// Args: orgIDs []string (viewer + shared orgs), viewerOrgID string.
+// Requires the snapshots table to be aliased as "s".
+const readableSnapshotOrgFilterSQL = `
+	(
+		repository_configurations.org_id IN ?
+		OR (
+			repository_configurations.partner = true
+			AND repository_configurations.org_id != ?
+			AND s.published = true
+		)
+	)`
+
 // IsForeignPartnerView reports whether viewerOrgID is accessing a partner repository it does not own.
 func IsForeignPartnerView(repoConfig models.RepositoryConfiguration, viewerOrgID string) bool {
 	return repoConfig.Partner && repoConfig.OrgID != viewerOrgID

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -69,13 +69,14 @@ func (sDao *snapshotDaoImpl) List(
 	var totalSnaps int64
 	var repoConfig models.RepositoryConfiguration
 
-	// First check if repo config exists
-	result := sDao.db.WithContext(ctx).Where(
-		"repository_configurations.org_id IN (?,?,?) AND uuid = ?",
-		orgID,
-		config.RedHatOrg,
-		config.CommunityOrg,
-		UuidifyString(repoConfigUUID)).
+	// First check if repo config exists and is readable by the viewer
+	result := sDao.db.WithContext(ctx).
+		Where("uuid = ?", UuidifyString(repoConfigUUID)).
+		Where(
+			"(org_id IN ?) OR ("+foreignPartnerVisibleSQL+")",
+			[]string{orgID, config.RedHatOrg, config.CommunityOrg},
+			orgID,
+		).
 		First(&repoConfig)
 
 	if result.Error != nil {
@@ -89,6 +90,10 @@ func (sDao *snapshotDaoImpl) List(
 
 	filteredDB := readableSnapshots(sDao.db.WithContext(ctx), orgID).
 		Where("repository_configuration_uuid = ?", UuidifyString(repoConfigUUID))
+
+	if IsForeignPartnerView(repoConfig, orgID) {
+		filteredDB = filteredDB.Where("snapshots.published = ?", true)
+	}
 
 	// Get count
 	filteredDB.Count(&totalSnaps)
@@ -177,14 +182,30 @@ func readableSnapshots(db *gorm.DB, orgId string) *gorm.DB {
 	return db.Model(&models.Snapshot{}).
 		Preload("RepositoryConfiguration").
 		Joins("JOIN repository_configurations ON repository_configuration_uuid = repository_configurations.uuid").
-		Where("repository_configurations.org_id IN (?,?,?)", orgId, config.RedHatOrg, config.CommunityOrg).
+		Where(
+			"(repository_configurations.org_id IN ?) OR ("+foreignPartnerVisibleSQL+")",
+			[]string{orgId, config.RedHatOrg, config.CommunityOrg},
+			orgId,
+		).
 		Where("snapshots.deleted_at IS NULL")
 }
 
-func (sDao *snapshotDaoImpl) Fetch(ctx context.Context, uuid string) (api.SnapshotResponse, error) {
+// denyUnpublishedForeignPartnerAccess returns a not-found error when a foreign viewer
+// attempts to access an unpublished snapshot of a partner repository.
+func denyUnpublishedForeignPartnerAccess(viewerOrgID string, snap models.Snapshot) error {
+	if IsForeignPartnerView(snap.RepositoryConfiguration, viewerOrgID) && !snap.Published {
+		return SnapshotsDBToApiError(gorm.ErrRecordNotFound, &snap.UUID)
+	}
+	return nil
+}
+
+func (sDao *snapshotDaoImpl) Fetch(ctx context.Context, orgID string, uuid string) (api.SnapshotResponse, error) {
 	var snapAPI api.SnapshotResponse
 	snapModel, err := sDao.fetch(ctx, uuid)
 	if err != nil {
+		return api.SnapshotResponse{}, err
+	}
+	if err := denyUnpublishedForeignPartnerAccess(orgID, snapModel); err != nil {
 		return api.SnapshotResponse{}, err
 	}
 	SnapshotModelToApi(snapModel, &snapAPI)
@@ -248,11 +269,19 @@ func (sDao *snapshotDaoImpl) GetRepositoryConfigurationFile(ctx context.Context,
 	if err != nil {
 		return "", err
 	}
-
-	rcDao := repositoryConfigDaoImpl{db: sDao.db, fsClient: sDao.fsClient}
-	repoConfig, err := rcDao.fetchRepoConfig(ctx, orgID, snapshot.RepositoryConfigurationUUID, true)
-	if err != nil {
+	if err := denyUnpublishedForeignPartnerAccess(orgID, snapshot); err != nil {
 		return "", err
+	}
+
+	var repoConfig models.RepositoryConfiguration
+	if IsForeignPartnerView(snapshot.RepositoryConfiguration, orgID) {
+		repoConfig = snapshot.RepositoryConfiguration
+	} else {
+		rcDao := repositoryConfigDaoImpl{db: sDao.db, fsClient: sDao.fsClient}
+		repoConfig, err = rcDao.fetchRepoConfig(ctx, orgID, snapshot.RepositoryConfigurationUUID, true)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	pc := sDao.pulpClient
@@ -471,6 +500,8 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 	snaps := []models.Snapshot{}
 	date := request.Date.UTC().Format(time.RFC3339)
 
+	readableOrgs := []string{orgID, config.RedHatOrg, config.CommunityOrg}
+
 	// finds the snapshot for each repo that is just before (or equal to) our date
 	beforeQuery := sDao.db.WithContext(ctx).Raw(`
 		SELECT DISTINCT ON (s.repository_configuration_uuid) s.uuid
@@ -478,10 +509,10 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 			INNER JOIN repository_configurations ON s.repository_configuration_uuid = repository_configurations.uuid
 			WHERE s.repository_configuration_uuid IN ?
 			AND s.deleted_at IS NULL
-			AND repository_configurations.org_id IN ?
+			AND `+readableSnapshotOrgFilterSQL+`
 			AND date_trunc('second', s.created_at::timestamptz) <= ?
 			ORDER BY s.repository_configuration_uuid,  s.created_at DESC
-	`, UuidifyStrings(request.RepositoryUUIDS), []string{orgID, config.RedHatOrg, config.CommunityOrg}, date)
+	`, UuidifyStrings(request.RepositoryUUIDS), readableOrgs, orgID, date)
 
 	// finds the snapshot for each repo that is the first one after our date
 	afterQuery := sDao.db.WithContext(ctx).Raw(`SELECT DISTINCT ON (s.repository_configuration_uuid) s.uuid
@@ -489,10 +520,10 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsModelByDateAndRepository(ctx context.
 			INNER JOIN repository_configurations ON s.repository_configuration_uuid = repository_configurations.uuid
 			WHERE s.repository_configuration_uuid IN ?
 			AND s.deleted_at IS NULL
-			AND repository_configurations.org_id IN ?
+			AND `+readableSnapshotOrgFilterSQL+`
 			AND date_trunc('second', s.created_at::timestamptz)  > ?
 			ORDER BY s.repository_configuration_uuid, s.created_at ASC
-	`, UuidifyStrings(request.RepositoryUUIDS), []string{orgID, config.RedHatOrg, config.CommunityOrg}, date)
+	`, UuidifyStrings(request.RepositoryUUIDS), readableOrgs, orgID, date)
 	// For each repo, pick the oldest of this combined set (ideally the one just before our date, if that doesn't exist, the one after)
 	combined := sDao.db.WithContext(ctx).Raw(`
 			select DISTINCT ON (s2.repository_configuration_uuid) s2.uuid
@@ -517,7 +548,14 @@ func (sDao *snapshotDaoImpl) FetchSnapshotsByDateAndRepository(ctx context.Conte
 	date = date.AddDate(0, 0, 1) // Set the date to 24 hours later, inclusive of the current day
 
 	var count int64
-	resp := sDao.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).Where("org_id = ? or org_id = ? or org_id = ?", orgID, config.RedHatOrg, config.CommunityOrg).Where("uuid in ?", UuidifyStrings(request.RepositoryUUIDS)).Count(&count)
+	resp := sDao.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).
+		Where(
+			"(org_id IN ?) OR ("+foreignPartnerVisibleSQL+")",
+			[]string{orgID, config.RedHatOrg, config.CommunityOrg},
+			orgID,
+		).
+		Where("uuid in ?", UuidifyStrings(request.RepositoryUUIDS)).
+		Count(&count)
 	if resp.Error != nil {
 		return api.ListSnapshotByDateResponse{}, fmt.Errorf("could not query repository UUIDs: %w", resp.Error)
 	}

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -91,10 +91,6 @@ func (sDao *snapshotDaoImpl) List(
 	filteredDB := readableSnapshots(sDao.db.WithContext(ctx), orgID).
 		Where("repository_configuration_uuid = ?", UuidifyString(repoConfigUUID))
 
-	if IsForeignPartnerView(repoConfig, orgID) {
-		filteredDB = filteredDB.Where("snapshots.published = ?", true)
-	}
-
 	// Get count
 	filteredDB.Count(&totalSnaps)
 
@@ -183,7 +179,12 @@ func readableSnapshots(db *gorm.DB, orgId string) *gorm.DB {
 		Preload("RepositoryConfiguration").
 		Joins("JOIN repository_configurations ON repository_configuration_uuid = repository_configurations.uuid").
 		Where(
-			"(repository_configurations.org_id IN ?) OR ("+foreignPartnerVisibleSQL+")",
+			`(repository_configurations.org_id IN ?)
+			 OR (
+				repository_configurations.partner = true
+				AND repository_configurations.org_id != ?
+				AND snapshots.published = true
+			)`,
 			[]string{orgId, config.RedHatOrg, config.CommunityOrg},
 			orgId,
 		).

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -477,6 +477,21 @@ func (sDao *snapshotDaoImpl) FetchLatestSnapshotModel(ctx context.Context, repoC
 	return snap, nil
 }
 
+func (sDao *snapshotDaoImpl) FetchLatestPublishedSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error) {
+	var snap models.Snapshot
+	result := sDao.db.WithContext(ctx).
+		Preload("RepositoryConfiguration").
+		Where("snapshots.repository_configuration_uuid = ?", UuidifyString(repoConfigUUID)).
+		Where("snapshots.published = ?", true).
+		Where("snapshots.deleted_at IS NULL").
+		Order("created_at DESC").
+		First(&snap)
+	if result.Error != nil {
+		return models.Snapshot{}, result.Error
+	}
+	return snap, nil
+}
+
 func (sDao *snapshotDaoImpl) FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error) {
 	var snap models.Snapshot
 	result := sDao.db.WithContext(ctx).

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -454,8 +454,7 @@ func (sDao *snapshotDaoImpl) ClearDeletedAt(ctx context.Context, snapUUID string
 }
 
 func (sDao *snapshotDaoImpl) FetchLatestSnapshot(ctx context.Context, repoConfigUUID string) (api.SnapshotResponse, error) {
-	var snap models.Snapshot
-	snap, err := sDao.FetchLatestSnapshotModel(ctx, repoConfigUUID)
+	snap, err := sDao.FetchLatestSnapshotForDistribution(ctx, repoConfigUUID)
 	if err != nil {
 		return api.SnapshotResponse{}, err
 	}
@@ -490,6 +489,24 @@ func (sDao *snapshotDaoImpl) FetchLatestPublishedSnapshotModel(ctx context.Conte
 		return models.Snapshot{}, result.Error
 	}
 	return snap, nil
+}
+
+// FetchLatestSnapshotForDistribution returns the snapshot that should back Pulp "{repo}/latest".
+// Partner repos use the newest published snapshot; others use the newest snapshot overall.
+// Callers need not load the repository configuration first.
+func (sDao *snapshotDaoImpl) FetchLatestSnapshotForDistribution(ctx context.Context, repoConfigUUID string) (models.Snapshot, error) {
+	var repoConfig models.RepositoryConfiguration
+	err := sDao.db.WithContext(ctx).
+		Select("uuid", "partner").
+		Where("uuid = ?", UuidifyString(repoConfigUUID)).
+		First(&repoConfig).Error
+	if err != nil {
+		return models.Snapshot{}, err
+	}
+	if repoConfig.Partner {
+		return sDao.FetchLatestPublishedSnapshotModel(ctx, repoConfigUUID)
+	}
+	return sDao.FetchLatestSnapshotModel(ctx, repoConfigUUID)
 }
 
 func (sDao *snapshotDaoImpl) FetchSnapshotByVersionHref(ctx context.Context, repoConfigUUID string, versionHref string) (*api.SnapshotResponse, error) {

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -386,6 +386,35 @@ func (s *SnapshotsSuite) TestFetchLatestSnapshot() {
 	assert.Equal(t, latestSnapshot.RepositoryPath, response.RepositoryPath)
 }
 
+func (s *SnapshotsSuite) TestFetchLatestPublishedSnapshotModel() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "latest published", true)
+
+	publishedOlder := createPublishedSnapshot(t, tx, repoConfig)
+	_ = createSnapshot(t, tx, repoConfig) // newer unpublished
+
+	latestOverall, err := sDao.FetchLatestSnapshotModel(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.NotEqual(t, publishedOlder.UUID, latestOverall.UUID)
+	assert.False(t, latestOverall.Published)
+
+	latestPublished, err := sDao.FetchLatestPublishedSnapshotModel(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, publishedOlder.UUID, latestPublished.UUID)
+	assert.True(t, latestPublished.Published)
+
+	unpublishedOnly := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "no published", true)
+	createSnapshot(t, tx, unpublishedOnly)
+	_, err = sDao.FetchLatestPublishedSnapshotModel(ctx, unpublishedOnly.UUID)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
 func (s *SnapshotsSuite) TestFetchSnapshotsByDateAndRepository() {
 	t := s.T()
 	tx := s.tx

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -386,6 +386,65 @@ func (s *SnapshotsSuite) TestFetchLatestSnapshot() {
 	assert.Equal(t, latestSnapshot.RepositoryPath, response.RepositoryPath)
 }
 
+func (s *SnapshotsSuite) TestFetchLatestSnapshotForDistributionPartnerUsesPublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "dist latest partner", true)
+
+	publishedOlder := createPublishedSnapshot(t, tx, repoConfig)
+	_ = createSnapshot(t, tx, repoConfig) // newer unpublished
+
+	overall, err := sDao.FetchLatestSnapshotModel(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.NotEqual(t, publishedOlder.UUID, overall.UUID)
+	assert.False(t, overall.Published)
+
+	forDist, err := sDao.FetchLatestSnapshotForDistribution(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, publishedOlder.UUID, forDist.UUID)
+	assert.True(t, forDist.Published)
+
+	// API FetchLatestSnapshot follows distribution semantics for partner repos
+	apiSnap, err := sDao.FetchLatestSnapshot(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, publishedOlder.UUID, apiSnap.UUID)
+	assert.True(t, apiSnap.Published)
+}
+
+func (s *SnapshotsSuite) TestFetchLatestSnapshotForDistributionNonPartnerUsesOverall() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createRepository(t, tx, "", false)
+	createSnapshot(t, tx, repoConfig)
+	latest := createSnapshot(t, tx, repoConfig)
+
+	forDist, err := sDao.FetchLatestSnapshotForDistribution(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, latest.UUID, forDist.UUID)
+}
+
+func (s *SnapshotsSuite) TestFetchLatestSnapshotForDistributionPartnerNoPublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "dist latest no published", true)
+	createSnapshot(t, tx, repoConfig)
+
+	_, err := sDao.FetchLatestSnapshotForDistribution(ctx, repoConfig.UUID)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
 func (s *SnapshotsSuite) TestFetchLatestPublishedSnapshotModel() {
 	t := s.T()
 	tx := s.tx
@@ -1215,6 +1274,43 @@ func (s *SnapshotsSuite) TestGetRepositoryConfigurationFilePartnerAccessControl(
 	file, err = sDao.GetRepositoryConfigurationFile(ctx, viewerOrg, unpublished.UUID, false)
 	assert.Error(t, err)
 	assert.Empty(t, file)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestGetLatestRepoConfigurationFilePartnerForeignUsesPublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner latest config.repo", true)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+	_ = createSnapshot(t, tx, repoConfig) // newer unpublished tip
+
+	overall, err := sDao.FetchLatestSnapshotModel(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.False(t, overall.Published)
+
+	latest, err := sDao.FetchLatestSnapshot(ctx, repoConfig.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, published.UUID, latest.UUID)
+	assert.True(t, latest.Published)
+
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
+	file, err := sDao.GetRepositoryConfigurationFile(ctx, viewerOrg, latest.UUID, true)
+	assert.NoError(t, err)
+	assert.Contains(t, file, repoConfig.Name)
+	assert.Contains(t, file, fmt.Sprintf("%s/latest", repoConfig.UUID))
+
+	_, err = sDao.GetRepositoryConfigurationFile(ctx, viewerOrg, overall.UUID, true)
+	assert.Error(t, err)
 	var daoError *ce.DaoError
 	require.True(t, errors.As(err, &daoError))
 	assert.True(t, daoError.NotFound)

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/config"
 	ce "github.com/content-services/content-sources-backend/pkg/errors"
 	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/seeds"
 	"github.com/content-services/content-sources-backend/pkg/utils"
 	"github.com/content-services/tang/pkg/tangy"
 	"github.com/content-services/yummy/pkg/yum"
@@ -803,7 +804,7 @@ func (s *SnapshotsSuite) TestSoftDeleteSnapshot() {
 	err := sDao.SoftDelete(context.Background(), snapshot.UUID)
 	assert.NoError(t, err)
 
-	snap, err := sDao.Fetch(context.Background(), snapshot.UUID)
+	snap, err := sDao.Fetch(context.Background(), repoConfig.OrgID, snapshot.UUID)
 	assert.Error(t, err)
 	assert.Equal(t, api.SnapshotResponse{}, snap)
 
@@ -860,7 +861,7 @@ func (s *SnapshotsSuite) TestClearDeletedAt() {
 	err = sDao.ClearDeletedAt(context.Background(), snapshot.UUID)
 	assert.NoError(t, err)
 
-	snap, err := sDao.Fetch(context.Background(), snapshot.UUID)
+	snap, err := sDao.Fetch(context.Background(), repoConfig.OrgID, snapshot.UUID)
 	assert.NoError(t, err)
 	assert.Equal(t, snapshot.UUID, snap.UUID)
 }
@@ -895,9 +896,9 @@ func (s *SnapshotsSuite) TestBulkDelete() {
 	errs := sDao.BulkDelete(context.Background(), []string{s2.UUID, s3.UUID})
 	assert.Len(t, errs, 0)
 
-	_, err := sDao.Fetch(context.Background(), s2.UUID)
+	_, err := sDao.Fetch(context.Background(), repoConfig.OrgID, s2.UUID)
 	assert.Error(t, err)
-	_, err = sDao.Fetch(context.Background(), s2.UUID)
+	_, err = sDao.Fetch(context.Background(), repoConfig.OrgID, s3.UUID)
 	assert.Error(t, err)
 
 	snaps, err := sDao.FetchForRepoConfigUUID(context.Background(), repoConfig.UUID, false)
@@ -977,4 +978,339 @@ func (s *SnapshotsSuite) TestSetDetectedOSVersion() {
 	err = tx.Where("uuid = ?", snap.UUID).First(&updatedSnap).Error
 	assert.NoError(t, err)
 	assert.Equal(t, "9.4", updatedSnap.DetectedOSVersion)
+}
+
+func createPublishedSnapshot(t *testing.T, tx *gorm.DB, rConfig models.RepositoryConfiguration) models.Snapshot {
+	t.Helper()
+	snap := createSnapshot(t, tx, rConfig)
+	err := tx.Model(&models.Snapshot{}).Where("uuid = ?", snap.UUID).Update("published", true).Error
+	require.NoError(t, err)
+	snap.Published = true
+	return snap
+}
+
+func (s *SnapshotsSuite) TestListPartnerRepoForeignViewerSeesOnlyPublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner list repo", true)
+	unpublished := createSnapshot(t, tx, repoConfig)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+
+	pageData := api.PaginationData{Limit: 100, Offset: 0}
+
+	ownerCollection, ownerTotal, err := sDao.List(ctx, ownerOrg, repoConfig.UUID, pageData, api.FilterData{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), ownerTotal)
+	assert.Len(t, ownerCollection.Data, 2)
+
+	viewerCollection, viewerTotal, err := sDao.List(ctx, viewerOrg, repoConfig.UUID, pageData, api.FilterData{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), viewerTotal)
+	require.Len(t, viewerCollection.Data, 1)
+	assert.Equal(t, published.UUID, viewerCollection.Data[0].UUID)
+	assert.True(t, viewerCollection.Data[0].Published)
+	assert.NotEqual(t, unpublished.UUID, viewerCollection.Data[0].UUID)
+}
+
+func (s *SnapshotsSuite) TestListPartnerRepoUnpublishedNotVisibleToForeignViewer() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	sDao := snapshotDaoImpl{db: tx}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner unpublished only", true)
+	createSnapshot(t, tx, repoConfig)
+
+	_, _, err := sDao.List(ctx, viewerOrg, repoConfig.UUID, api.PaginationData{Limit: 100}, api.FilterData{})
+	assert.Error(t, err)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchPartnerSnapshotAccessControl() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner fetch repo", true)
+	unpublished := createSnapshot(t, tx, repoConfig)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+
+	snap, err := sDao.Fetch(ctx, ownerOrg, unpublished.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, unpublished.UUID, snap.UUID)
+	assert.False(t, snap.Published)
+
+	snap, err = sDao.Fetch(ctx, viewerOrg, published.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, published.UUID, snap.UUID)
+	assert.True(t, snap.Published)
+
+	_, err = sDao.Fetch(ctx, viewerOrg, unpublished.UUID)
+	assert.Error(t, err)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchSnapshotsByDatePartnerPublishedOnly() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+	baseTime := time.Now()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner date repo", true)
+	s.createSnapshotAtSpecifiedTime(repoConfig, baseTime.Add(-time.Hour))
+	published := s.createSnapshotAtSpecifiedTime(repoConfig, baseTime)
+	err := tx.Model(&models.Snapshot{}).Where("uuid = ?", published.UUID).Update("published", true).Error
+	require.NoError(t, err)
+
+	request := api.ListSnapshotByDateRequest{
+		RepositoryUUIDS: []string{repoConfig.UUID},
+		Date:            baseTime,
+	}
+
+	ownerResp, err := sDao.FetchSnapshotsByDateAndRepository(ctx, ownerOrg, request)
+	assert.NoError(t, err)
+	require.Len(t, ownerResp.Data, 1)
+	require.NotNil(t, ownerResp.Data[0].Match)
+	// Owner can match nearest snap (published at baseTime)
+	assert.Equal(t, published.UUID, ownerResp.Data[0].Match.UUID)
+
+	viewerResp, err := sDao.FetchSnapshotsByDateAndRepository(ctx, viewerOrg, request)
+	assert.NoError(t, err)
+	require.Len(t, viewerResp.Data, 1)
+	require.NotNil(t, viewerResp.Data[0].Match)
+	assert.Equal(t, published.UUID, viewerResp.Data[0].Match.UUID)
+	assert.True(t, viewerResp.Data[0].Match.Published)
+
+	// Unpublished-only partner repo is not readable for foreign viewer
+	unpublishedOnly := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner date unpublished", true)
+	s.createSnapshotAtSpecifiedTime(unpublishedOnly, baseTime)
+	_, err = sDao.FetchSnapshotsByDateAndRepository(ctx, viewerOrg, api.ListSnapshotByDateRequest{
+		RepositoryUUIDS: []string{unpublishedOnly.UUID},
+		Date:            baseTime,
+	})
+	assert.Error(t, err)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestFetchSnapshotsByDatePartnerNearestUnpublishedForeignGetsPublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+	baseTime := time.Now()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner date nearest unpublished", true)
+	publishedOlder := s.createSnapshotAtSpecifiedTime(repoConfig, baseTime.Add(-2*time.Hour))
+	err := tx.Model(&models.Snapshot{}).Where("uuid = ?", publishedOlder.UUID).Update("published", true).Error
+	require.NoError(t, err)
+	unpublishedNearest := s.createSnapshotAtSpecifiedTime(repoConfig, baseTime)
+
+	request := api.ListSnapshotByDateRequest{
+		RepositoryUUIDS: []string{repoConfig.UUID},
+		Date:            baseTime,
+	}
+
+	ownerResp, err := sDao.FetchSnapshotsByDateAndRepository(ctx, ownerOrg, request)
+	assert.NoError(t, err)
+	require.Len(t, ownerResp.Data, 1)
+	require.NotNil(t, ownerResp.Data[0].Match)
+	assert.Equal(t, unpublishedNearest.UUID, ownerResp.Data[0].Match.UUID)
+	assert.False(t, ownerResp.Data[0].Match.Published)
+
+	viewerResp, err := sDao.FetchSnapshotsByDateAndRepository(ctx, viewerOrg, request)
+	assert.NoError(t, err)
+	require.Len(t, viewerResp.Data, 1)
+	require.NotNil(t, viewerResp.Data[0].Match)
+	assert.Equal(t, publishedOlder.UUID, viewerResp.Data[0].Match.UUID)
+	assert.True(t, viewerResp.Data[0].Match.Published)
+}
+
+func (s *SnapshotsSuite) TestGetRepositoryConfigurationFilePartnerAccessControl() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner config.repo", true)
+	unpublished := createSnapshot(t, tx, repoConfig)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil).Once()
+
+	file, err := sDao.GetRepositoryConfigurationFile(ctx, viewerOrg, published.UUID, false)
+	assert.NoError(t, err)
+	assert.Contains(t, file, repoConfig.Name)
+	assert.Contains(t, file, testContentPath)
+
+	file, err = sDao.GetRepositoryConfigurationFile(ctx, viewerOrg, unpublished.UUID, false)
+	assert.Error(t, err)
+	assert.Empty(t, file)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestListNonPartnerRepoNotVisibleToForeignViewer() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	sDao := snapshotDaoImpl{db: tx}
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "non-partner upload", false)
+	createSnapshot(t, tx, repoConfig)
+
+	_, _, err := sDao.List(ctx, viewerOrg, repoConfig.UUID, api.PaginationData{Limit: 100}, api.FilterData{})
+	assert.Error(t, err)
+	var daoError *ce.DaoError
+	require.True(t, errors.As(err, &daoError))
+	assert.True(t, daoError.NotFound)
+}
+
+func (s *SnapshotsSuite) TestListPartnerRepoOwnerSeesUnpublishedOnly() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner owner unpublished only", true)
+	unpublished := createSnapshot(t, tx, repoConfig)
+
+	collection, total, err := sDao.List(ctx, ownerOrg, repoConfig.UUID, api.PaginationData{Limit: 100}, api.FilterData{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, collection.Data, 1)
+	assert.Equal(t, unpublished.UUID, collection.Data[0].UUID)
+	assert.False(t, collection.Data[0].Published)
+}
+
+func (s *SnapshotsSuite) TestListPartnerRepoForeignViewerSeesPublishedOnlyRepo() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner published only", true)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+
+	collection, total, err := sDao.List(ctx, viewerOrg, repoConfig.UUID, api.PaginationData{Limit: 100}, api.FilterData{})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, collection.Data, 1)
+	assert.Equal(t, published.UUID, collection.Data[0].UUID)
+	assert.True(t, collection.Data[0].Published)
+}
+
+func (s *SnapshotsSuite) TestFetchSnapshotsByDateOwnedAndForeignPartnerMixed() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	viewerOrg := seeds.RandomOrgId()
+	partnerOwnerOrg := seeds.RandomOrgId()
+	baseTime := time.Now()
+
+	mockPulpClient := pulp_client.NewMockPulpClient(t)
+	mockPulpClient.On("GetContentPath").Return(testContentPath, nil)
+	sDao := snapshotDaoImpl{db: tx, pulpClient: mockPulpClient}
+
+	ownedRepo := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), viewerOrg, "viewer owned repo", false)
+	ownedSnap := s.createSnapshotAtSpecifiedTime(ownedRepo, baseTime)
+
+	partnerRepo := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), partnerOwnerOrg, "foreign partner repo", true)
+	partnerSnap := s.createSnapshotAtSpecifiedTime(partnerRepo, baseTime)
+	err := tx.Model(&models.Snapshot{}).Where("uuid = ?", partnerSnap.UUID).Update("published", true).Error
+	require.NoError(t, err)
+
+	resp, err := sDao.FetchSnapshotsByDateAndRepository(ctx, viewerOrg, api.ListSnapshotByDateRequest{
+		RepositoryUUIDS: []string{ownedRepo.UUID, partnerRepo.UUID},
+		Date:            baseTime,
+	})
+	assert.NoError(t, err)
+	require.Len(t, resp.Data, 2)
+
+	byRepo := map[string]*api.SnapshotResponse{}
+	for i := range resp.Data {
+		require.NotNil(t, resp.Data[i].Match)
+		byRepo[resp.Data[i].RepositoryUUID] = resp.Data[i].Match
+	}
+	require.Contains(t, byRepo, ownedRepo.UUID)
+	require.Contains(t, byRepo, partnerRepo.UUID)
+	assert.Equal(t, ownedSnap.UUID, byRepo[ownedRepo.UUID].UUID)
+	assert.Equal(t, partnerSnap.UUID, byRepo[partnerRepo.UUID].UUID)
+	assert.True(t, byRepo[partnerRepo.UUID].Published)
+}
+
+func (s *SnapshotsSuite) TestFetchNonPartnerSnapshotByForeignOrg() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	sDao := GetSnapshotDao(tx)
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "non-partner fetch by uuid", false)
+	snap := createSnapshot(t, tx, repoConfig)
+
+	// Fetch ACL currently only denies unpublished foreign *partner* snapshots.
+	// Non-partner snapshots remain fetchable by UUID regardless of org.
+	fetched, err := sDao.Fetch(ctx, viewerOrg, snap.UUID)
+	assert.NoError(t, err)
+	assert.Equal(t, snap.UUID, fetched.UUID)
+	assert.False(t, fetched.Published)
 }

--- a/pkg/dao/snapshots_test.go
+++ b/pkg/dao/snapshots_test.go
@@ -1109,6 +1109,45 @@ func (s *SnapshotsSuite) TestListPartnerRepoForeignViewerSeesOnlyPublished() {
 	assert.NotEqual(t, unpublished.UUID, viewerCollection.Data[0].UUID)
 }
 
+// TestReadableSnapshotsForeignPartnerExcludesUnpublished covers the UUID-based leak path:
+// when a partner repo has at least one published snapshot, foreignPartnerVisibleSQL (EXISTS)
+// would previously unlock *all* snaps of that repo via readableSnapshots. Callers such as
+// ListSnapshotRpms / ListByTemplate filter only by snapshot UUID, so an unpublished snap UUID
+// must still be excluded for foreign viewers. Owners keep access to unpublished snaps.
+func (s *SnapshotsSuite) TestReadableSnapshotsForeignPartnerExcludesUnpublished() {
+	t := s.T()
+	tx := s.tx
+	ctx := context.Background()
+
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repoConfig := createTestPartnerRepoConfig(t, tx, createTestUploadRepository(t, tx), ownerOrg, "partner readableSnapshots", true)
+	unpublished := createSnapshot(t, tx, repoConfig)
+	published := createPublishedSnapshot(t, tx, repoConfig)
+
+	var viewerUUIDs []string
+	err := readableSnapshots(tx.WithContext(ctx), viewerOrg).
+		Where("snapshots.uuid IN ?", []string{unpublished.UUID, published.UUID}).
+		Pluck("snapshots.uuid", &viewerUUIDs).Error
+	assert.NoError(t, err)
+	assert.Equal(t, []string{published.UUID}, viewerUUIDs)
+
+	var unpublishedForViewer []string
+	err = readableSnapshots(tx.WithContext(ctx), viewerOrg).
+		Where("snapshots.uuid = ?", unpublished.UUID).
+		Pluck("snapshots.uuid", &unpublishedForViewer).Error
+	assert.NoError(t, err)
+	assert.Empty(t, unpublishedForViewer)
+
+	var ownerUUIDs []string
+	err = readableSnapshots(tx.WithContext(ctx), ownerOrg).
+		Where("snapshots.uuid IN ?", []string{unpublished.UUID, published.UUID}).
+		Pluck("snapshots.uuid", &ownerUUIDs).Error
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{unpublished.UUID, published.UUID}, ownerUUIDs)
+}
+
 func (s *SnapshotsSuite) TestListPartnerRepoUnpublishedNotVisibleToForeignViewer() {
 	t := s.T()
 	tx := s.tx

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -390,11 +390,14 @@ func (sh *SnapshotHandler) isDeleteAllowed(c echo.Context, orgID, repoUUID strin
 	hasErr := false
 	errs := make([]error, len(snapshotUUIDs))
 	for i := range snapshotUUIDs {
-		err = sh.isSnapInRepo(repoSnaps, snapshotUUIDs[i])
+		snap, err := findSnapInRepo(repoSnaps, snapshotUUIDs[i])
 		if err != nil {
 			hasErr = true
 			errs[i] = err
 			continue
+		}
+		if snap.Published {
+			return ce.NewErrorResponse(http.StatusBadRequest, "Error deleting snapshots", "Cannot delete a published snapshot")
 		}
 	}
 	if hasErr {
@@ -408,13 +411,13 @@ func (sh *SnapshotHandler) isDeleteAllowed(c echo.Context, orgID, repoUUID strin
 	return nil
 }
 
-func (sh *SnapshotHandler) isSnapInRepo(repoSnaps []models.Snapshot, uuid string) error {
-	if slices.IndexFunc(repoSnaps, func(snapshot models.Snapshot) bool { return snapshot.UUID == uuid }) == -1 {
-		return &ce.DaoError{
+func findSnapInRepo(repoSnaps []models.Snapshot, uuid string) (*models.Snapshot, error) {
+	indx := slices.IndexFunc(repoSnaps, func(snapshot models.Snapshot) bool { return snapshot.UUID == uuid })
+	if indx == -1 {
+		return nil, &ce.DaoError{
 			NotFound: true,
 			Err:      errors.New("snapshot with this UUID does not exist for the specified repository"),
 		}
 	}
-
-	return nil
+	return &repoSnaps[indx], nil
 }

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
 )
 
 type SnapshotSuite struct {
@@ -221,6 +222,47 @@ func (suite *SnapshotSuite) TestGetRepositoryConfigurationFile() {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, response, repoConfigFile)
+}
+
+func (suite *SnapshotSuite) TestGetLatestRepoConfigurationFile() {
+	t := suite.T()
+
+	orgID := test_handler.MockOrgId
+	repoUUID := uuid.NewString()
+	snapUUID := uuid.NewString()
+	repoConfigFile := "latest-file"
+
+	suite.reg.Snapshot.WithContextMock().On("FetchLatestSnapshot", test.MockCtx(), repoUUID).Return(api.SnapshotResponse{
+		UUID:      snapUUID,
+		Published: true,
+	}, nil).Once()
+	suite.reg.Snapshot.WithContextMock().On("GetRepositoryConfigurationFile", test.MockCtx(), orgID, snapUUID, true).Return(repoConfigFile, nil).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/config.repo", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, body, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, repoConfigFile, string(body))
+}
+
+func (suite *SnapshotSuite) TestGetLatestRepoConfigurationFileNotFound() {
+	t := suite.T()
+
+	repoUUID := uuid.NewString()
+	suite.reg.Snapshot.WithContextMock().On("FetchLatestSnapshot", test.MockCtx(), repoUUID).Return(
+		api.SnapshotResponse{}, gorm.ErrRecordNotFound,
+	).Once()
+
+	path := fmt.Sprintf("%s/repositories/%s/config.repo", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNotFound, code)
 }
 
 func (suite *SnapshotSuite) TestDelete() {

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -237,7 +237,7 @@ func (suite *SnapshotSuite) TestDelete() {
 	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
 	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
 	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
-	suite.reg.Snapshot.On("Fetch", test.MockCtx(), snapUUID).Return(snap, nil)
+	suite.reg.Snapshot.On("Fetch", test.MockCtx(), orgID, snapUUID).Return(snap, nil)
 	suite.reg.Snapshot.On("SoftDelete", test.MockCtx(), snapUUID).Return(nil)
 	mockDeleteSnapshotEnqueue(suite.tcMock, repoUUID, requestID, snapUUID).Return(uuid.New(), nil)
 
@@ -630,6 +630,61 @@ func createSnapshotCollection(size, limit, offset int) api.SnapshotCollectionRes
 	params := fmt.Sprintf("?offset=%d&limit=%d", offset, limit)
 	setCollectionResponseMetadata(&collection, getTestContext(params), int64(size))
 	return collection
+}
+
+func (suite *SnapshotSuite) TestDeletePublishedSnapshotForbidden() {
+	t := suite.T()
+
+	orgID := test_handler.MockOrgId
+	requestID := uuid.NewString()
+	repoUUID := uuid.NewString()
+	collection := createSnapshotModels(4, repoUUID)
+	collection[0].Published = true
+	snapUUID := collection[0].UUID
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
+	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s", api.FullRootPath(), repoUUID, snapUUID)
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+	req.Header.Set(config.HeaderRequestId, requestID)
+
+	code, body, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Contains(t, string(body), "Cannot delete a published snapshot")
+}
+
+func (suite *SnapshotSuite) TestBulkDeletePublishedSnapshotForbidden() {
+	t := suite.T()
+
+	orgID := test_handler.MockOrgId
+	requestID := uuid.NewString()
+	repoUUID := uuid.NewString()
+	collection := createSnapshotModels(4, repoUUID)
+	collection[1].Published = true
+	snapUUIDs := []string{collection[0].UUID, collection[1].UUID}
+
+	suite.reg.RepositoryConfig.On("Fetch", test.MockCtx(), orgID, repoUUID).Return(api.RepositoryResponse{}, nil)
+	suite.reg.TaskInfo.On("FetchActiveTasks", test.MockCtx(), orgID, repoUUID, config.DeleteRepositorySnapshotsTask, config.DeleteSnapshotsTask).Return([]string{}, nil)
+	suite.reg.Snapshot.On("FetchForRepoConfigUUID", test.MockCtx(), repoUUID, false).Return(collection, nil)
+
+	body, err := json.Marshal(api.UUIDListRequest{UUIDs: snapUUIDs})
+	assert.NoError(t, err)
+
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/bulk_delete/", api.FullRootPath(), repoUUID)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+	req.Header.Set(config.HeaderRequestId, requestID)
+
+	code, respBody, err := suite.serveSnapshotsRouter(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Contains(t, string(respBody), "Cannot delete a published snapshot")
+	suite.reg.Snapshot.AssertNotCalled(t, "BulkDelete", mock.Anything, mock.Anything)
 }
 
 func createSnapshotModels(size int, repoUUID string) []models.Snapshot {

--- a/pkg/jobs/create_latest_distributions.go
+++ b/pkg/jobs/create_latest_distributions.go
@@ -54,22 +54,30 @@ func CreateLatestDistributions(_ []string) {
 			batch := repos.Data[i:end]
 			wg := sync.WaitGroup{}
 			for _, repo := range batch {
-				lastSnapshot := repo.LastSnapshot
-				if lastSnapshot == nil {
+				publicationHref := ""
+				if repo.Partner {
+					latestPublished, fetchErr := daoReg.Snapshot.FetchLatestPublishedSnapshotModel(ctx, repo.UUID)
+					if fetchErr != nil {
+						continue
+					}
+					publicationHref = latestPublished.PublicationHref
+				} else if repo.LastSnapshot != nil {
+					publicationHref = repo.LastSnapshot.PublicationHref
+				} else {
 					continue
 				}
 				wg.Add(1)
-				go func() {
+				go func(repo api.RepositoryResponse, publicationHref string) {
 					defer wg.Done()
-					_, err = distHelper.FindOrCreateDistribution(
+					_, createErr := distHelper.FindOrCreateDistribution(
 						repo,
-						lastSnapshot.PublicationHref,
+						publicationHref,
 						repo.UUID,
 						helpers.GetLatestRepoDistPath(repo.UUID))
-					if err != nil {
-						log.Error().Str("repo_uuid", repo.UUID).Str("org_id", domain.OrgId).Err(err).Msg("failed to create distribution")
+					if createErr != nil {
+						log.Error().Str("repo_uuid", repo.UUID).Str("org_id", domain.OrgId).Err(createErr).Msg("failed to create distribution")
 					}
-				}()
+				}(repo, publicationHref)
 			}
 			wg.Wait()
 		}

--- a/pkg/jobs/create_latest_distributions.go
+++ b/pkg/jobs/create_latest_distributions.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -11,6 +12,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/db"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 )
 
 func CreateLatestDistributions(_ []string) {
@@ -54,18 +56,16 @@ func CreateLatestDistributions(_ []string) {
 			batch := repos.Data[i:end]
 			wg := sync.WaitGroup{}
 			for _, repo := range batch {
-				publicationHref := ""
-				if repo.Partner {
-					latestPublished, fetchErr := daoReg.Snapshot.FetchLatestPublishedSnapshotModel(ctx, repo.UUID)
-					if fetchErr != nil {
+				latestSnap, fetchErr := daoReg.Snapshot.FetchLatestSnapshotForDistribution(ctx, repo.UUID)
+				if fetchErr != nil {
+					if errors.Is(fetchErr, gorm.ErrRecordNotFound) {
 						continue
 					}
-					publicationHref = latestPublished.PublicationHref
-				} else if repo.LastSnapshot != nil {
-					publicationHref = repo.LastSnapshot.PublicationHref
-				} else {
+					log.Error().Str("repo_uuid", repo.UUID).Str("org_id", domain.OrgId).Err(fetchErr).
+						Msg("failed to fetch latest snapshot for distribution")
 					continue
 				}
+				publicationHref := latestSnap.PublicationHref
 				wg.Add(1)
 				go func(repo api.RepositoryResponse, publicationHref string) {
 					defer wg.Done()

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -245,7 +245,7 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 		return fmt.Errorf("failed to find latest distribution by path %v: %w", latestPathIdent, err)
 	}
 	if latestDistro != nil {
-		latestSnap, err := ds.fetchSnapshotForLatestDistribution(repo)
+		latestSnap, err := ds.daoReg.Snapshot.FetchLatestSnapshotForDistribution(ds.ctx, repo.UUID)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				deleteDistributionHref, delErr := ds.getPulpClient().DeleteRpmDistribution(ds.ctx, *latestDistro.PulpHref)
@@ -454,13 +454,6 @@ func (ds *DeleteSnapshots) updateTemplatesUsingSnap(templateUpdateMap *map[strin
 	}
 
 	return nil
-}
-
-func (ds *DeleteSnapshots) fetchSnapshotForLatestDistribution(repo api.RepositoryResponse) (models.Snapshot, error) {
-	if repo.Partner {
-		return ds.daoReg.Snapshot.FetchLatestPublishedSnapshotModel(ds.ctx, repo.UUID)
-	}
-	return ds.daoReg.Snapshot.FetchLatestSnapshotModel(ds.ctx, repo.UUID)
 }
 
 func (ds *DeleteSnapshots) updateRepoConfig(repoUUID, snapUUID string) error {

--- a/pkg/tasks/delete_snapshots.go
+++ b/pkg/tasks/delete_snapshots.go
@@ -19,6 +19,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
 	"github.com/content-services/content-sources-backend/pkg/utils"
+	"gorm.io/gorm"
 )
 
 type DeleteSnapshots struct {
@@ -238,19 +239,33 @@ func (ds *DeleteSnapshots) deleteOrUpdatePulpContent(snap models.Snapshot, repo 
 		}
 	}
 
-	latestPathIdent := fmt.Sprintf("%v/%v", repo.UUID, "latest")
+	latestPathIdent := helpers.GetLatestRepoDistPath(repo.UUID)
 	latestDistro, err := ds.getPulpClient().FindDistributionByPath(ds.ctx, latestPathIdent)
 	if err != nil {
 		return fmt.Errorf("failed to find latest distribution by path %v: %w", latestPathIdent, err)
 	}
 	if latestDistro != nil {
-		latestSnap, err := ds.daoReg.Snapshot.FetchLatestSnapshotModel(ds.ctx, repo.UUID)
+		latestSnap, err := ds.fetchSnapshotForLatestDistribution(repo)
 		if err != nil {
-			return fmt.Errorf("failed to fetch latest snapshot for repo %v: %w", repo.UUID, err)
-		}
-		_, _, err = ds.pulpDistHelper.CreateOrUpdateDistribution(repo, latestSnap.PublicationHref, repo.UUID, latestPathIdent)
-		if err != nil {
-			return fmt.Errorf("failed to update latest distribution for repo %v: %w", repo.UUID, err)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				deleteDistributionHref, delErr := ds.getPulpClient().DeleteRpmDistribution(ds.ctx, *latestDistro.PulpHref)
+				if delErr != nil {
+					return fmt.Errorf("failed to delete latest distribution for repo %v: %w", repo.UUID, delErr)
+				}
+				if deleteDistributionHref != nil {
+					_, pollErr := ds.getPulpClient().PollTask(ds.ctx, *deleteDistributionHref)
+					if pollErr != nil {
+						return fmt.Errorf("failed to poll latest distribution deletion for repo %v: %w", repo.UUID, pollErr)
+					}
+				}
+			} else {
+				return fmt.Errorf("failed to fetch latest snapshot for repo %v: %w", repo.UUID, err)
+			}
+		} else {
+			_, _, err = ds.pulpDistHelper.CreateOrUpdateLatestDistribution(repo, latestSnap.PublicationHref)
+			if err != nil {
+				return fmt.Errorf("failed to update latest distribution for repo %v: %w", repo.UUID, err)
+			}
 		}
 	}
 
@@ -439,6 +454,13 @@ func (ds *DeleteSnapshots) updateTemplatesUsingSnap(templateUpdateMap *map[strin
 	}
 
 	return nil
+}
+
+func (ds *DeleteSnapshots) fetchSnapshotForLatestDistribution(repo api.RepositoryResponse) (models.Snapshot, error) {
+	if repo.Partner {
+		return ds.daoReg.Snapshot.FetchLatestPublishedSnapshotModel(ds.ctx, repo.UUID)
+	}
+	return ds.daoReg.Snapshot.FetchLatestSnapshotModel(ds.ctx, repo.UUID)
 }
 
 func (ds *DeleteSnapshots) updateRepoConfig(repoUUID, snapUUID string) error {

--- a/pkg/tasks/delete_snapshots_test.go
+++ b/pkg/tasks/delete_snapshots_test.go
@@ -103,6 +103,7 @@ func (s *DeleteSnapshotsSuite) TestDeleteSnapshots() {
 	s.mockDaoRegistry.Template.On("UpdateSnapshots", ctx, template.UUID, []string{snap.RepositoryConfigurationUUID}, []models.Snapshot{snap2}).Return(nil)
 	s.mockDaoRegistry.Template.On("DeleteTemplateSnapshot", ctx, snap.UUID).Return(nil)
 	s.mockDaoRegistry.Template.On("GetDistributionHref", ctx, template.UUID, repo.UUID).Return(&distHref, nil)
+	s.mockDaoRegistry.Snapshot.On("FetchLatestSnapshotForDistribution", ctx, repo.UUID).Return(snap2, nil)
 	s.mockDaoRegistry.Snapshot.On("FetchLatestSnapshotModel", ctx, repo.UUID).Return(snap2, nil)
 	s.mockDaoRegistry.TaskInfo.On("List", ctx, orgID, api.PaginationData{Limit: 1}, taskInfoFilter).Return(taskInfoResp, int64(1), nil)
 	s.mockDaoRegistry.RepositoryConfig.On("UpdateLastSnapshot", ctx, orgID, repo.UUID, snap2.UUID).Return(nil)

--- a/pkg/tasks/helpers/pulp_distribution_helper.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper.go
@@ -15,6 +15,18 @@ func GetLatestRepoDistPath(repoUUID string) string {
 	return fmt.Sprintf("%v/%v", repoUUID, "latest")
 }
 
+// ShouldUpdateLatestDistributionOnCreate reports whether creating a snapshot should update
+// the repository's Pulp "latest" distribution. Partner repos skip this: their "latest" always
+// tracks the newest published snapshot (or is removed when none exist).
+func ShouldUpdateLatestDistributionOnCreate(repo api.RepositoryResponse) bool {
+	return !repo.Partner
+}
+
+// CreateOrUpdateLatestDistribution points the repo's "latest" distribution at publicationHref.
+func (pdh *PulpDistributionHelper) CreateOrUpdateLatestDistribution(repo api.RepositoryResponse, publicationHref string) (string, string, error) {
+	return pdh.CreateOrUpdateDistribution(repo, publicationHref, repo.UUID, GetLatestRepoDistPath(repo.UUID))
+}
+
 func NewPulpDistributionHelper(ctx context.Context, client pulp_client.PulpClient) *PulpDistributionHelper {
 	return &PulpDistributionHelper{
 		pulpClient: client,

--- a/pkg/tasks/helpers/pulp_distribution_helper_test.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper_test.go
@@ -136,3 +136,8 @@ func (s *PulpDistributionHelperTest) TestRedHatDistributionWithFeatureCreate() {
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), created, &taskResp)
 }
+
+func TestShouldUpdateLatestDistributionOnCreate(t *testing.T) {
+	assert.True(t, ShouldUpdateLatestDistributionOnCreate(api.RepositoryResponse{Partner: false}))
+	assert.False(t, ShouldUpdateLatestDistributionOnCreate(api.RepositoryResponse{Partner: true}))
+}

--- a/pkg/tasks/snapshot_helper.go
+++ b/pkg/tasks/snapshot_helper.go
@@ -73,11 +73,13 @@ func (sh *SnapshotHelper) Run(versionHref string) error {
 		return fmt.Errorf("unable to save distribution task href: %w", err)
 	}
 
-	latestPathIdent := helpers.GetLatestRepoDistPath(sh.repo.UUID)
-
-	_, _, err = helper.CreateOrUpdateDistribution(sh.repo, publicationHref, sh.repo.UUID, latestPathIdent)
-	if err != nil {
-		return err
+	if helpers.ShouldUpdateLatestDistributionOnCreate(sh.repo) {
+		_, _, err = helper.CreateOrUpdateLatestDistribution(sh.repo, publicationHref)
+		if err != nil {
+			return err
+		}
+	} else {
+		sh.logger.Debug().Str("repo_uuid", sh.repo.UUID).Msg("Skipping latest distribution update for partner repository on snapshot create")
 	}
 	version, err := sh.pulpClient.GetRpmRepositoryVersion(sh.ctx, versionHref)
 	if err != nil {
@@ -170,7 +172,7 @@ func (sh *SnapshotHelper) Cleanup() error {
 		return err
 	}
 	if latestDistro != nil {
-		latestSnap, err := sh.daoReg.Snapshot.FetchLatestSnapshotModel(sh.ctx, sh.repo.UUID)
+		latestSnap, err := sh.fetchSnapshotForLatestDistribution()
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				deleteDistributionHref, err := sh.pulpClient.DeleteRpmDistribution(sh.ctx, *latestDistro.PulpHref)
@@ -188,13 +190,23 @@ func (sh *SnapshotHelper) Cleanup() error {
 			return err
 		}
 
-		_, _, err = helper.CreateOrUpdateDistribution(sh.repo, latestSnap.PublicationHref, sh.repo.UUID, latestPathIdent)
+		_, _, err = helper.CreateOrUpdateLatestDistribution(sh.repo, latestSnap.PublicationHref)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// fetchSnapshotForLatestDistribution returns the snapshot that should back Pulp "latest".
+// Partner repos use the newest published snapshot (caller removes latest if none exist);
+// others use the newest snapshot overall.
+func (sh *SnapshotHelper) fetchSnapshotForLatestDistribution() (models.Snapshot, error) {
+	if sh.repo.Partner {
+		return sh.daoReg.Snapshot.FetchLatestPublishedSnapshotModel(sh.ctx, sh.repo.UUID)
+	}
+	return sh.daoReg.Snapshot.FetchLatestSnapshotModel(sh.ctx, sh.repo.UUID)
 }
 
 func (sh *SnapshotHelper) findOrCreatePublication(versionHref string) (string, error) {

--- a/pkg/tasks/snapshot_helper.go
+++ b/pkg/tasks/snapshot_helper.go
@@ -172,7 +172,7 @@ func (sh *SnapshotHelper) Cleanup() error {
 		return err
 	}
 	if latestDistro != nil {
-		latestSnap, err := sh.fetchSnapshotForLatestDistribution()
+		latestSnap, err := sh.daoReg.Snapshot.FetchLatestSnapshotForDistribution(sh.ctx, sh.repo.UUID)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				deleteDistributionHref, err := sh.pulpClient.DeleteRpmDistribution(sh.ctx, *latestDistro.PulpHref)
@@ -197,16 +197,6 @@ func (sh *SnapshotHelper) Cleanup() error {
 	}
 
 	return nil
-}
-
-// fetchSnapshotForLatestDistribution returns the snapshot that should back Pulp "latest".
-// Partner repos use the newest published snapshot (caller removes latest if none exist);
-// others use the newest snapshot overall.
-func (sh *SnapshotHelper) fetchSnapshotForLatestDistribution() (models.Snapshot, error) {
-	if sh.repo.Partner {
-		return sh.daoReg.Snapshot.FetchLatestPublishedSnapshotModel(sh.ctx, sh.repo.UUID)
-	}
-	return sh.daoReg.Snapshot.FetchLatestSnapshotModel(sh.ctx, sh.repo.UUID)
 }
 
 func (sh *SnapshotHelper) findOrCreatePublication(versionHref string) (string, error) {


### PR DESCRIPTION
This PR:
- filter partner snapshot list/fetch/date so foreign viewers only see `published` snaps
- forbid deleting `published` snapshots
- skip Pulp `{repo}/latest` on partner create; re-point it to latest published (or remove)