### PR TITLE
Build: partner origin filter, repo dup when marking as partner

### DIFF
--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -2172,5 +2172,5 @@ func (r repositoryConfigDaoImpl) SetPartnerRepo(ctx context.Context, repoConfigU
 				Message: "Cannot unmark partner while published snapshots exist; unpublish all snapshots first"}
 		}
 	}
-	return r.db.WithContext(ctx).Model(&repoConfig).Update("partner", partner).Error
+	return r.db.WithContext(ctx).Model(&repoConfig).Omit("Repository").Update("partner", partner).Error
 }

--- a/pkg/dao/repository_configs.go
+++ b/pkg/dao/repository_configs.go
@@ -655,7 +655,17 @@ func (r repositoryConfigDaoImpl) filteredDbForList(OrgID string, filteredDB *gor
 
 	if filterData.Origin != "" {
 		origins := strings.Split(filterData.Origin, ",")
-		filteredDB = filteredDB.Where("repositories.origin IN ?", origins)
+		// foreign partner repos are masked as "community" but remain "upload" in the DB, match that behavior for origin list filters
+		hasCommunity := slices.Contains(origins, config.OriginCommunity)
+		nonForeignOrigin := r.db.Where(
+			"repositories.origin IN ? AND NOT ("+foreignPartnerVisibleSQL+")",
+			origins, OrgID,
+		)
+		if hasCommunity {
+			filteredDB = filteredDB.Where(nonForeignOrigin.Or(foreignPartnerVisibleSQL, OrgID))
+		} else {
+			filteredDB = filteredDB.Where(nonForeignOrigin)
+		}
 	}
 
 	if filterData.Arch != "" {

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -4104,6 +4104,57 @@ func (s *RepositoryConfigSuite) TestSetPartnerRepo_UnmarkWithDeletedPublishedSna
 	assert.False(t, updated.Partner)
 }
 
+func (s *RepositoryConfigSuite) TestSetPartnerRepo_DoesNotDuplicateRepositoryOrMoveRpms() {
+	t := s.T()
+	ctx := context.Background()
+	dao := s.getRepoConfigDao()
+
+	repo := createTestUploadRepository(t, s.tx)
+	repoConfig := createTestPartnerRepoConfig(t, s.tx, repo, seeds.RandomOrgId(), "partner no dup repo", false)
+
+	rpm := models.Rpm{
+		Base:     models.Base{UUID: uuid.NewString()},
+		Name:     "partner-pkg",
+		Arch:     "x86_64",
+		Version:  "1.0",
+		Release:  "1",
+		Epoch:    0,
+		Summary:  "pkg",
+		Checksum: uuid.NewString(),
+	}
+	require.NoError(t, s.tx.Create(&rpm).Error)
+	require.NoError(t, s.tx.Create(&models.RepositoryRpm{
+		RepositoryUUID: repo.UUID,
+		RpmUUID:        rpm.UUID,
+	}).Error)
+
+	var repoCountBefore int64
+	require.NoError(t, s.tx.Model(&models.Repository{}).
+		Where("origin = ?", config.OriginUpload).
+		Count(&repoCountBefore).Error)
+
+	err := dao.SetPartnerRepo(ctx, repoConfig.UUID, true)
+	require.NoError(t, err)
+
+	var updated models.RepositoryConfiguration
+	require.NoError(t, s.tx.Where("uuid = ?", repoConfig.UUID).First(&updated).Error)
+	assert.True(t, updated.Partner)
+	assert.Equal(t, repo.UUID, updated.RepositoryUUID, "config must keep pointing at the original repository")
+
+	var repoCountAfter int64
+	require.NoError(t, s.tx.Model(&models.Repository{}).
+		Where("origin = ?", config.OriginUpload).
+		Count(&repoCountAfter).Error)
+	assert.Equal(t, repoCountBefore, repoCountAfter, "must not insert an orphan repositories row")
+
+	var linkedRepoUUID string
+	require.NoError(t, s.tx.Model(&models.RepositoryRpm{}).
+		Select("repository_uuid").
+		Where("rpm_uuid = ?", rpm.UUID).
+		Scan(&linkedRepoUUID).Error)
+	assert.Equal(t, repo.UUID, linkedRepoUUID, "rpm join must stay on the original repository")
+}
+
 func (suite *RepositoryConfigSuite) TestListPartnerRepoVisibleToForeignOrg() {
 	t := suite.T()
 	ownerOrg := seeds.RandomOrgId()

--- a/pkg/dao/repository_configs_test.go
+++ b/pkg/dao/repository_configs_test.go
@@ -4171,6 +4171,86 @@ func (suite *RepositoryConfigSuite) TestListPartnerRepoNotVisibleWithoutPublishe
 	}
 }
 
+func (suite *RepositoryConfigSuite) TestListOriginCommunityIncludesForeignPartner() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-origin-community", true)
+
+	publishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/origin-community",
+		PublicationHref:             "/pulp/publication/origin-community",
+		DistributionPath:            "/content/origin-community",
+		RepositoryPath:              "/content/origin-community",
+		DistributionHref:            "/pulp/distribution/origin-community",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(t, suite.tx.Create(&publishedSnap).Error)
+	require.NoError(t, suite.tx.Model(&partnerRC).Update("last_snapshot_uuid", publishedSnap.UUID).Error)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), viewerOrg).Return([]string{}, nil).Once()
+	suite.mockPulpForListOrFetch(1)
+
+	response, total, err := rDao.List(context.Background(), viewerOrg, api.PaginationData{Limit: 100},
+		api.FilterData{Origin: config.OriginCommunity})
+	require.NoError(t, err)
+
+	var found *api.RepositoryResponse
+	for i := range response.Data {
+		if response.Data[i].UUID == partnerRC.UUID {
+			found = &response.Data[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "foreign partner should match origin=community filter, total=%d", total)
+	assert.Equal(t, config.OriginCommunity, found.Origin)
+}
+
+func (suite *RepositoryConfigSuite) TestListOriginUploadExcludesForeignPartner() {
+	t := suite.T()
+	ownerOrg := seeds.RandomOrgId()
+	viewerOrg := seeds.RandomOrgId()
+
+	repo := createTestUploadRepository(t, suite.tx)
+	partnerRC := createTestPartnerRepoConfig(t, suite.tx, repo, ownerOrg, "partner-origin-upload-excl", true)
+
+	publishedSnap := models.Snapshot{
+		Base:                        models.Base{UUID: uuid.NewString()},
+		VersionHref:                 "/pulp/version/origin-upload",
+		PublicationHref:             "/pulp/publication/origin-upload",
+		DistributionPath:            "/content/origin-upload",
+		RepositoryPath:              "/content/origin-upload",
+		DistributionHref:            "/pulp/distribution/origin-upload",
+		RepositoryConfigurationUUID: partnerRC.UUID,
+		ContentCounts:               models.ContentCountsType{},
+		AddedCounts:                 models.ContentCountsType{},
+		RemovedCounts:               models.ContentCountsType{},
+		Published:                   true,
+	}
+	require.NoError(t, suite.tx.Create(&publishedSnap).Error)
+	require.NoError(t, suite.tx.Model(&partnerRC).Update("last_snapshot_uuid", publishedSnap.UUID).Error)
+
+	rDao := repositoryConfigDaoImpl{db: suite.tx, pulpClient: suite.mockPulpClient, fsClient: suite.mockFsClient}
+	suite.mockFsClient.Mock.On("GetEntitledFeatures", context.Background(), viewerOrg).Return([]string{}, nil).Once()
+	suite.mockPulpForListOrFetch(1)
+
+	response, _, err := rDao.List(context.Background(), viewerOrg, api.PaginationData{Limit: 100},
+		api.FilterData{Origin: config.OriginUpload})
+	require.NoError(t, err)
+
+	for _, r := range response.Data {
+		assert.NotEqual(t, partnerRC.UUID, r.UUID, "foreign partner must not match origin=upload")
+	}
+}
+
 func (suite *RepositoryConfigSuite) TestListPartnerRepoVisibleToOwner() {
 	t := suite.T()
 	ownerOrg := seeds.RandomOrgId()


### PR DESCRIPTION
## Summary

- Aligns repo list origin filtering with partner response mask (`origin=community` includes foreign partner repos)
- Fixes `SetPartnerRepo` so gorm doesn't recreate the "Repository" association. This was inserting an orphan repo row and leaving `repositories_rpms` on the original `repo_uuid`

## Testing steps

1. Create an upload repo and upload an rpm
2. Mark the repo as a partner: `PATCH /admin/repositories/:uuid/partner '{"partner": true}'`
3. Listing rpms should return the uploaded rpm instead of an empty list: `GET /repositories/:uuid/rpms`
4. Publish the latest snapshot: `PATCH /repositories/:repo_uuid/snapshots/:snap_uuid/published '{"published": true}'`
5. List repos as another user with the origin filter set to community. The response should include the partner repo