### PR TITLE
Build: pin swag and openapi versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,11 @@ updates:
       npm:
         patterns:
           - '*'
+  - package-ecosystem: "docker"
+    directory: "/mk"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "Build: "

--- a/mk/docker-compose.versions.yml
+++ b/mk/docker-compose.versions.yml
@@ -1,0 +1,6 @@
+# This file exists solely so Dependabot can track the openapi-generator-cli version.
+
+services:
+  openapi-generator:
+    # Used by mk/swag.mk
+    image: openapitools/openapi-generator-cli:v7.23.0@sha256:5ffccd3b0d4ac57eac443e1c9b3e2f2bb7f0a21ffe6c6701f3690d7edc78bf2d

--- a/mk/swag.mk
+++ b/mk/swag.mk
@@ -4,7 +4,11 @@
 ##
 
 SWAG=$(GO_OUTPUT)/swag
-SWAG_VERSION := latest
+# version taken from go.mod, single source of truth, updated with dependabot
+SWAG_VERSION := $(shell grep 'github.com/swaggo/swag ' go.mod | awk '{print $$2}')
+
+# version taken from docker-compose.versions.yml
+OPENAPI_GENERATOR_IMAGE := $(shell grep 'openapi-generator-cli' mk/docker-compose.versions.yml | awk -F': ' '{print $$2}')
 
 .PHONY: install-swag
 install-swag: $(SWAG) ## Install swag locally on your GO_OUTPUT (./release) directory
@@ -31,7 +35,7 @@ openapi-doc: install-swag ## Regenerate openapi json document and lint
 
 .PHONY: openapi-js
 openapi-js: 
-	$(DOCKER) run -v .:/backend:z openapitools/openapi-generator-cli:latest-release generate -i backend/api/openapi.json  -g typescript-fetch -o backend/_playwright-tests/test-utils/src/client
+	$(DOCKER) run -v .:/backend:z $(OPENAPI_GENERATOR_IMAGE) generate -i backend/api/openapi.json  -g typescript-fetch -o backend/_playwright-tests/test-utils/src/client
 
 .PHONY: openapi
 openapi: openapi-doc openapi-js


### PR DESCRIPTION
## Summary
Swag and openapi were pulling latest releases
when `make openapi` command was run. Now both
of them are pinned to a particular version.

- swag-version is referenced from go.mod
- openapi-image-version is referenced from docker-compose.versions.yml, which was created so dependabot can provide updates for it

Both libraries are checked by dependabot for updates.
