### PR TITLE
[RHCLOUD-49129] Fetch default ws bypassing permission check

### DIFF
--- a/pkg/clients/kessel_client/client.go
+++ b/pkg/clients/kessel_client/client.go
@@ -60,7 +60,7 @@ func (k *kesselClientImpl) GetDefaultWorkspaceID(ctx context.Context, orgID stri
 	if err != nil {
 		return "", statusCode, fmt.Errorf("failed to get rbac url: %w", err)
 	}
-	url := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default", rbacUrl)
+	url := fmt.Sprintf("%s/api/rbac/v2/workspaces/?type=default&with_ancestry=true", rbacUrl)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
https://redhat.atlassian.net/browse/RHCLOUD-49129
RBAC require explicit parameter to bypass the permission check when fetching default workspace
## Testing steps

