### PR TITLE
HMS-10707: templates changes to support partner repos

### DIFF
--- a/pkg/dao/dao_mock.go
+++ b/pkg/dao/dao_mock.go
@@ -4243,6 +4243,32 @@ func (_c *MockSnapshotDao_FetchLatestSnapshot_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
+// HasPublishedSnapshot provides a mock function for the type MockSnapshotDao
+func (_mock *MockSnapshotDao) HasPublishedSnapshot(ctx context.Context, repoConfigUUID string) (bool, error) {
+	ret := _mock.Called(ctx, repoConfigUUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasPublishedSnapshot")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, repoConfigUUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r0 = ret.Bool(0)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, repoConfigUUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // FetchLatestSnapshotForDistribution provides a mock function for the type MockSnapshotDao
 func (_mock *MockSnapshotDao) FetchLatestSnapshotForDistribution(ctx context.Context, repoConfigUUID string) (models.Snapshot, error) {
 	ret := _mock.Called(ctx, repoConfigUUID)

--- a/pkg/dao/interfaces.go
+++ b/pkg/dao/interfaces.go
@@ -157,6 +157,7 @@ type SnapshotDao interface {
 	FetchLatestSnapshot(ctx context.Context, repoConfigUUID string) (api.SnapshotResponse, error)
 	FetchLatestSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
 	FetchLatestPublishedSnapshotModel(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)
+	HasPublishedSnapshot(ctx context.Context, repoConfigUUID string) (bool, error)
 	// FetchLatestSnapshotForDistribution returns the snapshot that should back Pulp "{repo}/latest"
 	// (newest published for partner repos; newest overall otherwise).
 	FetchLatestSnapshotForDistribution(ctx context.Context, repoConfigUUID string) (models.Snapshot, error)

--- a/pkg/dao/snapshots.go
+++ b/pkg/dao/snapshots.go
@@ -543,6 +543,10 @@ func (sDao *snapshotDaoImpl) FetchLatestPublishedSnapshotModel(ctx context.Conte
 	return snap, nil
 }
 
+func (sDao *snapshotDaoImpl) HasPublishedSnapshot(ctx context.Context, repoConfigUUID string) (bool, error) {
+	return HasPublishedSnapshot(ctx, sDao.db, repoConfigUUID)
+}
+
 // FetchLatestSnapshotForDistribution returns the snapshot that should back Pulp "{repo}/latest".
 // Partner repos use the newest published snapshot; others use the newest snapshot overall.
 // Callers need not load the repository configuration first.

--- a/pkg/dao/templates.go
+++ b/pkg/dao/templates.go
@@ -130,26 +130,27 @@ func (t templateDaoImpl) create(ctx context.Context, tx *gorm.DB, reqTemplate ap
 }
 
 func (t templateDaoImpl) validateRepositoryUUIDs(ctx context.Context, orgId string, uuids []string) error {
-	var count int64
 	orgIds := []string{orgId, config.RedHatOrg, config.CommunityOrg}
-	resp := t.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).Where("org_id in ?", orgIds).Where("uuid in ?", UuidifyStrings(uuids)).Count(&count)
-	if resp.Error != nil {
-		return fmt.Errorf("could not query repository uuids: %w", resp.Error)
-	}
-	if count != int64(len(uuids)) {
-		return &ce.DaoError{NotFound: true, Message: "One or more Repository UUIDs was invalid."}
-	}
 
 	var repos []models.RepositoryConfiguration
-	var missingSnapshotRepos []string
-	resp = t.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).
-		Where("org_id in ?", orgIds).
+	resp := t.db.WithContext(ctx).Model(models.RepositoryConfiguration{}).
 		Where("uuid in ?", UuidifyStrings(uuids)).
+		Where("org_id in ? OR ("+foreignPartnerVisibleSQL+")", orgIds, orgId).
 		Find(&repos)
 	if resp.Error != nil {
 		return fmt.Errorf("could not query repository uuids: %w", resp.Error)
 	}
+
+	if len(repos) != len(uuids) {
+		return &ce.DaoError{NotFound: true, Message: "One or more Repository UUIDs was invalid."}
+	}
+
+	var missingSnapshotRepos []string
 	for _, repo := range repos {
+		if IsForeignPartnerView(repo, orgId) {
+			// Foreign partners are already constrained to having a published snapshot by the query above.
+			continue
+		}
 		if repo.LastSnapshotUUID == "" {
 			missingSnapshotRepos = append(missingSnapshotRepos, repo.Name)
 		}
@@ -720,7 +721,8 @@ func (t templateDaoImpl) InternalOnlyGetTemplatesForRepoConfig(ctx context.Conte
 	var templates []models.Template
 	filtered := t.db.Model(&models.Template{}).WithContext(ctx).
 		Joins("INNER JOIN templates_repository_configurations on templates_repository_configurations.template_uuid = templates.uuid").
-		Where("templates_repository_configurations.repository_configuration_uuid", repoUUID)
+		Where("templates_repository_configurations.repository_configuration_uuid = ?", UuidifyString(repoUUID)).
+		Where("templates_repository_configurations.deleted_at IS NULL")
 	if useLatestOnly {
 		filtered = filtered.Where("use_latest = true")
 	}

--- a/pkg/dao/templates_test.go
+++ b/pkg/dao/templates_test.go
@@ -44,6 +44,157 @@ func (s *TemplateSuite) SetupTest() {
 	s.pulpClient = &pulp_client.MockPulpClient{}
 	s.pulpClient.On("GetContentPath").Return(testContentPath, nil).Maybe()
 }
+func (s *TemplateSuite) TestValidateRepositoryUUIDsForeignPartner() {
+	templateDao := s.templateDao()
+	ctx := context.Background()
+	templateOrg := orgIDTest
+	partnerOrg := seeds.RandomOrgId()
+
+	partnerRepo := createTestUploadRepository(s.T(), s.tx)
+	partnerConfig := createTestPartnerRepoConfig(s.T(), s.tx, partnerRepo, partnerOrg, "foreign partner repo", true)
+
+	// Foreign partner with no published snapshot is invalid
+	err := templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID})
+	var daoErr *ce.DaoError
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+	assert.Contains(s.T(), daoErr.Message, "One or more Repository UUIDs was invalid")
+
+	// Unpublished snapshot alone is still invalid for foreign org
+	unpublished := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/unpublished",
+		PublicationHref:             "/pulp/publication/unpublished",
+		DistributionPath:            "/content/unpublished/" + partnerConfig.UUID,
+		RepositoryPath:              "/content/unpublished/" + partnerConfig.UUID,
+		DistributionHref:            "/pulp/distribution/unpublished",
+		RepositoryConfigurationUUID: partnerConfig.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   false,
+	}
+	require.NoError(s.T(), s.tx.Create(&unpublished).Error)
+
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+	assert.Contains(s.T(), daoErr.Message, "One or more Repository UUIDs was invalid")
+
+	// Published snapshot makes the foreign partner repo valid (even without LastSnapshotUUID)
+	published := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/published",
+		PublicationHref:             "/pulp/publication/published",
+		DistributionPath:            "/content/published/" + partnerConfig.UUID,
+		RepositoryPath:              "/content/published/" + partnerConfig.UUID,
+		DistributionHref:            "/pulp/distribution/published",
+		RepositoryConfigurationUUID: partnerConfig.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(s.T(), s.tx.Create(&published).Error)
+
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID})
+	assert.NoError(s.T(), err)
+
+	// Owner of the partner repo still requires LastSnapshotUUID for their own templates
+	err = templateDao.validateRepositoryUUIDs(ctx, partnerOrg, []string{partnerConfig.UUID})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+	assert.Contains(s.T(), daoErr.Message, "No snapshots found")
+
+	// Non-partner repo from another org remains invalid
+	otherRepo := createTestUploadRepository(s.T(), s.tx)
+	otherConfig := createTestPartnerRepoConfig(s.T(), s.tx, otherRepo, partnerOrg, "non-partner foreign repo", false)
+	s.createSnapshot(otherConfig)
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{otherConfig.UUID})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+	assert.Contains(s.T(), daoErr.Message, "One or more Repository UUIDs was invalid")
+
+	// Duplicate and mixed valid/invalid input cannot pass validation by count.
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID, partnerConfig.UUID})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID, uuid.NewString()})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+
+	// A soft-deleted published snapshot does not make a foreign partner visible.
+	require.NoError(s.T(), s.tx.Delete(&published).Error)
+	err = templateDao.validateRepositoryUUIDs(ctx, templateOrg, []string{partnerConfig.UUID})
+	require.ErrorAs(s.T(), err, &daoErr)
+	assert.True(s.T(), daoErr.NotFound)
+}
+
+func (s *TemplateSuite) TestCreateForeignPartnerSelectsPublishedSnapshotByDate() {
+	t := s.T()
+	ctx := context.Background()
+	templateOrg := orgIDTest
+	ownerOrg := seeds.RandomOrgId()
+	baseTime := time.Now().Add(-time.Hour)
+
+	partnerConfig := createTestPartnerRepoConfig(t, s.tx, createTestUploadRepository(t, s.tx), ownerOrg, "partner fixed date", true)
+	published := s.createSnapshotAtSpecifiedTime(partnerConfig, baseTime.Add(-2*time.Hour))
+	require.NoError(t, s.tx.Model(&models.Snapshot{}).Where("uuid = ?", published.UUID).Update("published", true).Error)
+	unpublished := s.createSnapshotAtSpecifiedTime(partnerConfig, baseTime)
+	require.NoError(t, s.tx.Model(&models.RepositoryConfiguration{}).Where("uuid = ?", partnerConfig.UUID).UpdateColumn("last_snapshot_uuid", nil).Error)
+
+	created, err := s.templateDao().Create(ctx, api.TemplateRequest{
+		Name:            utils.Ptr("foreign partner fixed date"),
+		RepositoryUUIDS: []string{partnerConfig.UUID},
+		Arch:            utils.Ptr(config.X8664),
+		Version:         utils.Ptr(config.El9),
+		Date:            (*api.EmptiableDate)(&baseTime),
+		OrgID:           &templateOrg,
+		UseLatest:       utils.Ptr(false),
+	})
+	require.NoError(t, err)
+
+	var link models.TemplateRepositoryConfiguration
+	require.NoError(t, s.tx.Where("template_uuid = ?", created.UUID).First(&link).Error)
+	assert.Equal(t, partnerConfig.UUID, link.RepositoryConfigurationUUID)
+	assert.Equal(t, published.UUID, link.SnapshotUUID)
+	assert.NotEqual(t, unpublished.UUID, link.SnapshotUUID)
+}
+
+func (s *TemplateSuite) TestUpdateForeignPartnerUseLatestSelectsPublishedSnapshot() {
+	t := s.T()
+	ctx := context.Background()
+	templateOrg := orgIDTest
+	ownerOrg := seeds.RandomOrgId()
+	baseTime := time.Now().Add(-2 * time.Hour)
+
+	partnerConfig := createTestPartnerRepoConfig(t, s.tx, createTestUploadRepository(t, s.tx), ownerOrg, "partner latest", true)
+	published := s.createSnapshotAtSpecifiedTime(partnerConfig, baseTime)
+	require.NoError(t, s.tx.Model(&models.Snapshot{}).Where("uuid = ?", published.UUID).Update("published", true).Error)
+	unpublished := s.createSnapshotAtSpecifiedTime(partnerConfig, baseTime.Add(time.Hour))
+
+	created, err := s.templateDao().Create(ctx, api.TemplateRequest{
+		Name:            utils.Ptr("foreign partner latest"),
+		RepositoryUUIDS: []string{partnerConfig.UUID},
+		Arch:            utils.Ptr(config.X8664),
+		Version:         utils.Ptr(config.El9),
+		Date:            (*api.EmptiableDate)(&baseTime),
+		OrgID:           &templateOrg,
+		UseLatest:       utils.Ptr(false),
+	})
+	require.NoError(t, err)
+
+	updated, err := s.templateDao().Update(ctx, templateOrg, created.UUID, api.TemplateUpdateRequest{
+		RepositoryUUIDS: []string{partnerConfig.UUID},
+		Date:            utils.Ptr(api.EmptiableDate(time.Time{})),
+		UseLatest:       utils.Ptr(true),
+	})
+	require.NoError(t, err)
+	require.Len(t, updated.Snapshots, 1)
+	assert.Equal(t, published.UUID, updated.Snapshots[0].UUID)
+	assert.NotEqual(t, unpublished.UUID, updated.Snapshots[0].UUID)
+}
+
 func (s *TemplateSuite) TestCreate() {
 	templateDao := s.templateDao()
 

--- a/pkg/handler/snapshots.go
+++ b/pkg/handler/snapshots.go
@@ -266,7 +266,7 @@ func (sh *SnapshotHandler) publishSnapshot(c echo.Context) error {
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error enqueueing task", err.Error())
 	}
-	updateLatestSnapshotTaskID, err := enqueueUpdateLatestSnapshotTask(c, sh.TaskClient, repoUUID, publishTaskID)
+	_, err = enqueueUpdateLatestSnapshotTask(c, sh.TaskClient, repoUUID, publishTaskID)
 	if err != nil {
 		return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error enqueueing task", err.Error())
 	}
@@ -280,7 +280,7 @@ func (sh *SnapshotHandler) publishSnapshot(c echo.Context) error {
 			continue
 		}
 
-		_, err := enqueueUpdateTemplateContentTask(c, sh.TaskClient, repoUUID, t.UUID, t.OrgID, updateLatestSnapshotTaskID)
+		_, err := enqueueUpdateTemplateContentTask(c, sh.TaskClient, repoUUID, t.UUID, t.OrgID, publishTaskID)
 		if err != nil {
 			return ce.NewErrorResponse(ce.HttpCodeForDaoError(err), "Error enqueueing task", err.Error())
 		}

--- a/pkg/handler/snapshots_test.go
+++ b/pkg/handler/snapshots_test.go
@@ -786,14 +786,48 @@ func (suite *SnapshotSuite) TestPublishSnapshotWithForeignTemplates() {
 	suite.reg.Template.On("InternalOnlyGetTemplatesForRepoConfig", test.MockCtx(), repoUUID, false).
 		Return([]api.TemplateResponse{
 			{UUID: templateUUID, OrgID: "foreign-org"},
-			{UUID: uuid.NewString(), OrgID: orgID}, // same org, should be skipped
+			{UUID: uuid.NewString(), OrgID: orgID},                          // same org, should be skipped
+			{UUID: uuid.NewString(), OrgID: "foreign-org", UseLatest: true}, // handled by UpdateLatestSnapshot
 		}, nil)
-	mockUpdateTemplateContentEnqueue(suite.tcMock, repoUUID, templateUUID, "foreign-org", requestID, updateLatestTaskID).
+	mockUpdateTemplateContentEnqueue(suite.tcMock, repoUUID, templateUUID, "foreign-org", requestID, publishTaskID).
 		Return(uuid.New(), nil)
 
 	body, err := json.Marshal(api.SnapshotPublishedUpdateRequest{Published: utils.Ptr(true)})
 	assert.NoError(t, err)
 
+	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s/published", api.FullRootPath(), repoUUID, snapshotUUID)
+	req := httptest.NewRequest(http.MethodPatch, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(api.IdentityHeader, test_handler.EncodedIdentity(t))
+	req.Header.Set(config.HeaderRequestId, requestID)
+
+	code, _, err := suite.serveSnapshotsRouter(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+}
+
+func (suite *SnapshotSuite) TestUnpublishSnapshotEnqueuesForeignFixedTemplateFromPublicationTask() {
+	t := suite.T()
+	orgID := test_handler.MockOrgId
+	requestID := uuid.NewString()
+	repoUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	publishTaskID := uuid.New()
+
+	suite.reg.Snapshot.On("UpdatePublishedStatus", test.MockCtx(), orgID, false, repoUUID, snapshotUUID).
+		Return(api.SnapshotResponse{UUID: snapshotUUID, Published: false}, nil)
+	mockUpdateSnapshotPublishedEnqueue(suite.tcMock, repoUUID, snapshotUUID, requestID, false).
+		Return(publishTaskID, nil)
+	mockUpdateLatestSnapshotEnqueue(suite.tcMock, repoUUID, requestID, publishTaskID).
+		Return(uuid.New(), nil)
+	suite.reg.Template.On("InternalOnlyGetTemplatesForRepoConfig", test.MockCtx(), repoUUID, false).
+		Return([]api.TemplateResponse{{UUID: templateUUID, OrgID: "foreign-org"}}, nil)
+	mockUpdateTemplateContentEnqueue(suite.tcMock, repoUUID, templateUUID, "foreign-org", requestID, publishTaskID).
+		Return(uuid.New(), nil)
+
+	body, err := json.Marshal(api.SnapshotPublishedUpdateRequest{Published: utils.Ptr(false)})
+	assert.NoError(t, err)
 	path := fmt.Sprintf("%s/repositories/%s/snapshots/%s/published", api.FullRootPath(), repoUUID, snapshotUUID)
 	req := httptest.NewRequest(http.MethodPatch, path, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/handler/utils.go
+++ b/pkg/handler/utils.go
@@ -150,7 +150,7 @@ func enqueueUpdateTemplateContentTask(c echo.Context, tc client.TaskClient, repo
 
 	task := queue.Task{
 		Typename:     config.UpdateTemplateContentTask,
-		Payload:      payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, RepoConfigUUIDs: []string{repoUUID}},
+		Payload:      payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, TriggeredByRepositoryUUID: utils.Ptr(repoUUID)},
 		OrgId:        templateOrg,
 		AccountId:    accountID,
 		ObjectUUID:   utils.Ptr(templateUUID),

--- a/pkg/handler/utils_test.go
+++ b/pkg/handler/utils_test.go
@@ -299,7 +299,7 @@ func mockUpdateTemplateContentEnqueue(
 ) *mock.Call {
 	return tcMock.On("Enqueue", queue.Task{
 		Typename:     config.UpdateTemplateContentTask,
-		Payload:      payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, RepoConfigUUIDs: []string{repoUUID}},
+		Payload:      payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, TriggeredByRepositoryUUID: utils.Ptr(repoUUID)},
 		OrgId:        templateOrg,
 		AccountId:    test_handler.MockAccountNumber,
 		ObjectUUID:   utils.Ptr(templateUUID),

--- a/pkg/tasks/candlepin_helpers.go
+++ b/pkg/tasks/candlepin_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	caliri "github.com/content-services/caliri/release/v4"
 	"github.com/content-services/content-sources-backend/pkg/api"
@@ -16,6 +15,14 @@ import (
 )
 
 func GenContentDto(repo api.RepositoryResponse) caliri.ContentDTO {
+	contentURL := repo.URL
+	if repo.Origin == config.OriginUpload {
+		contentURL = repo.LatestSnapshotURL
+	}
+	return genContentDto(repo, contentURL)
+}
+
+func genContentDto(repo api.RepositoryResponse, contentURL string) caliri.ContentDTO {
 	repoName := repo.Name
 	id := candlepin_client.GetContentID(repo.UUID)
 	repoType := candlepin_client.YumRepoType
@@ -26,11 +33,6 @@ func GenContentDto(repo api.RepositoryResponse) caliri.ContentDTO {
 	if repo.OrgID != config.RedHatOrg && repo.GpgKey != "" {
 		gpgKeyUrl = models.CandlepinContentGpgKeyUrl(repo.OrgID, repo.UUID)
 	}
-	url := repo.URL
-	if repo.Origin == config.OriginUpload {
-		url = repo.LatestSnapshotURL
-	}
-
 	return caliri.ContentDTO{
 		Id:         &id,
 		Type:       &repoType,
@@ -38,7 +40,7 @@ func GenContentDto(repo api.RepositoryResponse) caliri.ContentDTO {
 		Name:       &repoName,
 		Vendor:     &repoVendor,
 		GpgUrl:     gpgKeyUrl,
-		ContentUrl: &url, // Set to upstream URL, but it is not used. Will use content overrides instead.
+		ContentUrl: &contentURL, // Set to upstream URL, but it is not used. Will use content overrides instead.
 	}
 }
 
@@ -64,30 +66,24 @@ func UnneededOverrides(existingDtos []caliri.ContentOverrideDTO, expectedDTOs []
 
 // GenOverrideDTO loads repository configs by UUID and returns Candlepin content override DTOs for the template snapshot (e.g. sslcacert, base URL).
 //
-// repoConfigUUIDs must be non-empty (UpdateTemplateContentHandler enforces this). Empty UUIDs would omit the List UUID filter and return unrelated repos.
-func GenOverrideDTO(ctx context.Context, daoReg *dao.DaoRegistry, orgId, domainName, rhDomainName, contentPath string, template api.TemplateResponse, repoConfigUUIDs []string) ([]caliri.ContentOverrideDTO, error) {
+// repoConfigUUIDs must be non-empty (UpdateTemplateContentHandler enforces this).
+func GenOverrideDTO(ctx context.Context, daoReg *dao.DaoRegistry, orgId, domainName, rhDomainName, communityDomainName, contentPath string, template api.TemplateResponse, repoConfigUUIDs []string) ([]caliri.ContentOverrideDTO, error) {
 	mapping := []caliri.ContentOverrideDTO{}
 
-	uuids := strings.Join(repoConfigUUIDs, ",")
-	if uuids == "" {
+	if len(repoConfigUUIDs) == 0 {
 		return nil, fmt.Errorf("refusing to list repository configs for template %s: no repository config UUIDs (unfiltered list would include unrelated orgs)", template.UUID)
 	}
-	origins := strings.Join([]string{config.OriginExternal, config.OriginRedHat, config.OriginUpload, config.OriginCommunity}, ",")
-	repos, _, err := daoReg.RepositoryConfig.List(ctx, orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: origins})
-	if err != nil {
-		return mapping, err
-	}
-	for _, repo := range repos.Data {
-		var domain string
-		switch repo.OrgID {
-		case config.RedHatOrg:
-			domain = rhDomainName
-		case config.CommunityOrg:
-			domain = config.CommunityDomainName
-		default:
-			domain = domainName
+	for _, repoConfigUUID := range repoConfigUUIDs {
+		repo, err := daoReg.RepositoryConfig.FetchWithoutOrgID(ctx, repoConfigUUID, false)
+		if err != nil {
+			return mapping, err
 		}
-		repoOver, err := ContentOverridesForRepo(domain, template.UUID, contentPath, repo)
+		domain, err := repositoryDomain(ctx, daoReg, repo, orgId, domainName, rhDomainName, communityDomainName)
+		if err != nil {
+			return mapping, err
+		}
+		// The template's linked snapshot is authoritative even when last_snapshot_uuid is absent.
+		repoOver, err := contentOverridesForRepo(domain, template.UUID, contentPath, repo, false)
 		if err != nil {
 			return mapping, err
 		}
@@ -112,8 +108,12 @@ func RemoveUneededOverrides(ctx context.Context, cpClient candlepin_client.Candl
 }
 
 func ContentOverridesForRepo(domainName string, templateUUID string, pulpContentPath string, repo api.RepositoryResponse) ([]caliri.ContentOverrideDTO, error) {
+	return contentOverridesForRepo(domainName, templateUUID, pulpContentPath, repo, true)
+}
+
+func contentOverridesForRepo(domainName string, templateUUID string, pulpContentPath string, repo api.RepositoryResponse, requireLastSnapshot bool) ([]caliri.ContentOverrideDTO, error) {
 	mapping := []caliri.ContentOverrideDTO{}
-	if repo.LastSnapshot == nil { // ignore repos without a snapshot
+	if requireLastSnapshot && repo.LastSnapshot == nil { // ignore repos without a snapshot outside template content resolution
 		return mapping, nil
 	}
 

--- a/pkg/tasks/helpers/pulp_distribution_helper.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/api"
 	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/utils"
 	zest "github.com/content-services/zest/release/v2026"
 )
@@ -40,17 +41,14 @@ type PulpDistributionHelper struct {
 }
 
 func (pdh *PulpDistributionHelper) CreateDistribution(repo api.RepositoryResponse, publicationHref, distName, distPath string) (*zest.TaskResponse, error) {
-	// Create content guard
-	var contentGuardHref *string
-	if config.Get().Clients.Pulp.RepoContentGuards {
-		href, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
-		if err != nil {
-			return nil, err
-		}
-		contentGuardHref = href
+	contentGuardHref, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
+	if err != nil {
+		return nil, err
 	}
+	return pdh.createDistribution(publicationHref, distName, distPath, contentGuardHref)
+}
 
-	// Create distribution
+func (pdh *PulpDistributionHelper) createDistribution(publicationHref, distName, distPath string, contentGuardHref *string) (*zest.TaskResponse, error) {
 	distTask, err := pdh.pulpClient.CreateRpmDistribution(pdh.ctx, publicationHref, distName, distPath, contentGuardHref)
 	if err != nil {
 		return nil, err
@@ -67,33 +65,32 @@ func (pdh *PulpDistributionHelper) CreateDistribution(repo api.RepositoryRespons
 func (pdh *PulpDistributionHelper) DistributionUpdateNeeded(repo api.RepositoryResponse,
 	existingDist zest.RpmRpmDistributionResponse,
 	publicationHref string) (bool, error) {
-	var contentGuardHref *string
+	contentGuardHref, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
+	if err != nil {
+		return true, err
+	}
+	return distributionUpdateNeeded(existingDist, publicationHref, contentGuardHref), nil
+}
 
-	if config.Get().Clients.Pulp.RepoContentGuards {
-		href, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
-		if err != nil {
-			return true, err
-		}
-		contentGuardHref = href
+func distributionUpdateNeeded(existingDist zest.RpmRpmDistributionResponse, publicationHref string, contentGuardHref *string) bool {
+	if !utils.OptionalStringsEqual(existingDist.ContentGuard.Get(), contentGuardHref) {
+		return true
 	}
-	if contentGuardHref != nil && existingDist.ContentGuard.Get() != nil && *existingDist.ContentGuard.Get() != *contentGuardHref {
-		return true, nil
+	if existingDist.Publication.Get() == nil || *existingDist.Publication.Get() != publicationHref {
+		return true
 	}
-	if existingDist.Publication.Get() != nil && *existingDist.Publication.Get() != publicationHref {
-		return true, nil
-	}
-	return false, nil
+	return false
 }
 
 func (pdh *PulpDistributionHelper) UpdateDistribution(repo api.RepositoryResponse, distHref, publicationHref, distName, distPath string) (*zest.TaskResponse, error) {
-	var contentGuardHref *string
-	if config.Get().Clients.Pulp.RepoContentGuards {
-		href, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
-		if err != nil {
-			return nil, err
-		}
-		contentGuardHref = href
+	contentGuardHref, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
+	if err != nil {
+		return nil, err
 	}
+	return pdh.updateDistribution(distHref, publicationHref, distName, distPath, contentGuardHref)
+}
+
+func (pdh *PulpDistributionHelper) updateDistribution(distHref, publicationHref, distName, distPath string, contentGuardHref *string) (*zest.TaskResponse, error) {
 	distTaskHref, err := pdh.pulpClient.UpdateRpmDistribution(pdh.ctx, distHref, publicationHref, distName, distPath, contentGuardHref)
 	if err != nil {
 		return nil, err
@@ -108,6 +105,29 @@ func (pdh *PulpDistributionHelper) UpdateDistribution(repo api.RepositoryRespons
 }
 
 func (pdh *PulpDistributionHelper) CreateOrUpdateDistribution(repo api.RepositoryResponse, publicationHref, distName, distPath string) (string, string, error) {
+	contentGuardHref, err := pdh.FetchContentGuard(repo.OrgID, repo.FeatureName)
+	if err != nil {
+		return "", "", err
+	}
+	return pdh.createOrUpdateDistribution(publicationHref, distName, distPath, contentGuardHref)
+}
+
+// CreateOrUpdateUnguardedDistribution creates or reconciles a distribution with no content guard.
+func (pdh *PulpDistributionHelper) CreateOrUpdateUnguardedDistribution(publicationHref, distName, distPath string) (string, string, error) {
+	return pdh.createOrUpdateDistribution(publicationHref, distName, distPath, nil)
+}
+
+func (pdh *PulpDistributionHelper) CreateOrUpdateTemplateDistribution(repo api.RepositoryResponse, snapshot models.Snapshot, templateOrgID, distName, distPath string) (string, string, error) {
+	if repo.Partner && repo.OrgID != templateOrgID {
+		if !snapshot.Published {
+			return "", "", fmt.Errorf("refusing to create unguarded distribution for foreign partner repository %s using unpublished snapshot %s", repo.UUID, snapshot.UUID)
+		}
+		return pdh.CreateOrUpdateUnguardedDistribution(snapshot.PublicationHref, distName, distPath)
+	}
+	return pdh.CreateOrUpdateDistribution(repo, snapshot.PublicationHref, distName, distPath)
+}
+
+func (pdh *PulpDistributionHelper) createOrUpdateDistribution(publicationHref, distName, distPath string, contentGuardHref *string) (string, string, error) {
 	distTask := &zest.TaskResponse{}
 	var distTaskHref string
 
@@ -117,7 +137,7 @@ func (pdh *PulpDistributionHelper) CreateOrUpdateDistribution(repo api.Repositor
 	}
 
 	if resp == nil {
-		distTask, err = pdh.CreateDistribution(repo, publicationHref, distName, distPath)
+		distTask, err = pdh.createDistribution(publicationHref, distName, distPath, contentGuardHref)
 		if distTask != nil && distTask.PulpHref != nil {
 			distTaskHref = *distTask.PulpHref
 		}
@@ -131,14 +151,11 @@ func (pdh *PulpDistributionHelper) CreateOrUpdateDistribution(repo api.Repositor
 		return *distHrefPtr, distTaskHref, err
 	}
 
-	updateNeeded, err := pdh.DistributionUpdateNeeded(repo, *resp, publicationHref)
-	if err != nil {
-		return "", "", err
-	} else if !updateNeeded {
+	if !distributionUpdateNeeded(*resp, publicationHref, contentGuardHref) {
 		return "", "", nil
 	}
 
-	distTask, err = pdh.UpdateDistribution(repo, *resp.PulpHref, publicationHref, distName, distPath)
+	distTask, err = pdh.updateDistribution(*resp.PulpHref, publicationHref, distName, distPath, contentGuardHref)
 	if distTask != nil && distTask.PulpHref != nil {
 		distTaskHref = *distTask.PulpHref
 	}

--- a/pkg/tasks/helpers/pulp_distribution_helper_test.go
+++ b/pkg/tasks/helpers/pulp_distribution_helper_test.go
@@ -113,6 +113,68 @@ func (s *PulpDistributionHelperTest) TestRedHatDistributionUpdate() {
 	assert.NoError(s.T(), err)
 }
 
+func (s *PulpDistributionHelperTest) TestUnguardedDistributionRemovesExistingGuard() {
+	ctx := context.Background()
+	mockPulp := pulp_client.NewMockPulpClient(s.T())
+	helper := NewPulpDistributionHelper(ctx, mockPulp)
+
+	pubHref := "pubhref"
+	distPath := "distpath"
+	distName := "distname"
+	distHref := "disthref"
+	guardHref := "guardhref"
+	taskHref := "taskhref"
+	publication := zest.NullableString{}
+	publication.Set(&pubHref)
+	contentGuard := zest.NullableString{}
+	contentGuard.Set(&guardHref)
+
+	mockPulp.On("FindDistributionByPath", ctx, distPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:     &distHref,
+		Publication:  publication,
+		ContentGuard: contentGuard,
+	}, nil)
+	mockPulp.On("UpdateRpmDistribution", ctx, distHref, pubHref, distName, distPath, (*string)(nil)).Return(taskHref, nil)
+	mockPulp.On("PollTask", ctx, taskHref).Return(&zest.TaskResponse{PulpHref: &taskHref}, nil)
+
+	resultHref, _, err := helper.CreateOrUpdateUnguardedDistribution(pubHref, distName, distPath)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), distHref, resultHref)
+}
+
+func (s *PulpDistributionHelperTest) TestDisabledGuardsRemoveExistingGuard() {
+	previous := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = false
+	s.T().Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = previous })
+
+	ctx := context.Background()
+	mockPulp := pulp_client.NewMockPulpClient(s.T())
+	helper := NewPulpDistributionHelper(ctx, mockPulp)
+
+	pubHref := "pubhref"
+	distPath := "distpath"
+	distName := "distname"
+	distHref := "disthref"
+	guardHref := "guardhref"
+	taskHref := "taskhref"
+	publication := zest.NullableString{}
+	publication.Set(&pubHref)
+	contentGuard := zest.NullableString{}
+	contentGuard.Set(&guardHref)
+
+	mockPulp.On("FindDistributionByPath", ctx, distPath).Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:     &distHref,
+		Publication:  publication,
+		ContentGuard: contentGuard,
+	}, nil)
+	mockPulp.On("UpdateRpmDistribution", ctx, distHref, pubHref, distName, distPath, (*string)(nil)).Return(taskHref, nil)
+	mockPulp.On("PollTask", ctx, taskHref).Return(&zest.TaskResponse{PulpHref: &taskHref}, nil)
+
+	resultHref, _, err := helper.CreateOrUpdateDistribution(api.RepositoryResponse{OrgID: "owner"}, pubHref, distName, distPath)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), distHref, resultHref)
+}
+
 func (s *PulpDistributionHelperTest) TestRedHatDistributionWithFeatureCreate() {
 	ctx := context.Background()
 	mockPulp := pulp_client.NewMockPulpClient(s.T())

--- a/pkg/tasks/payloads/update_template_content.go
+++ b/pkg/tasks/payloads/update_template_content.go
@@ -1,7 +1,8 @@
 package payloads
 
 type UpdateTemplateContentPayload struct {
-	TemplateUUID    string
-	RepoConfigUUIDs []string
-	PoolID          *string // Add during task runtime
+	TemplateUUID              string
+	RepoConfigUUIDs           []string
+	TriggeredByRepositoryUUID *string
+	PoolID                    *string // Add during task runtime
 }

--- a/pkg/tasks/update_latest_snapshot.go
+++ b/pkg/tasks/update_latest_snapshot.go
@@ -13,7 +13,10 @@ import (
 	"github.com/content-services/content-sources-backend/pkg/event"
 	"github.com/content-services/content-sources-backend/pkg/models"
 	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
+	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
 	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	"github.com/content-services/content-sources-backend/pkg/utils"
+	"github.com/google/uuid"
 )
 
 type UpdateLatestSnapshotPayload struct {
@@ -58,6 +61,8 @@ func UpdateLatestSnapshotHandler(ctx context.Context, task *models.TaskInfo, que
 		domainName:          domainName,
 		rhDomainName:        rhDomainName,
 		communityDomainName: communityDomainName,
+		queue:               queue,
+		task:                task,
 	}
 
 	return t.Run()
@@ -72,13 +77,18 @@ type UpdateLatestSnapshot struct {
 	domainName          string
 	rhDomainName        string
 	communityDomainName string
+	queue               *queue.Queue
+	task                *models.TaskInfo
 }
 
 func (t *UpdateLatestSnapshot) Run() error {
-	var err error
+	repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, t.payload.RepositoryConfigUUID, false)
+	if err != nil {
+		return err
+	}
 
 	var templates []api.TemplateResponse
-	if t.orgID == config.RedHatOrg || t.orgID == config.CommunityOrg {
+	if t.orgID == config.RedHatOrg || t.orgID == config.CommunityOrg || repo.Partner {
 		templates, err = t.daoReg.Template.InternalOnlyGetTemplatesForRepoConfig(t.ctx, t.payload.RepositoryConfigUUID, true)
 		if err != nil {
 			return err
@@ -92,24 +102,24 @@ func (t *UpdateLatestSnapshot) Run() error {
 		templates = resp.Data
 	}
 
-	repo, err := t.daoReg.RepositoryConfig.Fetch(t.ctx, t.orgID, t.payload.RepositoryConfigUUID)
-	if err != nil {
-		return err
+	if repo.Partner {
+		hasPublishedSnapshot, err := t.daoReg.Snapshot.HasPublishedSnapshot(t.ctx, repo.UUID)
+		if err != nil {
+			return fmt.Errorf("error checking published snapshots for repository %s: %w", repo.UUID, err)
+		}
+		if !hasPublishedSnapshot {
+			return t.enqueueTemplateRemovalTasks(repo.UUID, templates)
+		}
 	}
 
-	snap, err := t.daoReg.Snapshot.FetchLatestSnapshotModel(t.ctx, repo.UUID)
+	snap, err := t.daoReg.Snapshot.FetchLatestSnapshotForDistribution(t.ctx, repo.UUID)
 	if err != nil {
 		return err
 	}
 
 	for _, template := range templates {
-		switch repo.OrgID {
-		case config.RedHatOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.rhDomainName)
-		case config.CommunityOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.communityDomainName)
-		default:
-			t.pulpClient = t.pulpClient.WithDomain(t.domainName)
+		if err := t.configurePulpClientForRepo(repo); err != nil {
+			return err
 		}
 
 		err = t.updateLatestSnapshot(repo, template, snap)
@@ -126,13 +136,52 @@ func (t *UpdateLatestSnapshot) Run() error {
 	return nil
 }
 
+func (t *UpdateLatestSnapshot) enqueueTemplateRemovalTasks(repoUUID string, templates []api.TemplateResponse) error {
+	if t.queue == nil || t.task == nil {
+		return fmt.Errorf("cannot enqueue template cleanup tasks without queue and parent task metadata")
+	}
+
+	for _, template := range templates {
+		child := queue.Task{
+			Typename: config.UpdateTemplateContentTask,
+			Payload: payloads.UpdateTemplateContentPayload{
+				TemplateUUID:              template.UUID,
+				TriggeredByRepositoryUUID: utils.Ptr(repoUUID),
+			},
+			Dependencies: []uuid.UUID{t.task.Id},
+			OrgId:        template.OrgID,
+			AccountId:    t.task.AccountId,
+			ObjectUUID:   utils.Ptr(template.UUID),
+			ObjectType:   utils.Ptr(string(config.ObjectTypeTemplate)),
+			RequestID:    t.task.RequestID,
+		}
+		if _, err := (*t.queue).Enqueue(&child); err != nil {
+			return fmt.Errorf("error enqueueing template cleanup for template %s: %w", template.UUID, err)
+		}
+	}
+
+	return nil
+}
+
+// configurePulpClientForRepo points the client at the domain that owns the repo's Pulp content.
+// For custom/partner uploads that is always the repo owner's org, which may differ from task.OrgId.
+func (t *UpdateLatestSnapshot) configurePulpClientForRepo(repo api.RepositoryResponse) error {
+	domain, err := repositoryDomain(t.ctx, t.daoReg, repo, t.orgID, t.domainName, t.rhDomainName, t.communityDomainName)
+	if err != nil {
+		return err
+	}
+	t.pulpClient = t.pulpClient.WithDomain(domain)
+	return nil
+}
+
 func (t *UpdateLatestSnapshot) updateLatestSnapshot(repo api.RepositoryResponse, template api.TemplateResponse, snap models.Snapshot) error {
 	distPath, distName, err := getDistPathAndName(repo, template.UUID)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snap.PublicationHref, distName, distPath)
+	pdh := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient)
+	_, _, err = pdh.CreateOrUpdateTemplateDistribution(repo, snap, template.OrgID, distName, distPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/update_latest_snapshot_test.go
+++ b/pkg/tasks/update_latest_snapshot_test.go
@@ -1,0 +1,187 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
+	"github.com/content-services/content-sources-backend/pkg/tasks/queue"
+	zest "github.com/content-services/zest/release/v2026"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateLatestSnapshotPartnerUsesPublishedSnapshotAcrossOrganizations(t *testing.T) {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(t)
+	pulp := pulp_client.NewMockPulpClient(t)
+	contentGuards := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = false
+	t.Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = contentGuards })
+
+	taskOrg := "template-viewer-org"
+	ownerOrg := "partner-owner-org"
+	ownerDomain := "partner-owner-domain"
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	publicationHref := "/pulp/publications/" + uuid.NewString()
+	distHref := "/pulp/distributions/" + uuid.NewString()
+	distPath := customTemplateSnapshotPath(templateUUID, repoUUID)
+	distName := templateUUID + "/" + repoUUID
+
+	repo := api.RepositoryResponse{UUID: repoUUID, OrgID: ownerOrg, Partner: true, Origin: config.OriginUpload}
+	template := api.TemplateResponse{UUID: templateUUID, OrgID: taskOrg, UseLatest: true}
+	snapshot := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		RepositoryConfigurationUUID: repoUUID,
+		PublicationHref:             publicationHref,
+		Published:                   true,
+	}
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, true).Return([]api.TemplateResponse{template}, nil)
+	reg.Snapshot.On("HasPublishedSnapshot", ctx, repoUUID).Return(true, nil)
+	reg.Snapshot.On("FetchLatestSnapshotForDistribution", ctx, repoUUID).Return(snapshot, nil)
+	reg.Domain.On("Fetch", ctx, ownerOrg).Return(ownerDomain, nil)
+	pulp.On("WithDomain", ownerDomain).Return(pulp)
+
+	publication := zest.NullableString{}
+	publication.Set(&publicationHref)
+	distribution := &zest.RpmRpmDistributionResponse{PulpHref: &distHref, Name: distName, BasePath: distPath, Publication: publication}
+	pulp.On("FindDistributionByPath", ctx, distPath).Return(distribution, nil).Twice()
+	reg.Template.On("UpdateDistributionHrefs", ctx, templateUUID, []string{repoUUID}, []models.Snapshot{snapshot}, map[string]string{repoUUID: distHref}).Return(nil)
+	reg.Template.On("UpdateSnapshots", ctx, templateUUID, []string{repoUUID}, []models.Snapshot{snapshot}).Return(nil)
+
+	task := UpdateLatestSnapshot{
+		daoReg:              reg.ToDaoRegistry(),
+		ctx:                 ctx,
+		orgID:               taskOrg,
+		payload:             &UpdateLatestSnapshotPayload{RepositoryConfigUUID: repoUUID},
+		pulpClient:          pulp,
+		domainName:          "viewer-domain",
+		rhDomainName:        "redhat-domain",
+		communityDomainName: "community-domain",
+	}
+	require.NoError(t, task.Run())
+}
+
+func TestUpdateLatestSnapshotWithoutPublishedSnapshotsEnqueuesCleanupForEveryUseLatestTemplate(t *testing.T) {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(t)
+	mockQueue := queue.NewMockQueue(t)
+	var taskQueue queue.Queue = mockQueue
+
+	repoUUID := uuid.NewString()
+	ownerOrg := "partner-owner"
+	parentID := uuid.New()
+	templates := []api.TemplateResponse{
+		{UUID: uuid.NewString(), OrgID: ownerOrg, UseLatest: true},
+		{UUID: uuid.NewString(), OrgID: "foreign-org", UseLatest: true},
+	}
+	repo := api.RepositoryResponse{UUID: repoUUID, OrgID: ownerOrg, Partner: true}
+	parent := models.TaskInfo{
+		Id:        parentID,
+		AccountId: "account-id",
+		RequestID: "request-id",
+	}
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, true).Return(templates, nil)
+	reg.Snapshot.On("HasPublishedSnapshot", ctx, repoUUID).Return(false, nil)
+
+	var children []*queue.Task
+	mockQueue.On("Enqueue", mock.Anything).Run(func(args mock.Arguments) {
+		enqueued, ok := args.Get(0).(*queue.Task)
+		require.True(t, ok)
+		children = append(children, enqueued)
+	}).Return(uuid.New(), nil).Twice()
+
+	task := UpdateLatestSnapshot{
+		daoReg:  reg.ToDaoRegistry(),
+		ctx:     ctx,
+		orgID:   ownerOrg,
+		payload: &UpdateLatestSnapshotPayload{RepositoryConfigUUID: repoUUID},
+		queue:   &taskQueue,
+		task:    &parent,
+	}
+	require.NoError(t, task.Run())
+	require.Len(t, children, len(templates))
+
+	for i, child := range children {
+		require.Equal(t, config.UpdateTemplateContentTask, child.Typename)
+		require.Equal(t, templates[i].OrgID, child.OrgId)
+		require.Equal(t, []uuid.UUID{parentID}, child.Dependencies)
+		require.Equal(t, "account-id", child.AccountId)
+		require.Equal(t, "request-id", child.RequestID)
+		require.Equal(t, templates[i].UUID, *child.ObjectUUID)
+		payload, ok := child.Payload.(payloads.UpdateTemplateContentPayload)
+		require.True(t, ok)
+		require.Equal(t, templates[i].UUID, payload.TemplateUUID)
+		require.Empty(t, payload.RepoConfigUUIDs)
+		require.NotNil(t, payload.TriggeredByRepositoryUUID)
+		require.Equal(t, repoUUID, *payload.TriggeredByRepositoryUUID)
+	}
+	reg.Snapshot.AssertNotCalled(t, "FetchLatestSnapshotForDistribution", mock.Anything, mock.Anything)
+}
+
+func TestUpdateLatestSnapshotPublicationCheckErrorDoesNotEnqueueCleanup(t *testing.T) {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(t)
+	mockQueue := queue.NewMockQueue(t)
+	var taskQueue queue.Queue = mockQueue
+	repoUUID := uuid.NewString()
+	expectedErr := fmt.Errorf("database unavailable")
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).
+		Return(api.RepositoryResponse{UUID: repoUUID, OrgID: "owner", Partner: true}, nil)
+	reg.Template.On("InternalOnlyGetTemplatesForRepoConfig", ctx, repoUUID, true).
+		Return([]api.TemplateResponse{{UUID: uuid.NewString(), OrgID: "foreign", UseLatest: true}}, nil)
+	reg.Snapshot.On("HasPublishedSnapshot", ctx, repoUUID).Return(false, expectedErr)
+
+	task := UpdateLatestSnapshot{
+		daoReg: reg.ToDaoRegistry(), ctx: ctx, orgID: "owner",
+		payload: &UpdateLatestSnapshotPayload{RepositoryConfigUUID: repoUUID},
+		queue:   &taskQueue, task: &models.TaskInfo{Id: uuid.New()},
+	}
+	err := task.Run()
+	require.ErrorIs(t, err, expectedErr)
+	mockQueue.AssertNotCalled(t, "Enqueue", mock.Anything)
+}
+
+func TestRepositoryDomain(t *testing.T) {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(t)
+	viewerOrg := "viewer-org"
+	viewerDomain := "viewer-domain"
+	rhDomain := "redhat-domain"
+	communityDomain := "community-domain"
+
+	tests := []struct {
+		name string
+		repo api.RepositoryResponse
+		want string
+	}{
+		{name: "red hat", repo: api.RepositoryResponse{OrgID: config.RedHatOrg}, want: rhDomain},
+		{name: "community", repo: api.RepositoryResponse{OrgID: config.CommunityOrg}, want: communityDomain},
+		{name: "owned custom", repo: api.RepositoryResponse{OrgID: viewerOrg}, want: viewerDomain},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := repositoryDomain(ctx, reg.ToDaoRegistry(), tc.repo, viewerOrg, viewerDomain, rhDomain, communityDomain)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	reg.Domain.On("Fetch", ctx, "partner-owner").Return("partner-domain", nil)
+	got, err := repositoryDomain(ctx, reg.ToDaoRegistry(), api.RepositoryResponse{OrgID: "partner-owner", Partner: true}, viewerOrg, viewerDomain, rhDomain, communityDomain)
+	require.NoError(t, err)
+	require.Equal(t, "partner-domain", got)
+}

--- a/pkg/tasks/update_template_content.go
+++ b/pkg/tasks/update_template_content.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
-	"strings"
 	"time"
 
 	caliri "github.com/content-services/caliri/release/v4"
@@ -56,7 +55,7 @@ func UpdateTemplateContentHandler(ctx context.Context, task *models.TaskInfo, qu
 	if template == nil || err != nil {
 		return err
 	}
-	if len(opts.RepoConfigUUIDs) == 0 {
+	if opts.TriggeredByRepositoryUUID == nil && len(opts.RepoConfigUUIDs) == 0 {
 		return fmt.Errorf("update template content: no repository config UUIDs in task payload (template %s)", opts.TemplateUUID)
 	}
 
@@ -93,6 +92,17 @@ func UpdateTemplateContentHandler(ctx context.Context, task *models.TaskInfo, qu
 		queue:               queue,
 		ctx:                 ctxWithLogger,
 		logger:              logger,
+	}
+
+	skip, err := t.prepareTriggeredUpdate()
+	if err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+	if len(opts.RepoConfigUUIDs) == 0 {
+		return fmt.Errorf("update template content: no repository config UUIDs available for template %s", opts.TemplateUUID)
 	}
 
 	err = t.daoReg.Template.UpdateLastError(t.ctx, template.OrgID, template.UUID, "")
@@ -136,6 +146,69 @@ type UpdateTemplateContent struct {
 	queue               *queue.Queue
 	ctx                 context.Context
 	logger              *zerolog.Logger
+}
+
+// prepareTriggeredUpdate turns a publication-triggered task into the complete desired repository
+// state for the template. Publication state is intentionally checked at execution time so a
+// publish/unpublish race cannot remove a repository based on stale handler data.
+func (t *UpdateTemplateContent) prepareTriggeredUpdate() (bool, error) {
+	if t.payload.TriggeredByRepositoryUUID == nil {
+		return false, nil
+	}
+
+	repoUUID := *t.payload.TriggeredByRepositoryUUID
+	repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, repoUUID, false)
+	if err != nil {
+		return false, fmt.Errorf("error fetching triggering repository %s: %w", repoUUID, err)
+	}
+	if !repo.Partner {
+		return false, fmt.Errorf("repository %s triggered partner template reconciliation but is not a partner repository", repoUUID)
+	}
+
+	hasPublishedSnapshot, err := t.daoReg.Snapshot.HasPublishedSnapshot(t.ctx, repoUUID)
+	if err != nil {
+		return false, fmt.Errorf("error checking published snapshots for repository %s: %w", repoUUID, err)
+	}
+
+	t.payload.RepoConfigUUIDs = slices.Clone(t.template.RepositoryUUIDS)
+	isAssociated := slices.Contains(t.payload.RepoConfigUUIDs, repoUUID)
+	if !isAssociated {
+		// A previous attempt may already have removed the association. Keep reconciling the
+		// remaining desired state so Pulp/Candlepin cleanup can complete, but never re-add it.
+		return false, nil
+	}
+
+	if hasPublishedSnapshot {
+		if t.template.UseLatest {
+			// This task can only be a cleanup child of UpdateLatestSnapshot. A new publication
+			// has won the race, and its UpdateLatestSnapshot task owns published selection.
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if !t.template.UseLatest && repo.OrgID == t.template.OrgID {
+		// Owners of fixed-date templates retain access to their unpublished snapshots.
+		return false, nil
+	}
+
+	desired := make([]string, 0, len(t.payload.RepoConfigUUIDs)-1)
+	for _, currentRepoUUID := range t.payload.RepoConfigUUIDs {
+		if currentRepoUUID != repoUUID {
+			desired = append(desired, currentRepoUUID)
+		}
+	}
+	t.payload.RepoConfigUUIDs = desired
+	t.template.RepositoryUUIDS = slices.Clone(desired)
+	if t.logger != nil {
+		t.logger.Info().
+			Str("template_uuid", t.template.UUID).
+			Str("repository_uuid", repoUUID).
+			Bool("use_latest", t.template.UseLatest).
+			Msg("automatically removing partner repository without a published snapshot from template")
+	}
+
+	return false, nil
 }
 
 // RunPulp creates (when a repository is added), updates (if the template date has changed), or removes (when a repository is removed) pulp distributions
@@ -196,28 +269,22 @@ func (t *UpdateTemplateContent) RunPulp() error {
 	if err != nil {
 		return fmt.Errorf("error updating distribution hrefs: %w", err)
 	}
+	err = t.daoReg.Template.UpdateSnapshots(t.ctx, t.payload.TemplateUUID, t.payload.RepoConfigUUIDs, snapshots)
+	if err != nil {
+		return fmt.Errorf("error updating template snapshots: %w", err)
+	}
 
 	return nil
 }
 
 func (t *UpdateTemplateContent) handleReposAdded(reposAdded []string, snapshots []models.Snapshot, repoConfigDistributionHref map[string]string) error {
 	for _, repoConfigUUID := range reposAdded {
-		repo, err := t.daoReg.RepositoryConfig.Fetch(t.ctx, t.orgId, repoConfigUUID)
+		repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, repoConfigUUID, false)
 		if err != nil {
 			return err
 		}
-		if repo.LastSnapshot == nil {
-			continue
-		}
-
-		// Configure client for org
-		switch repo.OrgID {
-		case config.RedHatOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.rhDomainName)
-		case config.CommunityOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.communityDomainName)
-		default:
-			t.pulpClient = t.pulpClient.WithDomain(t.domainName)
+		if err := t.configurePulpClientForRepo(repo); err != nil {
+			return err
 		}
 
 		snapIndex := slices.IndexFunc(snapshots, func(s models.Snapshot) bool {
@@ -233,7 +300,8 @@ func (t *UpdateTemplateContent) handleReposAdded(reposAdded []string, snapshots 
 			return err
 		}
 
-		distHref, _, err := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
+		pdh := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient)
+		distHref, _, err := pdh.CreateOrUpdateTemplateDistribution(repo, snapshots[snapIndex], t.orgId, distName, distPath)
 		if err != nil {
 			return err
 		}
@@ -245,22 +313,12 @@ func (t *UpdateTemplateContent) handleReposAdded(reposAdded []string, snapshots 
 
 func (t *UpdateTemplateContent) handleReposUnchanged(reposUnchanged []string, snapshots []models.Snapshot, repoConfigDistributionHref map[string]string) error {
 	for _, repoConfigUUID := range reposUnchanged {
-		repo, err := t.daoReg.RepositoryConfig.Fetch(t.ctx, t.orgId, repoConfigUUID)
+		repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, repoConfigUUID, false)
 		if err != nil {
 			return err
 		}
-		if repo.LastSnapshot == nil {
-			continue
-		}
-
-		// Configure client for org
-		switch repo.OrgID {
-		case config.RedHatOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.rhDomainName)
-		case config.CommunityOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.communityDomainName)
-		default:
-			t.pulpClient = t.pulpClient.WithDomain(t.domainName)
+		if err := t.configurePulpClientForRepo(repo); err != nil {
+			return err
 		}
 
 		snapIndex := slices.IndexFunc(snapshots, func(s models.Snapshot) bool {
@@ -275,7 +333,8 @@ func (t *UpdateTemplateContent) handleReposUnchanged(reposUnchanged []string, sn
 			return err
 		}
 
-		_, _, err = helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient).CreateOrUpdateDistribution(repo, snapshots[snapIndex].PublicationHref, distName, distPath)
+		pdh := helpers.NewPulpDistributionHelper(t.ctx, t.pulpClient)
+		_, _, err = pdh.CreateOrUpdateTemplateDistribution(repo, snapshots[snapIndex], t.orgId, distName, distPath)
 		if err != nil {
 			return err
 		}
@@ -293,22 +352,12 @@ func (t *UpdateTemplateContent) handleReposRemoved(reposRemoved []string) error 
 	logger := LogForTask(t.task.Id.String(), t.task.Typename, t.task.RequestID)
 
 	for _, repoConfigUUID := range reposRemoved {
-		repo, err := t.daoReg.RepositoryConfig.Fetch(t.ctx, t.orgId, repoConfigUUID)
+		repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, repoConfigUUID, false)
 		if err != nil {
 			return err
 		}
-		if repo.LastSnapshot == nil {
-			continue
-		}
-
-		// Configure client for org
-		switch repo.OrgID {
-		case config.RedHatOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.rhDomainName)
-		case config.CommunityOrg:
-			t.pulpClient = t.pulpClient.WithDomain(t.communityDomainName)
-		default:
-			t.pulpClient = t.pulpClient.WithDomain(t.domainName)
+		if err := t.configurePulpClientForRepo(repo); err != nil {
+			return err
 		}
 
 		distHref, err := t.daoReg.Template.GetDistributionHref(t.ctx, t.payload.TemplateUUID, repoConfigUUID)
@@ -335,6 +384,15 @@ func (t *UpdateTemplateContent) handleReposRemoved(reposRemoved []string) error 
 			}
 		}
 	}
+	return nil
+}
+
+func (t *UpdateTemplateContent) configurePulpClientForRepo(repo api.RepositoryResponse) error {
+	domain, err := repositoryDomain(t.ctx, t.daoReg, repo, t.orgId, t.domainName, t.rhDomainName, t.communityDomainName)
+	if err != nil {
+		return err
+	}
+	t.pulpClient = t.pulpClient.WithDomain(domain)
 	return nil
 }
 
@@ -406,7 +464,12 @@ func (t *UpdateTemplateContent) RunCandlepin(env *caliri.EnvironmentDTO) error {
 		return err
 	}
 
-	customContent, customContentIDs, rhContentIDs, err := t.getContentList()
+	contentPath, err := t.pulpClient.GetContentPath()
+	if err != nil {
+		return err
+	}
+
+	customContent, customContentIDs, rhContentIDs, err := t.getContentList(contentPath)
 	if err != nil {
 		return err
 	}
@@ -457,12 +520,7 @@ func (t *UpdateTemplateContent) RunCandlepin(env *caliri.EnvironmentDTO) error {
 		}
 	}
 
-	rhContentPath, err := t.pulpClient.GetContentPath()
-	if err != nil {
-		return err
-	}
-
-	overrideDtos, err := GenOverrideDTO(t.ctx, t.daoReg, t.orgId, t.domainName, t.rhDomainName, rhContentPath, t.template, t.payload.RepoConfigUUIDs)
+	overrideDtos, err := GenOverrideDTO(t.ctx, t.daoReg, t.orgId, t.domainName, t.rhDomainName, t.communityDomainName, contentPath, t.template, t.payload.RepoConfigUUIDs)
 	if err != nil {
 		return err
 	}
@@ -527,26 +585,33 @@ func (t *UpdateTemplateContent) demoteContent(repoConfigUUIDs []string) error {
 
 // getContentList return the list of ContentDTO that will be created in Candlepin.
 // Returns list of custom content to be created, a list of custom content IDs, a list of red hat content IDs, and an error.
-func (t *UpdateTemplateContent) getContentList() ([]caliri.ContentDTO, []string, []string, error) {
-	uuids := strings.Join(t.payload.RepoConfigUUIDs, ",")
-	if uuids == "" {
+func (t *UpdateTemplateContent) getContentList(contentPath string) ([]caliri.ContentDTO, []string, []string, error) {
+	if len(t.payload.RepoConfigUUIDs) == 0 {
 		return nil, nil, nil, fmt.Errorf("update template content: no repository config uuids available for template %s", t.payload.TemplateUUID)
 	}
-	repoConfigs, _, err := t.daoReg.RepositoryConfig.List(t.ctx, t.orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: strings.Join([]string{config.OriginExternal, config.OriginUpload, config.OriginCommunity}, ",")})
-	if err != nil {
-		return nil, nil, nil, err
+
+	customRepos := make([]api.RepositoryResponse, 0, len(t.payload.RepoConfigUUIDs))
+	rhRepos := make([]api.RepositoryResponse, 0, len(t.payload.RepoConfigUUIDs))
+	for _, repoConfigUUID := range t.payload.RepoConfigUUIDs {
+		repo, err := t.daoReg.RepositoryConfig.FetchWithoutOrgID(t.ctx, repoConfigUUID, false)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if repo.OrgID == config.RedHatOrg {
+			rhRepos = append(rhRepos, repo)
+		} else {
+			customRepos = append(customRepos, repo)
+		}
 	}
 
-	rhRepos, _, err := t.daoReg.RepositoryConfig.List(t.ctx, t.orgId, api.PaginationData{Limit: -1}, api.FilterData{UUID: uuids, Origin: config.OriginRedHat})
+	rhContentIDs, err := t.getRedHatContentIDs(rhRepos)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	rhContentIDs, err := t.getRedHatContentIDs(rhRepos.Data)
+	contentToCreate, customContentIDs, err := t.createContentItems(customRepos, contentPath)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	contentToCreate, customContentIDs := createContentItems(repoConfigs.Data)
 
 	return contentToCreate, customContentIDs, rhContentIDs, nil
 }
@@ -583,7 +648,7 @@ func (t *UpdateTemplateContent) updatePayload() error {
 	return nil
 }
 
-func createContentItems(repos []api.RepositoryResponse) ([]caliri.ContentDTO, []string) {
+func (t *UpdateTemplateContent) createContentItems(repos []api.RepositoryResponse, contentPath string) ([]caliri.ContentDTO, []string, error) {
 	var content []caliri.ContentDTO
 	var contentIDs []string
 
@@ -591,14 +656,35 @@ func createContentItems(repos []api.RepositoryResponse) ([]caliri.ContentDTO, []
 		if repo.OrgID == config.RedHatOrg {
 			continue
 		}
-		if repo.LastSnapshot == nil {
-			continue
+		contentURL, err := t.contentURLForRepo(repo, contentPath)
+		if err != nil {
+			return nil, nil, err
 		}
-		repoContent := GenContentDto(repo)
+		repoContent := genContentDto(repo, contentURL)
 		content = append(content, repoContent)
 		contentIDs = append(contentIDs, *repoContent.Id)
 	}
-	return content, contentIDs
+	return content, contentIDs, nil
+}
+
+func (t *UpdateTemplateContent) contentURLForRepo(repo api.RepositoryResponse, contentPath string) (string, error) {
+	if repo.Origin != config.OriginUpload {
+		return repo.URL, nil
+	}
+
+	domain, err := repositoryDomain(t.ctx, t.daoReg, repo, t.orgId, t.domainName, t.rhDomainName, t.communityDomainName)
+	if err != nil {
+		return "", err
+	}
+	if domain == "" {
+		return "", fmt.Errorf("cannot generate Candlepin content URL for upload repository %s: Pulp domain is empty", repo.UUID)
+	}
+
+	contentURL, err := url.JoinPath(contentPath, domain, repo.UUID, "latest")
+	if err != nil {
+		return "", fmt.Errorf("cannot generate Candlepin content URL for upload repository %s: %w", repo.UUID, err)
+	}
+	return contentURL + "/", nil
 }
 
 func getRepoVendor(repo api.RepositoryResponse) string {

--- a/pkg/tasks/update_template_content_test.go
+++ b/pkg/tasks/update_template_content_test.go
@@ -1,12 +1,25 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	caliri "github.com/content-services/caliri/release/v4"
 	"github.com/content-services/content-sources-backend/pkg/api"
+	candlepin_client "github.com/content-services/content-sources-backend/pkg/clients/candlepin_client"
+	"github.com/content-services/content-sources-backend/pkg/clients/pulp_client"
 	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+	"github.com/content-services/content-sources-backend/pkg/models"
+	"github.com/content-services/content-sources-backend/pkg/tasks/helpers"
+	"github.com/content-services/content-sources-backend/pkg/tasks/payloads"
+	zest "github.com/content-services/zest/release/v2026"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -78,4 +91,373 @@ func (s *UpdateTemplateContentSuite) TestNormalizeExtendedReleaseLabel() {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func (s *UpdateTemplateContentSuite) TestForeignPartnerWithoutLastSnapshotUsesOwnerDomain() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	pulp := pulp_client.NewMockPulpClient(s.T())
+	contentGuards := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = true
+	s.T().Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = contentGuards })
+
+	viewerOrg := "template-owner"
+	ownerOrg := "partner-owner"
+	ownerDomain := "partner-domain"
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	publicationHref := "/pulp/publications/" + uuid.NewString()
+	distHref := "/pulp/distributions/" + uuid.NewString()
+	distPath := customTemplateSnapshotPath(templateUUID, repoUUID)
+
+	repo := api.RepositoryResponse{UUID: repoUUID, OrgID: ownerOrg, Partner: true, Origin: config.OriginUpload, LastSnapshot: nil}
+	snapshot := models.Snapshot{Base: models.Base{UUID: uuid.NewString()}, RepositoryConfigurationUUID: repoUUID, PublicationHref: publicationHref, Published: true}
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Domain.On("Fetch", ctx, ownerOrg).Return(ownerDomain, nil)
+	pulp.On("WithDomain", ownerDomain).Return(pulp)
+	publication := zest.NullableString{}
+	publication.Set(&publicationHref)
+	pulp.On("FindDistributionByPath", ctx, distPath).Return(&zest.RpmRpmDistributionResponse{PulpHref: &distHref, Publication: publication}, nil)
+
+	task := UpdateTemplateContent{
+		orgId:               viewerOrg,
+		domainName:          "viewer-domain",
+		rhDomainName:        "redhat-domain",
+		communityDomainName: "community-domain",
+		daoReg:              reg.ToDaoRegistry(),
+		pulpClient:          pulp,
+		payload:             &payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID},
+		ctx:                 ctx,
+	}
+	distributions := map[string]string{}
+	require.NoError(s.T(), task.handleReposAdded([]string{repoUUID}, []models.Snapshot{snapshot}, distributions))
+	_, found := distributions[repoUUID]
+	assert.True(s.T(), found)
+}
+
+func (s *UpdateTemplateContentSuite) TestForeignPartnerUnpublishedSnapshotFailsClosed() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	pulp := pulp_client.NewMockPulpClient(s.T())
+
+	viewerOrg := "template-owner"
+	ownerOrg := "partner-owner"
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	repo := api.RepositoryResponse{UUID: repoUUID, OrgID: ownerOrg, Partner: true, Origin: config.OriginUpload}
+	snapshot := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		RepositoryConfigurationUUID: repoUUID,
+		PublicationHref:             "/pulp/publications/" + uuid.NewString(),
+		Published:                   false,
+	}
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Domain.On("Fetch", ctx, ownerOrg).Return("partner-domain", nil)
+	pulp.On("WithDomain", "partner-domain").Return(pulp)
+
+	task := UpdateTemplateContent{
+		orgId:      viewerOrg,
+		daoReg:     reg.ToDaoRegistry(),
+		pulpClient: pulp,
+		payload:    &payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID},
+		ctx:        ctx,
+	}
+
+	err := task.handleReposAdded([]string{repoUUID}, []models.Snapshot{snapshot}, map[string]string{})
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "unpublished snapshot")
+}
+
+func (s *UpdateTemplateContentSuite) TestSameOrgPartnerKeepsContentGuard() {
+	ctx := context.Background()
+	pulp := pulp_client.NewMockPulpClient(s.T())
+	contentGuards := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = true
+	s.T().Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = contentGuards })
+
+	orgID := "partner-owner"
+	publicationHref := "/pulp/publications/" + uuid.NewString()
+	guardHref := "/pulp/content-guards/" + uuid.NewString()
+	distHref := "/pulp/distributions/" + uuid.NewString()
+	publication := zest.NullableString{}
+	publication.Set(&publicationHref)
+	contentGuard := zest.NullableString{}
+	contentGuard.Set(&guardHref)
+
+	pulp.On("CreateOrUpdateGuardsForOrg", ctx, orgID).Return(guardHref, nil)
+	pulp.On("FindDistributionByPath", ctx, "template-path").Return(&zest.RpmRpmDistributionResponse{
+		PulpHref:     &distHref,
+		Publication:  publication,
+		ContentGuard: contentGuard,
+	}, nil)
+
+	pdh := helpers.NewPulpDistributionHelper(ctx, pulp)
+	_, _, err := pdh.CreateOrUpdateTemplateDistribution(
+		api.RepositoryResponse{UUID: uuid.NewString(), OrgID: orgID, Partner: true},
+		models.Snapshot{Base: models.Base{UUID: uuid.NewString()}, PublicationHref: publicationHref},
+		orgID,
+		"template-name",
+		"template-path",
+	)
+	require.NoError(s.T(), err)
+}
+
+func (s *UpdateTemplateContentSuite) TestForeignPartnerUploadContentUsesOwnerDomain() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	cp := candlepin_client.NewMockCandlepinClient(s.T())
+
+	viewerOrg := "template-owner"
+	ownerOrg := "partner-owner"
+	repoUUID := uuid.NewString()
+	repo := api.RepositoryResponse{
+		UUID:              repoUUID,
+		Name:              "Partner upload",
+		Label:             "partner-upload",
+		OrgID:             ownerOrg,
+		Origin:            config.OriginUpload,
+		Partner:           true,
+		LastSnapshot:      nil,
+		LatestSnapshotURL: "",
+	}
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Domain.On("Fetch", ctx, ownerOrg).Return("partner-owner-domain", nil)
+	cp.On("FetchContentsByLabel", ctx, viewerOrg, []string{}).Return([]caliri.ContentDTO{}, nil)
+
+	task := UpdateTemplateContent{
+		orgId:      viewerOrg,
+		domainName: "viewer-domain",
+		daoReg:     reg.ToDaoRegistry(),
+		cpClient:   cp,
+		payload:    &payloads.UpdateTemplateContentPayload{TemplateUUID: uuid.NewString(), RepoConfigUUIDs: []string{repoUUID}},
+		ctx:        ctx,
+	}
+
+	content, _, _, err := task.getContentList("http://pulp.example/api/pulp-content")
+	require.NoError(s.T(), err)
+	require.Len(s.T(), content, 1)
+	require.NotNil(s.T(), content[0].ContentUrl)
+	assert.Equal(s.T(), "http://pulp.example/api/pulp-content/partner-owner-domain/"+repoUUID+"/latest/", *content[0].ContentUrl)
+}
+
+func (s *UpdateTemplateContentSuite) TestRunPulpMakesSnapshotUpdateDecision() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	pulp := pulp_client.NewMockPulpClient(s.T())
+	contentGuards := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = false
+	s.T().Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = contentGuards })
+
+	viewerOrg := "template-owner"
+	ownerOrg := "partner-owner"
+	ownerDomain := "partner-domain"
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	snapshotUUID := uuid.NewString()
+	publicationHref := "/pulp/publications/" + uuid.NewString()
+	distHref := "/pulp/distributions/" + uuid.NewString()
+	distPath := customTemplateSnapshotPath(templateUUID, repoUUID)
+	templateDate := time.Now().Add(-time.Hour)
+
+	repo := api.RepositoryResponse{UUID: repoUUID, OrgID: ownerOrg, Partner: true, Origin: config.OriginUpload}
+	snapshot := models.Snapshot{
+		Base:                        models.Base{UUID: snapshotUUID},
+		RepositoryConfigurationUUID: repoUUID,
+		PublicationHref:             publicationHref,
+		Published:                   true,
+	}
+	publication := zest.NullableString{}
+	publication.Set(&publicationHref)
+	distribution := &zest.RpmRpmDistributionResponse{PulpHref: &distHref, Publication: publication}
+
+	reg.Template.On("GetRepoChanges", ctx, templateUUID, []string{repoUUID}).
+		Return([]string(nil), []string(nil), []string{repoUUID}, []string{repoUUID}, nil)
+	reg.Snapshot.On("FetchSnapshotsModelByDateAndRepository", ctx, viewerOrg, mock.MatchedBy(func(req api.ListSnapshotByDateRequest) bool {
+		return req.Date.Equal(templateDate) && len(req.RepositoryUUIDS) == 1 && req.RepositoryUUIDS[0] == repoUUID
+	})).Return([]models.Snapshot{snapshot}, nil)
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Domain.On("Fetch", ctx, ownerOrg).Return(ownerDomain, nil)
+	pulp.On("WithDomain", ownerDomain).Return(pulp)
+	// The selected snapshot already backs the distribution, so the task must not issue a Pulp update.
+	pulp.On("FindDistributionByPath", ctx, distPath).Return(distribution, nil).Twice()
+	reg.Template.On("UpdateDistributionHrefs", ctx, templateUUID, []string{repoUUID}, []models.Snapshot{snapshot}, map[string]string{repoUUID: distHref}).Return(nil)
+	reg.Template.On("UpdateSnapshots", ctx, templateUUID, []string{repoUUID}, []models.Snapshot{snapshot}).Return(nil)
+
+	task := UpdateTemplateContent{
+		orgId:               viewerOrg,
+		domainName:          "viewer-domain",
+		rhDomainName:        "redhat-domain",
+		communityDomainName: "community-domain",
+		template:            api.TemplateResponse{UUID: templateUUID, OrgID: viewerOrg, Date: templateDate},
+		daoReg:              reg.ToDaoRegistry(),
+		pulpClient:          pulp,
+		payload:             &payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, RepoConfigUUIDs: []string{repoUUID}},
+		ctx:                 ctx,
+	}
+	require.NoError(s.T(), task.RunPulp())
+}
+
+func (s *UpdateTemplateContentSuite) TestRunPulpRemovesForeignPartnerAndPreservesBaseRepository() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	pulp := pulp_client.NewMockPulpClient(s.T())
+	contentGuards := config.Get().Clients.Pulp.RepoContentGuards
+	config.Get().Clients.Pulp.RepoContentGuards = false
+	s.T().Cleanup(func() { config.Get().Clients.Pulp.RepoContentGuards = contentGuards })
+
+	templateUUID := uuid.NewString()
+	baseRepoUUID := uuid.NewString()
+	partnerRepoUUID := uuid.NewString()
+	baseSnapshot := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		RepositoryConfigurationUUID: baseRepoUUID,
+		PublicationHref:             "/pulp/publications/" + uuid.NewString(),
+	}
+	baseRepo := api.RepositoryResponse{
+		UUID:  baseRepoUUID,
+		OrgID: config.RedHatOrg,
+		URL:   "https://cdn.redhat.com/content/dist/rhel9/baseos/x86_64/os/",
+	}
+	partnerRepo := api.RepositoryResponse{UUID: partnerRepoUUID, OrgID: "partner-owner", Partner: true, Origin: config.OriginUpload}
+	partnerDistHref := "/pulp/distributions/" + uuid.NewString()
+	baseDistHref := "/pulp/distributions/" + uuid.NewString()
+	baseDistPath, _, err := getDistPathAndName(baseRepo, templateUUID)
+	require.NoError(s.T(), err)
+	publication := zest.NullableString{}
+	publication.Set(&baseSnapshot.PublicationHref)
+
+	reg.Template.On("GetRepoChanges", ctx, templateUUID, []string{baseRepoUUID}).
+		Return([]string(nil), []string{partnerRepoUUID}, []string{baseRepoUUID}, []string{baseRepoUUID, partnerRepoUUID}, nil)
+	reg.Snapshot.On("FetchSnapshotsModelByDateAndRepository", ctx, "template-owner", mock.Anything).
+		Return([]models.Snapshot{baseSnapshot}, nil)
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, partnerRepoUUID, false).Return(partnerRepo, nil)
+	reg.Domain.On("Fetch", ctx, partnerRepo.OrgID).Return("partner-domain", nil)
+	pulp.On("WithDomain", "partner-domain").Return(pulp)
+	reg.Template.On("GetDistributionHref", ctx, templateUUID, partnerRepoUUID).Return(&partnerDistHref, nil)
+	pulp.On("DeleteRpmDistribution", ctx, partnerDistHref).Return((*string)(nil), nil)
+	reg.Template.On("DeleteTemplateRepoConfigs", ctx, templateUUID, []string{baseRepoUUID}).Return(nil)
+
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, baseRepoUUID, false).Return(baseRepo, nil)
+	pulp.On("WithDomain", "redhat-domain").Return(pulp)
+	pulp.On("FindDistributionByPath", ctx, baseDistPath).
+		Return(&zest.RpmRpmDistributionResponse{PulpHref: &baseDistHref, Publication: publication}, nil).Twice()
+	reg.Template.On("UpdateDistributionHrefs", ctx, templateUUID, []string{baseRepoUUID}, []models.Snapshot{baseSnapshot}, map[string]string{baseRepoUUID: baseDistHref}).Return(nil)
+	reg.Template.On("UpdateSnapshots", ctx, templateUUID, []string{baseRepoUUID}, []models.Snapshot{baseSnapshot}).Return(nil)
+
+	taskInfo := &models.TaskInfo{Id: uuid.New(), Typename: config.UpdateTemplateContentTask}
+	task := UpdateTemplateContent{
+		orgId:               "template-owner",
+		domainName:          "viewer-domain",
+		rhDomainName:        "redhat-domain",
+		communityDomainName: "community-domain",
+		template:            api.TemplateResponse{UUID: templateUUID, OrgID: "template-owner", Date: time.Now()},
+		daoReg:              reg.ToDaoRegistry(),
+		pulpClient:          pulp,
+		payload:             &payloads.UpdateTemplateContentPayload{TemplateUUID: templateUUID, RepoConfigUUIDs: []string{baseRepoUUID}},
+		task:                taskInfo,
+		ctx:                 ctx,
+	}
+	require.NoError(s.T(), task.RunPulp())
+}
+
+func (s *UpdateTemplateContentSuite) TestPartnerOverrideUsesOwnerDomainWithoutLastSnapshot() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	repoUUID := uuid.NewString()
+	templateUUID := uuid.NewString()
+	repo := api.RepositoryResponse{
+		UUID:         repoUUID,
+		OrgID:        "partner-owner",
+		Partner:      true,
+		Origin:       config.OriginUpload,
+		Label:        "partner-label",
+		LastSnapshot: nil,
+	}
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, repoUUID, false).Return(repo, nil)
+	reg.Domain.On("Fetch", ctx, repo.OrgID).Return("partner-domain", nil)
+
+	overrides, err := GenOverrideDTO(ctx, reg.ToDaoRegistry(), "template-owner", "viewer-domain", "redhat-domain", "community-domain", "/content", api.TemplateResponse{UUID: templateUUID}, []string{repoUUID})
+	require.NoError(s.T(), err)
+	baseURL := findOverride(overrides, "baseurl")
+	require.NotNil(s.T(), baseURL)
+	assert.Equal(s.T(), "/content/partner-domain/templates/"+templateUUID+"/"+repoUUID, *baseURL.Value)
+}
+
+func (s *UpdateTemplateContentSuite) TestPrepareTriggeredUpdateDecisionMatrix() {
+	tests := []struct {
+		name         string
+		templateOrg  string
+		repoOwnerOrg string
+		useLatest    bool
+		hasPublished bool
+		associated   bool
+		wantRepos    []string
+		wantSkip     bool
+	}{
+		{name: "foreign fixed removes without published", templateOrg: "viewer", repoOwnerOrg: "owner", wantRepos: []string{"base"}, associated: true},
+		{name: "owner fixed retains without published", templateOrg: "owner", repoOwnerOrg: "owner", wantRepos: []string{"base", "partner"}, associated: true},
+		{name: "owner use latest removes without published", templateOrg: "owner", repoOwnerOrg: "owner", useLatest: true, wantRepos: []string{"base"}, associated: true},
+		{name: "foreign fixed retains with published", templateOrg: "viewer", repoOwnerOrg: "owner", hasPublished: true, wantRepos: []string{"base", "partner"}, associated: true},
+		{name: "use latest defers when publication reappears", templateOrg: "viewer", repoOwnerOrg: "owner", useLatest: true, hasPublished: true, wantRepos: []string{"base", "partner"}, wantSkip: true, associated: true},
+		{name: "already removed is never re-added", templateOrg: "viewer", repoOwnerOrg: "owner", wantRepos: []string{"base"}},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			reg := dao.GetMockDaoRegistry(t)
+			trigger := "partner"
+			repositories := []string{"base"}
+			if tc.associated {
+				repositories = append(repositories, trigger)
+			}
+			reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, trigger, false).
+				Return(api.RepositoryResponse{UUID: trigger, OrgID: tc.repoOwnerOrg, Partner: true}, nil)
+			reg.Snapshot.On("HasPublishedSnapshot", ctx, trigger).Return(tc.hasPublished, nil)
+
+			task := UpdateTemplateContent{
+				ctx:      ctx,
+				daoReg:   reg.ToDaoRegistry(),
+				template: api.TemplateResponse{UUID: "template", OrgID: tc.templateOrg, UseLatest: tc.useLatest, RepositoryUUIDS: repositories},
+				payload:  &payloads.UpdateTemplateContentPayload{TemplateUUID: "template", TriggeredByRepositoryUUID: &trigger},
+			}
+			skip, err := task.prepareTriggeredUpdate()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSkip, skip)
+			require.Equal(t, tc.wantRepos, task.payload.RepoConfigUUIDs)
+			require.Equal(t, tc.wantRepos, task.template.RepositoryUUIDS)
+		})
+	}
+}
+
+func (s *UpdateTemplateContentSuite) TestPrepareTriggeredUpdateFailsClosedOnPublicationCheckError() {
+	ctx := context.Background()
+	reg := dao.GetMockDaoRegistry(s.T())
+	trigger := "partner"
+	expectedErr := fmt.Errorf("database unavailable")
+	reg.RepositoryConfig.On("FetchWithoutOrgID", ctx, trigger, false).
+		Return(api.RepositoryResponse{UUID: trigger, OrgID: "owner", Partner: true}, nil)
+	reg.Snapshot.On("HasPublishedSnapshot", ctx, trigger).Return(false, expectedErr)
+
+	task := UpdateTemplateContent{
+		ctx:      ctx,
+		daoReg:   reg.ToDaoRegistry(),
+		template: api.TemplateResponse{UUID: "template", OrgID: "viewer", RepositoryUUIDS: []string{"base", trigger}},
+		payload:  &payloads.UpdateTemplateContentPayload{TemplateUUID: "template", TriggeredByRepositoryUUID: &trigger},
+	}
+	_, err := task.prepareTriggeredUpdate()
+	require.ErrorIs(s.T(), err, expectedErr)
+	require.Empty(s.T(), task.payload.RepoConfigUUIDs)
+}
+
+func findOverride(overrides []caliri.ContentOverrideDTO, name string) *caliri.ContentOverrideDTO {
+	for i := range overrides {
+		if overrides[i].Name != nil && *overrides[i].Name == name {
+			return &overrides[i]
+		}
+	}
+	return nil
 }

--- a/pkg/tasks/utils.go
+++ b/pkg/tasks/utils.go
@@ -1,0 +1,33 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/content-services/content-sources-backend/pkg/api"
+	"github.com/content-services/content-sources-backend/pkg/config"
+	"github.com/content-services/content-sources-backend/pkg/dao"
+)
+
+// repositoryDomain returns the Pulp domain that owns a repository's content.
+func repositoryDomain(
+	ctx context.Context,
+	daoReg *dao.DaoRegistry,
+	repo api.RepositoryResponse,
+	viewerOrgID, viewerDomain, rhDomain, communityDomain string,
+) (string, error) {
+	switch repo.OrgID {
+	case config.RedHatOrg:
+		return rhDomain, nil
+	case config.CommunityOrg:
+		return communityDomain, nil
+	case viewerOrgID:
+		return viewerDomain, nil
+	default:
+		ownerDomain, err := daoReg.Domain.Fetch(ctx, repo.OrgID)
+		if err != nil {
+			return "", fmt.Errorf("error fetching domain for repo org %s: %w", repo.OrgID, err)
+		}
+		return ownerDomain, nil
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -109,3 +109,10 @@ func SleepWithCancel(ctx context.Context, duration time.Duration) error {
 		return ctx.Err() // Cancelled or timed out
 	}
 }
+
+func OptionalStringsEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}


### PR DESCRIPTION
## Summary
This updates the repo validation for templates and the two template tasks along with surrounding helpers, to support consuming partner repositories.

- select published snapshots when foreign organizations use partner repositories
- update template and latest distributions after publication changes
- resolve partner content through the repository owner's Pulp domain
- synchronize template associations, snapshots, Candlepin content, and overrides

## Testing steps
This is a bit tedious to test, but it's doable. I did test it very thoroughly with local client VM. 
_(so you probably don't have to go to that extent)_
- create uploads repos with org X ➡️ mark them as partner ➡️ publish some snapshots.
- use them in templates (latest and fixed date), in both the owner and some viewer orgs.
- use those templates on a local VM: 
  - verify the content is accessible and registration works.
  - make changes to the templates + publish and unpublish snapshots ➡️ and watch that the templates are updated correctly.